### PR TITLE
Fix toLowerCase issue

### DIFF
--- a/addon/mixins/upf-table-search.js
+++ b/addon/mixins/upf-table-search.js
@@ -29,7 +29,10 @@ export default Mixin.create({
         }
 
         return collection.filter((item) => {
-          let itemName = item.get(this.get('searchAttribute')).toLowerCase();
+          let itemName = item.getWithDefault(
+            this.get('searchAttribute'), ''
+          ).toLowerCase();
+
           let i;
 
           for (i = 0; i < searchWords.length; i++) {


### PR DESCRIPTION
In case of `searchAttribute` is linked to a relation, the itemName can be empty (if not loaded yet) and this lead to an error with the `toLowerCase` on a `null` value.


https://sentry.io/upfluence/inbox-web/issues/452088331/?query=is:unresolved