### PR TITLE
Add support for inline icons (after the data) in upf-stat

### DIFF
--- a/addon/components/upf-stat.js
+++ b/addon/components/upf-stat.js
@@ -6,7 +6,7 @@ const {
 } = Ember;
 
 export default Component.extend({
-  classNames: ['upf-stat--new'],
+  classNames: ['upf-stat'],
   classNameBindings: [
     'small:upf-stat--new--small', 'xsmall:upf-stat--new--x-small'
   ],
@@ -15,9 +15,11 @@ export default Component.extend({
   xsmall: null,
   name: null,
   data: null,
+  dataClass: null,
   label: null,
 
   icon: null,
+  iconPlacement: 'top',
   iconClass: '',
   iconUrl: null,
   iconLabel: null,

--- a/app/templates/components/upf-stat.hbs
+++ b/app/templates/components/upf-stat.hbs
@@ -1,20 +1,32 @@
-<span class='upf-stat__name'>
+<span class="upf-stat__name">
   {{name}}
 
   {{#if icon}}
-    <span class='upf-stat__icon' title="{{iconLabel}}">
-      {{#if iconUrl}}
-        <a href="{{iconUrl}}" target="_blank">
+    {{#if (eq iconPlacement "top")}}
+      <span class="upf-stat__icon" title="{{iconLabel}}">
+        {{#if iconUrl}}
+          <a href="{{iconUrl}}" target="_blank">
+            {{fa-icon icon class=iconClass}}
+          </a>
+        {{else}}
           {{fa-icon icon class=iconClass}}
-        </a>
-      {{else}}
-        {{fa-icon icon class=iconClass}}
-      {{/if}}
-    </span>
+        {{/if}}
+      </span>
+    {{/if}}
   {{/if}}
 </span>
 
-<span class='upf-stat__data{{unless data ' upf-stat__data--null'}}'>{{data}}</span>
+<span class={{concat "upf-stat__data " dataClass (unless data "upf-stat__data--null")}}>
+  {{data}}
+
+  {{#if icon}}
+    {{#if (eq iconPlacement "right")}}
+      <span class="upf-stat__icon" title="{{iconLabel}}">
+        {{fa-icon icon class=iconClass}}
+      </span>
+    {{/if}}
+  {{/if}}
+</span>
 
 {{#if label}}
   <span class="upf-stat__label">{{{label}}}</span>

--- a/app/templates/components/upf-stat.hbs
+++ b/app/templates/components/upf-stat.hbs
@@ -16,7 +16,7 @@
   {{/if}}
 </span>
 
-<span class={{concat "upf-stat__data " dataClass (unless data "upf-stat__data--null")}}>
+<span class={{concat "upf-stat__data " dataClass (unless data " upf-stat__data--null")}}>
   {{data}}
 
   {{#if icon}}


### PR DESCRIPTION
Related: https://github.com/upfluence/oss/pull/56