### PR TITLE
Allow disabled option for radio button segmented control

### DIFF
--- a/addon/components/radio-button.js
+++ b/addon/components/radio-button.js
@@ -11,7 +11,7 @@ export default Component.extend({
   }),
 
   isChecked: computed('value', 'currentValue', 'disabled', function() {
-      return !this.disabled && this.get('value') === this.get('currentValue');
+      return !this.disabled && this.value === this.currentValue;
   }),
 
   click() {

--- a/addon/components/radio-button.js
+++ b/addon/components/radio-button.js
@@ -11,10 +11,7 @@ export default Component.extend({
   }),
 
   isChecked: computed('value', 'currentValue', 'disabled', function() {
-    if (!this.disabled) {
-      return this.get('value') === this.get('currentValue');
-    }
-    return false;
+      return !this.disabled && this.get('value') === this.get('currentValue');
   }),
 
   click() {

--- a/addon/components/radio-button.js
+++ b/addon/components/radio-button.js
@@ -1,18 +1,24 @@
 import Component from '@ember/component';
 import { computed } from '@ember/object';
+import { equal } from '@ember/object/computed';
 
 export default Component.extend({
   tagName: 'label',
   classNames: ['btn', 'upf-radio-btn'],
-  classNameBindings: ['isChecked:active'],
+  classNameBindings: ['isChecked:active', 'isDisabled:disabled'],
   attributeBindings: ['style'],
   style: computed('options', function() {
     return `width: ${100 / Object.keys(this.get('options')).length}%;`;
   }),
 
-  isChecked: computed('value', 'currentValue', function() {
-    return this.get('value') === this.get('currentValue');
+  isChecked: computed('value', 'currentValue', 'isDisabled', function() {
+    if (!this.isDisabled) {
+      return this.get('value') === this.get('currentValue');
+    }
+    return false;
   }),
+
+  isDisabled: equal('disabled', true),
 
   click() {
     this.sendAction('onCheck', this.get('value'));

--- a/addon/components/radio-button.js
+++ b/addon/components/radio-button.js
@@ -1,24 +1,21 @@
 import Component from '@ember/component';
 import { computed } from '@ember/object';
-import { equal } from '@ember/object/computed';
 
 export default Component.extend({
   tagName: 'label',
   classNames: ['btn', 'upf-radio-btn'],
-  classNameBindings: ['isChecked:active', 'isDisabled:disabled'],
+  classNameBindings: ['isChecked:active', 'disabled'],
   attributeBindings: ['style'],
   style: computed('options', function() {
     return `width: ${100 / Object.keys(this.get('options')).length}%;`;
   }),
 
-  isChecked: computed('value', 'currentValue', 'isDisabled', function() {
-    if (!this.isDisabled) {
+  isChecked: computed('value', 'currentValue', 'disabled', function() {
+    if (!this.disabled) {
       return this.get('value') === this.get('currentValue');
     }
     return false;
   }),
-
-  isDisabled: equal('disabled', true),
 
   click() {
     this.sendAction('onCheck', this.get('value'));


### PR DESCRIPTION
While loading if disabled is true, then don't show the isChecked state as well till it is not disabled anymore. 

Wanting to use this for analytics-web because it takes a while for the following count on edit form to update to the correct value. So while it is updating, then i disable the radio buttons, until it is done updating then i enable it and show the correct selection type `currentType`.