### PR TITLE
Settable upf-icon assets root path

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @phndiaye @tgallice @Hegazy360 @JulienVannier66 @upfluence/frontend

--- a/addon/components/upf-icon.js
+++ b/addon/components/upf-icon.js
@@ -6,6 +6,8 @@ import $ from 'jquery';
 const UpfIconComponent = Component.extend({
   assetMap: service('asset-map'),
 
+  assetsRoot: 'assets',
+
   icon: computed('params.[]', function() {
     return this.get('params')[0];
   }),
@@ -20,7 +22,7 @@ const UpfIconComponent = Component.extend({
 
   willInsertElement() {
     $.get(
-      this.get('assetMap').resolve(`assets/upf-icons/${this.get('icon')}.svg`),
+      this.get('assetMap').resolve(`${this.assetsRoot}/upf-icons/${this.get('icon')}.svg`),
       (data) => {
         let element = this.$()[0];
 


### PR DESCRIPTION
### What does this PR do?

Because the root path of the assets differs wether we are in an addon or an Ember application, this allows it to be overwritten where needed.

### What are the observable changes?

None

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [x] Properly labeled

### Additional Notes

<!--
    You can add anything you want here, an explanation on the way you built your implementation,
    precisions on the origin of the bug, gotchas you need to mention.
 -->