### PR TITLE
Oss components : upgrade column selection panel

### DIFF
--- a/addon/components/column-visibility-panel.js
+++ b/addon/components/column-visibility-panel.js
@@ -4,7 +4,7 @@ export default Component.extend({
   displayedColumnsPanel: false,
   hasToggleableColumns: false,
 
-  clickHandler(event) {
+  handleClick(event) {
     if (event.target.closest('.button-column-visibility-panel')) {
       this.toggleProperty('displayedColumnsPanel');
     }
@@ -16,14 +16,14 @@ export default Component.extend({
   init(){
     this._super();
 
-    this.set('bindClickHandler', this.clickHandler.bind(this));
+    this.set('clickHandler', this.handleClick.bind(this));
   },
 
   willInsertElement() {
-    document.addEventListener('click', this.bindClickHandler, false);
+    document.addEventListener('click', this.clickHandler, false);
   },
 
   willDestroyElement(){
-    document.removeEventListener('click', this.bindClickHandler, false);
+    document.removeEventListener('click', this.clickHandler, false);
   }
 });

--- a/addon/components/column-visibility-panel.js
+++ b/addon/components/column-visibility-panel.js
@@ -1,0 +1,29 @@
+import Component from '@ember/component';
+
+export default Component.extend({
+  displayedColumnsPanel: false,
+  hasToggleableColumns: false,
+
+  handleClick(event) {
+    if (event.target.closest('.button-column-visibility-panel')) {
+      this.toggleProperty('displayedColumnsPanel');
+    }
+    else {
+      this.set('displayedColumnsPanel', false);
+    }
+  },
+
+  init(){
+    this._super();
+
+    this.set('bindHandleClick', this.get('handleClick').bind(this));
+  },
+
+  willInsertElement() {
+    document.addEventListener('click', this.get('bindHandleClick'), false);
+  },
+
+  willDestroyElement(){
+    document.removeEventListener('click', this.get('bindHandleClick'), false);
+  }
+});

--- a/addon/components/column-visibility-panel.js
+++ b/addon/components/column-visibility-panel.js
@@ -5,10 +5,10 @@ export default Component.extend({
   hasToggleableColumns: false,
 
   handleClick(event) {
-    if (event.target.closest('.button-column-visibility-panel')) {
+    if (event.target.closest('.button-column-visibility-panel') != null) {
       this.toggleProperty('displayedColumnsPanel');
     }
-    else {
+    else if (event.target.closest('.side-panel--appearance') == null) {
       this.set('displayedColumnsPanel', false);
     }
   },

--- a/addon/components/column-visibility-panel.js
+++ b/addon/components/column-visibility-panel.js
@@ -4,7 +4,7 @@ export default Component.extend({
   displayedColumnsPanel: false,
   hasToggleableColumns: false,
 
-  handleClick(event) {
+  clickHandler(event) {
     if (event.target.closest('.button-column-visibility-panel') != null) {
       this.toggleProperty('displayedColumnsPanel');
     }
@@ -16,14 +16,14 @@ export default Component.extend({
   init(){
     this._super();
 
-    this.set('bindHandleClick', this.get('handleClick').bind(this));
+    this.set('bindClickHandler', this.clickHandler.bind(this));
   },
 
   willInsertElement() {
-    document.addEventListener('click', this.get('bindHandleClick'), false);
+    document.addEventListener('click', this.bindClickHandler, false);
   },
 
   willDestroyElement(){
-    document.removeEventListener('click', this.get('bindHandleClick'), false);
+    document.removeEventListener('click', this.bindClickHandler, false);
   }
 });

--- a/addon/components/column-visibility-panel.js
+++ b/addon/components/column-visibility-panel.js
@@ -5,10 +5,10 @@ export default Component.extend({
   hasToggleableColumns: false,
 
   clickHandler(event) {
-    if (event.target.closest('.button-column-visibility-panel') != null) {
+    if (event.target.closest('.button-column-visibility-panel')) {
       this.toggleProperty('displayedColumnsPanel');
     }
-    else if (event.target.closest('.side-panel--appearance') == null) {
+    else if (!event.target.closest('.side-panel--appearance')) {
       this.set('displayedColumnsPanel', false);
     }
   },

--- a/addon/components/upf-table/index.js
+++ b/addon/components/upf-table/index.js
@@ -2,6 +2,7 @@ import Component from '@ember/component';
 import EmberObject, { observer, computed } from '@ember/object';
 import { filterBy } from '@ember/object/computed';
 import { run } from '@ember/runloop';
+import $ from 'jquery';
 
 export default Component.extend({
   classNames: ['upf-table__container'],
@@ -34,6 +35,7 @@ export default Component.extend({
     this._super();
 
     this.set('_searchQuery', this.get('searchQuery'));
+    this._toggleDisplayedColumnVisibilityPanel()
   },
 
   _columns: computed('columns', function() {
@@ -76,11 +78,17 @@ export default Component.extend({
     run.debounce(this, this._bubbleSearch, 100);
   }),
 
-  actions: {
-    toggleDisplayedColumnVisibilityPanel() {
-      this.toggleProperty('displayedColumnsPanel');
-    },
+  _toggleDisplayedColumnVisibilityPanel() {
+    $(window).click(e => {
+      if ($(e.target).closest('a#button-column-visibility-panel').length > 0) {
+        this.toggleProperty('displayedColumnsPanel');
+      } else if ($(e.target).closest('div#column-visibility-panel').length === 0) {
+        this.set('displayedColumnsPanel', false);
+      }
+    })
+  },
 
+  actions: {
     callOnRowClickCallback(action, record) {
       this.onRowClick(record);
     },

--- a/addon/components/upf-table/index.js
+++ b/addon/components/upf-table/index.js
@@ -2,7 +2,6 @@ import Component from '@ember/component';
 import EmberObject, { observer, computed } from '@ember/object';
 import { filterBy } from '@ember/object/computed';
 import { run } from '@ember/runloop';
-import $ from 'jquery';
 
 export default Component.extend({
   classNames: ['upf-table__container'],

--- a/addon/components/upf-table/index.js
+++ b/addon/components/upf-table/index.js
@@ -35,11 +35,6 @@ export default Component.extend({
     this._super();
 
     this.set('_searchQuery', this.get('searchQuery'));
-    this.toggleDisplayedColumnVisibilityPanel()
-  },
-
-  didDestroyElement() {
-    $(window).off('click')
   },
 
   _columns: computed('columns', function() {
@@ -81,16 +76,6 @@ export default Component.extend({
   _searchQueryObserver: observer('_searchQuery', function() {
     run.debounce(this, this._bubbleSearch, 100);
   }),
-
-  toggleDisplayedColumnVisibilityPanel() {
-    $(window).click(e => {
-      if ($(e.target).closest('a#button-column-visibility-panel').length > 0) {
-        this.toggleProperty('displayedColumnsPanel');
-      } else if ($(e.target).closest('div#column-visibility-panel').length === 0) {
-        this.set('displayedColumnsPanel', false);
-      }
-    })
-  },
 
   actions: {
     callOnRowClickCallback(action, record) {

--- a/addon/components/upf-table/index.js
+++ b/addon/components/upf-table/index.js
@@ -35,7 +35,11 @@ export default Component.extend({
     this._super();
 
     this.set('_searchQuery', this.get('searchQuery'));
-    this._toggleDisplayedColumnVisibilityPanel()
+    this.toggleDisplayedColumnVisibilityPanel()
+  },
+
+  didDestroyElement() {
+    $(window).off('click')
   },
 
   _columns: computed('columns', function() {
@@ -78,7 +82,7 @@ export default Component.extend({
     run.debounce(this, this._bubbleSearch, 100);
   }),
 
-  _toggleDisplayedColumnVisibilityPanel() {
+  toggleDisplayedColumnVisibilityPanel() {
     $(window).click(e => {
       if ($(e.target).closest('a#button-column-visibility-panel').length > 0) {
         this.toggleProperty('displayedColumnsPanel');

--- a/app/components/column-visibility-panel.js
+++ b/app/components/column-visibility-panel.js
@@ -1,0 +1,1 @@
+export { default } from 'oss-components/components/column-visibility-panel';

--- a/app/templates/components/column-visibility-panel.hbs
+++ b/app/templates/components/column-visibility-panel.hbs
@@ -1,10 +1,6 @@
 <button class="upf-btn upf-btn--default upf-btn--small upf-link--reset button-column-visibility-panel">
   <i class="fa fa-columns"></i> &nbsp;
-  {{#if displayedColumnsPanel}}
-    <i class="fa fa-caret-up"></i>
-  {{else}}
-    <i class="fa fa-caret-down"></i>
-  {{/if}}
+  <i class="fa {{if displayedColumnsPanel "fa-caret-up" "fa-caret-down"}}"></i>
 </button>
 
 {{#if displayedColumnsPanel}}

--- a/app/templates/components/column-visibility-panel.hbs
+++ b/app/templates/components/column-visibility-panel.hbs
@@ -1,0 +1,23 @@
+<button class="upf-btn upf-btn--default upf-btn--small upf-link--reset button-column-visibility-panel">
+  <i class="fa fa-columns"></i> &nbsp;
+  {{#if displayedColumnsPanel}}
+    <i class="fa fa-caret-up"></i>
+  {{else}}
+    <i class="fa fa-caret-down"></i>
+  {{/if}}
+</button>
+
+{{#if displayedColumnsPanel}}
+  <div class="upf-datatable__side-panel--arrow-up side-panel--appearance"></div>
+  <div class="upf-datatable__side-panel side-panel--appearance column-visibility-panel">
+    {{#each columns as |column|}}
+      {{#unless column.unhideable}}
+        <div class="margin-bottom-sm">
+          {{#upf-checkbox value=column.visible hasLabel=true}}
+            <span class="text-color-contrast">{{column.title}}</span>
+          {{/upf-checkbox}}
+        </div>
+      {{/unless}}
+    {{/each}}
+  </div>
+{{/if}}

--- a/app/templates/components/upf-table.hbs
+++ b/app/templates/components/upf-table.hbs
@@ -5,14 +5,7 @@
 
   <li class="upf-datatable__actions-pull-right">
     {{#if hasToggleableColumns}}
-      <a class="upf-btn upf-btn--default upf-btn--small upf-link--reset" id="button-column-visibility-panel">
-        <i class="fa fa-columns"></i> &nbsp;
-        {{#if displayedColumnsPanel}}
-          <i class="fa fa-caret-up"></i>
-        {{else}}
-          <i class="fa fa-caret-down"></i>
-        {{/if}}
-      </a>
+      {{column-visibility-panel columns=_columns}}
     {{/if}}
 
     {{#if hasPagination}}
@@ -26,21 +19,6 @@
     {{#if hasSearch}}
       {{expanding-search classNames="margin-left-xx-sm" searchQuery=_searchQuery
                          placeholder=searchInputPlaceholder small=true}}
-    {{/if}}
-    {{#if displayedColumnsPanel}}
-      <div class="upf-datatable__side-panel--arrow-up side-panel--appearance"></div>
-      <div class="upf-datatable__side-panel side-panel--appearance"
-           id="column-visibility-panel">
-        {{#each _columns as |column|}}
-          {{#unless column.unhideable}}
-            <div class="margin-bottom-sm">
-              {{#upf-checkbox value=column.visible hasLabel=true}}
-                <span class="text-color-contrast">{{column.title}}</span>
-              {{/upf-checkbox}}
-            </div>
-          {{/unless}}
-        {{/each}}
-      </div>
     {{/if}}
   </li>
 </ul>

--- a/app/templates/components/upf-table.hbs
+++ b/app/templates/components/upf-table.hbs
@@ -5,7 +5,7 @@
 
   <li class="upf-datatable__actions-pull-right">
     {{#if hasToggleableColumns}}
-      <a {{action "toggleDisplayedColumnVisibilityPanel"}} class="upf-btn upf-btn--default upf-btn--small upf-link--reset">
+      <a class="upf-btn upf-btn--default upf-btn--small upf-link--reset" id="button-column-visibility-panel">
         <i class="fa fa-columns"></i> &nbsp;
         {{#if displayedColumnsPanel}}
           <i class="fa fa-caret-up"></i>
@@ -27,21 +27,23 @@
       {{expanding-search classNames="margin-left-xx-sm" searchQuery=_searchQuery
                          placeholder=searchInputPlaceholder small=true}}
     {{/if}}
+    {{#if displayedColumnsPanel}}
+      <div class="upf-datatable__side-panel--arrow-up"></div>
+      <div class="upf-datatable__side-panel"
+           id="column-visibility-panel">
+        {{#each _columns as |column|}}
+          {{#unless column.unhideable}}
+            <div class="margin-bottom-sm">
+              {{#upf-checkbox value=column.visible hasLabel=true}}
+                <span class="text-color-contrast">{{column.title}}</span>
+              {{/upf-checkbox}}
+            </div>
+          {{/unless}}
+        {{/each}}
+      </div>
+    {{/if}}
   </li>
 </ul>
-
-<div class="upf-datatable__side-panel
-     {{if displayedColumnsPanel 'upf-datatable__side-panel--visible'}}">
-  {{#each _columns as |column|}}
-    {{#unless column.unhideable}}
-      <div class="margin-bottom-sm">
-        {{#upf-checkbox value=column.visible hasLabel=true}}
-          <span class="text-color-contrast">{{column.title}}</span>
-        {{/upf-checkbox}}
-      </div>
-    {{/unless}}
-  {{/each}}
-</div>
 
 <table class="upf-datatable__table">
   <thead>

--- a/app/templates/components/upf-table.hbs
+++ b/app/templates/components/upf-table.hbs
@@ -27,19 +27,21 @@
       {{expanding-search classNames="margin-left-xx-sm" searchQuery=_searchQuery
                          placeholder=searchInputPlaceholder small=true}}
     {{/if}}
-    <div class="upf-datatable__side-panel--arrow-up {{if displayedColumnsPanel "side-panel--appearance"}}"></div>
-    <div class="upf-datatable__side-panel {{if displayedColumnsPanel "side-panel--appearance"}}"
-         id="column-visibility-panel">
-      {{#each _columns as |column|}}
-        {{#unless column.unhideable}}
-          <div class="margin-bottom-sm">
-            {{#upf-checkbox value=column.visible hasLabel=true}}
-              <span class="text-color-contrast">{{column.title}}</span>
-            {{/upf-checkbox}}
-          </div>
-        {{/unless}}
-      {{/each}}
-    </div>
+    {{#if displayedColumnsPanel}}
+      <div class="upf-datatable__side-panel--arrow-up side-panel--appearance"></div>
+      <div class="upf-datatable__side-panel side-panel--appearance"
+           id="column-visibility-panel">
+        {{#each _columns as |column|}}
+          {{#unless column.unhideable}}
+            <div class="margin-bottom-sm">
+              {{#upf-checkbox value=column.visible hasLabel=true}}
+                <span class="text-color-contrast">{{column.title}}</span>
+              {{/upf-checkbox}}
+            </div>
+          {{/unless}}
+        {{/each}}
+      </div>
+    {{/if}}
   </li>
 </ul>
 

--- a/app/templates/components/upf-table.hbs
+++ b/app/templates/components/upf-table.hbs
@@ -27,21 +27,19 @@
       {{expanding-search classNames="margin-left-xx-sm" searchQuery=_searchQuery
                          placeholder=searchInputPlaceholder small=true}}
     {{/if}}
-    {{#if displayedColumnsPanel}}
-      <div class="upf-datatable__side-panel--arrow-up"></div>
-      <div class="upf-datatable__side-panel"
-           id="column-visibility-panel">
-        {{#each _columns as |column|}}
-          {{#unless column.unhideable}}
-            <div class="margin-bottom-sm">
-              {{#upf-checkbox value=column.visible hasLabel=true}}
-                <span class="text-color-contrast">{{column.title}}</span>
-              {{/upf-checkbox}}
-            </div>
-          {{/unless}}
-        {{/each}}
-      </div>
-    {{/if}}
+    <div class="upf-datatable__side-panel--arrow-up {{if displayedColumnsPanel "side-panel--appearance"}}"></div>
+    <div class="upf-datatable__side-panel {{if displayedColumnsPanel "side-panel--appearance"}}"
+         id="column-visibility-panel">
+      {{#each _columns as |column|}}
+        {{#unless column.unhideable}}
+          <div class="margin-bottom-sm">
+            {{#upf-checkbox value=column.visible hasLabel=true}}
+              <span class="text-color-contrast">{{column.title}}</span>
+            {{/upf-checkbox}}
+          </div>
+        {{/unless}}
+      {{/each}}
+    </div>
   </li>
 </ul>
 


### PR DESCRIPTION
Related to: https://github.com/upfluence/backlog/issues/312
### What does this PR do?

When the user opens the workflow column selector, it does not close if the user clicks outside this section. It is necessary to close the column selector if the user clicks outside this section (focus out).

### What are the observable changes?
![Peek 2021-02-16 16-06](https://user-images.githubusercontent.com/43567222/108081167-ef65b400-7070-11eb-98bb-50c583dbcafc.gif)

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [ ] ~Added/updated tests~
- [ ] ~Added/updated documentation~
- [ ] ~Migrated touched components to Glimmer Components~
- [x] Properly labeled