### PR TITLE
Add a `data-control-name` attribute binding on all user-actionable elements

### DIFF
--- a/addon/components/destructive-button.js
+++ b/addon/components/destructive-button.js
@@ -12,7 +12,7 @@ const {
 export default Component.extend(TargetActionSupport, {
   tagName: 'button',
   classNames: ['upf-btn', 'upf-btn--destructive'],
-  attributeBindings: ['disabled', 'title'],
+  attributeBindings: ['disabled', 'title', 'data-control-name'],
 
   actionFailed: false,
   isLoading: false,

--- a/addon/components/expanding-search.js
+++ b/addon/components/expanding-search.js
@@ -7,6 +7,7 @@ export default Component.extend({
     'expandedSearch:expanding-search--opened',
     'small:expanding-search--small'
   ],
+  attributeBindings: ['data-control-name'],
 
   searchQuery: '',
   emptySearchQuery: empty('searchQuery'),

--- a/addon/components/loading-button.js
+++ b/addon/components/loading-button.js
@@ -11,7 +11,7 @@ const {
 const LoadingButtonComponent = Component.extend(TargetActionSupport, {
   tagName: 'button',
   classNameBindings: ['isLoading:js-btn--loading'],
-  attributeBindings: ['disabled', 'title'],
+  attributeBindings: ['disabled', 'title', 'data-control-name'],
   disabled: false,
   isLoading: false,
   initiallyDisabled: false,

--- a/addon/components/radio-button.js
+++ b/addon/components/radio-button.js
@@ -5,7 +5,7 @@ export default Component.extend({
   tagName: 'label',
   classNames: ['btn', 'upf-radio-btn'],
   classNameBindings: ['isChecked:active', 'disabled'],
-  attributeBindings: ['style'],
+  attributeBindings: ['style', 'data-control-name'],
 
   style: computed('options', function() {
     return `width: ${100 / Object.keys(this.get('options')).length}%;`;

--- a/addon/components/upf-checkbox.js
+++ b/addon/components/upf-checkbox.js
@@ -8,6 +8,7 @@ export default Component.extend({
     'hasLabel:upf-checkbox--has-label', 'sizeSmall:upf-checkbox--sm',
     'disabled:upf-checkbox--disabled'
   ],
+  attributeBindings: ['data-control-name'],
 
   sizeSmall: equal('size', 'sm'),
   disabled: false,

--- a/addon/components/upf-numeric-range.js
+++ b/addon/components/upf-numeric-range.js
@@ -12,6 +12,7 @@ const DEFAULT_OPTIONS = {
 export default Component.extend({
   classNames: ['upf-numeric-range'],
   classNameBindings: ['sizeSmall:upf-numeric-range--small'],
+  attributeBindings: ['data-control-name'],
 
   size: null,
 

--- a/addon/components/upf-slider.js
+++ b/addon/components/upf-slider.js
@@ -4,6 +4,7 @@ import { computed } from '@ember/object';
 export default Component.extend({
   classNames: ['upf-slider'],
   classNameBindings: ['color', 'active'],
+  attributeBindings: ['data-control-name'],
 
   value: 0,
   active: false,


### PR DESCRIPTION
### What does this PR do?

As we want to rollout `data-control-name` all around the soft, we start first by adding the `data-control-name` binding on all user actionable elements.

Relates to https://github.com/upfluence/backlog/issues/657

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled

### Additional Notes

<!--
    You can add anything you want here, an explanation on the way you built your implementation,
    precisions on the origin of the bug, gotchas you need to mention.
 -->
