### PR TITLE
Added: ability to pass disabled argument to component

### DIFF
--- a/addon/components/o-s-s/toggle-switch.hbs
+++ b/addon/components/o-s-s/toggle-switch.hbs
@@ -1,4 +1,5 @@
-<div class="upf-toggle {{if @value 'upf-toggle--toggled'}}" {{on "click" this.switchState}}>
+<div class="upf-toggle {{if @value 'upf-toggle--toggled'}} {{if @disabled 'upf-toggle--disabled'}}"
+     {{on "click" this.switchState}}>
   <div class="upf-toggle__switch">
   </div>
 </div>

--- a/addon/components/o-s-s/toggle-switch.js
+++ b/addon/components/o-s-s/toggle-switch.js
@@ -2,6 +2,8 @@ import Component from '@glimmer/component';
 import { action } from '@ember/object';
 
 export default class OSSToggleSwitchComponent extends Component {
+  isDisabled = false;
+
   constructor(owner, args) {
     super(owner, args);
 
@@ -12,10 +14,20 @@ export default class OSSToggleSwitchComponent extends Component {
     if (typeof args.value !== 'boolean') {
       throw new Error(`[component][OSS::ToggleSwitch] Please provide a boolean @value. @value is ${typeof args.value}`);
     }
+
+    if (typeof args.disabled !== 'undefined' && typeof args.disabled !== 'boolean') {
+      throw new Error(
+        `[component][OSS::ToggleSwitch] Please provide a boolean @disabled. @disabled is ${typeof args.disabled}`
+      );
+    } else {
+      this.isDisabled = this.args.disabled;
+    }
   }
 
   @action
   switchState() {
-    this.args.onChange(!this.args.value);
+    if (!this.isDisabled) {
+      this.args.onChange(!this.args.value);
+    }
   }
 }

--- a/app/styles/oss-components.less
+++ b/app/styles/oss-components.less
@@ -1,3 +1,4 @@
 @import "bootstrap.less";
 @import "font-awesome";
 @import "upfluence-oss";
+@import "toggle-switch";

--- a/app/styles/toggle-switch.less
+++ b/app/styles/toggle-switch.less
@@ -1,0 +1,13 @@
+.upf-toggle.upf-toggle--disabled {
+  background-color: lighten(@upf-gray, 15%);
+  border-color: lighten(@upf-gray, 15%);
+
+  .upf-toggle__switch {
+    background-color: darken(#fff, 15%);
+  }
+}
+
+.upf-toggle.upf-toggle--disabled,
+.upf-toggle.upf-toggle--disabled > div {
+  cursor: not-allowed;
+}


### PR DESCRIPTION
### What does this PR do?

Adds the ability to pass "disabled" argument to the component.

Related to: https://github.com/upfluence/backlog/issues/732

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [ ] Properly labeled
