### PR TITLE
Add OSS::Link component and add args to OSS::Button & OSS::InputContainer

### DIFF
--- a/addon/components/o-s-s/button.stories.js
+++ b/addon/components/o-s-s/button.stories.js
@@ -2,6 +2,7 @@ import hbs from 'htmlbars-inline-precompile';
 
 const SkinTypes = ['default', 'primary', 'secondary', 'destructive', 'instagram', 'facebook', 'youtube'];
 const SizeTypes = ['xs', 's'];
+const ThemeTypes = ['light', 'dark'];
 
 export default {
   title: 'Components/OSS::Button',
@@ -57,6 +58,17 @@ export default {
       control: {
         type: 'text'
       }
+    },
+    theme: {
+      description: 'Whether the button is being on a dark background or not',
+      table: {
+        type: {
+          summary: ThemeTypes.join('|')
+        },
+        defaultValue: { summary: 'light' }
+      },
+      options: ThemeTypes,
+      control: { type: 'select' }
     }
   }
 };
@@ -66,12 +78,17 @@ const defaultArgs = {
   size: null,
   loading: false,
   label: 'Label',
-  icon: 'far fa-envelope-open'
+  icon: 'far fa-envelope-open',
+  theme: 'light'
 };
 
 const Template = (args) => ({
   template: hbs`
-    <OSS::Button @skin={{this.skin}} @size={{this.size}} @loading={{this.loading}} @label={{this.label}} @icon={{this.icon}} />
+    <div style="padding: 2em; {{if (eq this.theme 'dark') 'background-color: #060666'}}">
+    <OSS::Button
+      @skin={{this.skin}} @size={{this.size}} @loading={{this.loading}} @label={{this.label}} @icon={{this.icon}}
+      @theme={{this.theme}} />
+    </div>
   `,
   context: args
 });

--- a/addon/components/o-s-s/button.ts
+++ b/addon/components/o-s-s/button.ts
@@ -12,6 +12,11 @@ type SizeDefType = {
   [key in SizeType]: string;
 };
 
+type ThemeType = 'light' | 'dark';
+type ThemeDefType = {
+  [key in ThemeType]?: string;
+};
+
 const SkinDefinition: SkinDefType = {
   default: 'default',
   primary: 'primary',
@@ -25,6 +30,9 @@ const SizeDefinition: SizeDefType = {
   xs: 'x-small',
   s: 'small'
 };
+const ThemeDefinition: ThemeDefType = {
+  dark: 'dark-bg'
+};
 
 const BASE_CLASS = 'upf-btn';
 
@@ -34,6 +42,7 @@ interface ButtonArgs {
   loading?: boolean;
   icon?: string;
   label?: string;
+  theme?: string;
 }
 
 export default class OSSButton extends Component<ButtonArgs> {
@@ -43,7 +52,7 @@ export default class OSSButton extends Component<ButtonArgs> {
     super(owner, args);
 
     if (!args.label && !args.icon) {
-      throw new Error('[component][OSS::Button] You must pass either a @label or an @icon argument.')
+      throw new Error('[component][OSS::Button] You must pass either a @label or an @icon argument.');
     }
   }
 
@@ -61,11 +70,23 @@ export default class OSSButton extends Component<ButtonArgs> {
     return SizeDefinition[this.args.size as SizeType];
   }
 
+  get theme() {
+    if (!this.args.theme || !Object.keys(ThemeDefinition).includes(this.args.theme)) {
+      return 'light';
+    }
+
+    return this.args.theme;
+  }
+
   get computedClass() {
     let classes = [BASE_CLASS, `upf-btn--${this.skin}`];
 
     if (this.size) {
       classes.push(`upf-btn--${this.size}`);
+    }
+
+    if (this.theme !== 'light') {
+      classes.push(`upf-btn--${ThemeDefinition[this.args.theme as ThemeType]}`);
     }
 
     return classes.join(' ');

--- a/addon/components/o-s-s/input-container.hbs
+++ b/addon/components/o-s-s/input-container.hbs
@@ -8,7 +8,7 @@
     <div class="yielded-input">{{yield to="input"}}</div>
   {{else}}
     <Input {{on "keyup" (fn this._onChange @value)}} @value={{@value}} placeholder={{@placeholder}}
-           class="upf-input" />
+           disabled={{@disabled}} class="upf-input" />
   {{/if}}
 
   {{#if (has-block "suffix")}}

--- a/addon/components/o-s-s/input-container.stories.js
+++ b/addon/components/o-s-s/input-container.stories.js
@@ -15,6 +15,16 @@ export default {
       },
       control: { type: 'text' }
     },
+    disabled: {
+      description: 'Disable the default input (when not passing an input named block)',
+      table: {
+        type: {
+          summary: 'boolean'
+        },
+        defaultValue: { summary: false }
+      },
+      control: { type: 'boolean' }
+    },
     placeholder: {
       description: 'Placeholder of the input',
       table: {
@@ -53,6 +63,7 @@ const BasicWithParametersTemplate = (args) => ({
   template: hbs`
       <OSS::InputContainer class="margin-bottom-sm" data-control-name="input-firstname"
                          @value={{this.value}}
+                         @disabled={{this.disabled}}
                          @onChange={{this.onChange}}
                          @placeholder={{this.placeholder}} />
   `,
@@ -61,7 +72,8 @@ const BasicWithParametersTemplate = (args) => ({
 export const BasicWithParamaters = BasicWithParametersTemplate.bind({});
 BasicWithParamaters.args = {
   placeholder: 'Enter your name',
-  onChange: action('')
+  onChange: action(''),
+  disabled: false
 };
 
 const AdvancedWithNamedBlocksTemplate = (args) => ({

--- a/addon/components/o-s-s/input-container.ts
+++ b/addon/components/o-s-s/input-container.ts
@@ -3,6 +3,7 @@ import Component from '@glimmer/component';
 
 interface OSSInputContainerArgs {
   value?: string;
+  disabled?: boolean;
   placeholder?: string;
   onChange?: (value: string) => void;
 }

--- a/addon/components/o-s-s/link.hbs
+++ b/addon/components/o-s-s/link.hbs
@@ -1,0 +1,9 @@
+<a onclick="event.preventDefault()" href="" class="upf-link" ...attributes>
+  {{#if @icon}}
+    <i class={{@icon}}></i>
+  {{/if}}
+
+  {{#if @label}}
+    <span class={{if @icon "margin-left-xxx-sm"}}>{{@label}}</span>
+  {{/if}}
+</a>

--- a/addon/components/o-s-s/link.hbs
+++ b/addon/components/o-s-s/link.hbs
@@ -1,4 +1,4 @@
-<a onclick="event.preventDefault()" href="" class="upf-link" ...attributes>
+<a href="" class="upf-link" {{on "click" this.preventDefault}} ...attributes>
   {{#if @icon}}
     <i class={{@icon}}></i>
   {{/if}}

--- a/addon/components/o-s-s/link.ts
+++ b/addon/components/o-s-s/link.ts
@@ -13,4 +13,8 @@ export default class OSSLink extends Component<OSSLinkArgs> {
       throw new Error('[component][OSS::Link] You must pass either a @label or an @icon argument.')
     }
   }
+
+  preventDefault(event: Event) {
+    event.preventDefault();
+  }
 }

--- a/addon/components/o-s-s/link.ts
+++ b/addon/components/o-s-s/link.ts
@@ -1,0 +1,16 @@
+import Component from '@glimmer/component';
+
+interface OSSLinkArgs {
+  icon: string;
+  label: string;
+}
+
+export default class OSSLink extends Component<OSSLinkArgs> {
+  constructor(owner: unknown, args: OSSLinkArgs) {
+    super(owner, args);
+
+    if (!args.label && !args.icon) {
+      throw new Error('[component][OSS::Link] You must pass either a @label or an @icon argument.')
+    }
+  }
+}

--- a/app/components/o-s-s/link.js
+++ b/app/components/o-s-s/link.js
@@ -1,0 +1,2 @@
+export { default } from '@upfluence/oss-components/components/o-s-s/link';
+

--- a/tests/integration/components/o-s-s/button-test.js
+++ b/tests/integration/components/o-s-s/button-test.js
@@ -102,4 +102,12 @@ module('Integration | Component | o-s-s/button', function (hooks) {
       assert.equal(btn.children[0].className, 'fas fa-circle-notch fa-spin');
     });
   });
+
+  module('it renders with the right theme', function () {
+    test('it adds the right class for usage on dark theme', async function (assert) {
+      await render(hbs`<OSS::Button @label="Test" @theme="dark" />`);
+
+      assert.dom('.upf-btn').hasClass('upf-btn--dark-bg');
+    });
+  });
 });

--- a/tests/integration/components/o-s-s/link-test.ts
+++ b/tests/integration/components/o-s-s/link-test.ts
@@ -1,0 +1,36 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render, setupOnerror } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Component | o-s-s/link', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it fails if no label nor icon argument are present', async function (assert: Assert) {
+    setupOnerror((err: Error) => {
+      assert.equal(err.message, '[component][OSS::Link] You must pass either a @label or an @icon argument.');
+    });
+
+    await render(hbs`<OSS::Link />`);
+  });
+
+  test('it renders with icon only', async function (assert: Assert) {
+    await render(hbs`<OSS::Link @icon="fab fa-facebook" />`);
+
+    assert.dom('.upf-link i').hasClass('fa-facebook');
+  });
+
+  test('it renders with label only', async function (assert: Assert) {
+    await render(hbs`<OSS::Link @label="Super Label" />`);
+
+    assert.dom('.upf-link span').hasText('Super Label');
+  });
+
+  test('it renders with both label and icon', async function (assert: Assert) {
+    await render(hbs`<OSS::Link @icon="fab fa-facebook" @label="Facebook" />`);
+
+    assert.dom('.upf-link i').hasClass('fa-facebook');
+    assert.dom('.upf-link span').hasClass('margin-left-xxx-sm');
+    assert.dom('.upf-link span').hasText('Facebook');
+  });
+});


### PR DESCRIPTION
### What does this PR do?

- Adds a new component: OSS::Link for displaying transparent "buttons" that trigger actions.
- Adds `theme` argument to the OSS::Button component to control its display on dark backgrounds.
- Adds `disabled`. argument to OSS::InputContainer to disable the inner input easily without having having to pass an `input` named block.

### What are the observable changes?
<!-- This question could be adequate with multiple use cases, for example: -->

<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [x] Added/updated documentation
- [x] Migrated touched components to Glimmer Components
- [x] Properly labeled

### Additional Notes

<!--
    You can add anything you want here, an explanation on the way you built your implementation,
    precisions on the origin of the bug, gotchas you need to mention.
 -->
