### PR TITLE
OSS::Badge: add support for skin and plain args

### DIFF
--- a/addon/components/o-s-s/badge.stories.js
+++ b/addon/components/o-s-s/badge.stories.js
@@ -1,6 +1,7 @@
 import hbs from 'htmlbars-inline-precompile';
 
 const SizeTypes = ['sm', 'md', 'lg'];
+const SkinTypes = ['primary', 'success', 'alert', 'error'];
 
 export default {
   title: 'Components/OSS::Badge',
@@ -16,6 +17,27 @@ export default {
       },
       options: SizeTypes,
       control: { type: 'select' }
+    },
+    skin: {
+      description: 'Adjust the skin of the badge',
+      table: {
+        type: {
+          summary: SkinTypes.join('|')
+        },
+        defaultValue: { summary: null }
+      },
+      options: SkinTypes,
+      control: { type: 'select' }
+    },
+    plain: {
+      description: 'Displays the badge with a plain background',
+      table: {
+        type: { summary: 'true | false' },
+        defaultValue: { summary: 'false' }
+      },
+      control: {
+        type: 'boolean'
+      }
     },
     icon: {
       description: 'Font Awesome class, for example',
@@ -46,12 +68,16 @@ const defaultArgs = {
   size: null,
   icon: null,
   image: null,
-  text: null
+  text: null,
+  plain: null,
+  skin: null
 };
 
 const Template = (args) => ({
   template: hbs`
-    <OSS::Badge @image={{this.image}} @icon={{this.icon}} @text={{this.text}} @size={{this.size}} />
+    <OSS::Badge
+      @image={{this.image}} @icon={{this.icon}} @text={{this.text}} @size={{this.size}} @skin={{this.skin}}
+      @plain={{this.plain}} />
   `,
   context: args
 });

--- a/addon/components/o-s-s/badge.ts
+++ b/addon/components/o-s-s/badge.ts
@@ -10,7 +10,7 @@ const SizeDefinition: SizeDefType = {
 
 type SkinType = 'primary' | 'success' | 'alert' | 'error';
 type SkinDefType = { [key in SkinType]: string };
-const SkinDefinition: SkinDefType = {
+export const SkinDefinition: SkinDefType = {
   primary: 'upf-badge--primary',
   success: 'upf-badge--success',
   alert: 'upf-badge--alert',

--- a/addon/components/o-s-s/badge.ts
+++ b/addon/components/o-s-s/badge.ts
@@ -8,11 +8,22 @@ const SizeDefinition: SizeDefType = {
   lg: 'upf-badge--size-lg'
 };
 
+type SkinType = 'primary' | 'success' | 'alert' | 'error';
+type SkinDefType = { [key in SkinType]: string };
+const SkinDefinition: SkinDefType = {
+  primary: 'upf-badge--primary',
+  success: 'upf-badge--success',
+  alert: 'upf-badge--alert',
+  error: 'upf-badge--error'
+};
+
 interface OSSBadgeArgs {
   icon: string;
   image: string;
   text: string;
+  plain: boolean;
   size: SizeType;
+  skin: SkinType;
 }
 
 export default class OSSBadge extends Component<OSSBadgeArgs> {
@@ -40,10 +51,30 @@ export default class OSSBadge extends Component<OSSBadgeArgs> {
     return SizeDefinition[size as SizeType];
   }
 
+  get skinClass(): string {
+    const skin: SkinType = this.args.skin;
+
+    if (!skin) return '';
+
+    if (!Object.keys(SkinDefinition).includes(skin as SkinType)) {
+      throw new Error(
+        `[component][OSS::Badge] Unknown skin. Available skins are: ${Object.keys(SkinDefinition).join(', ')}`
+      );
+    }
+
+    return SkinDefinition[skin as SkinType];
+  }
+
   get computedClass(): string {
     const classes = ['upf-badge', 'upf-badge--shape-round'];
 
-    classes.push(this.sizeClass);
+    [this.sizeClass, this.skinClass].forEach((klass) => {
+      classes.push(klass);
+    });
+
+    if (this.args.plain) {
+      classes.push('upf-badge--plain');
+    }
 
     return classes.join(' ');
   }

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -41,6 +41,17 @@
   </div>
 
   <div class="fx-row fx-gap-px-10 fx-xalign-center">
+    <OSS::Badge @icon="fas fa-box-open" @skin="primary" />
+    <OSS::Badge @icon="fas fa-box-open" @skin="primary" @plain={{true}} />
+    <OSS::Badge @icon="fas fa-box-open" @skin="success" />
+    <OSS::Badge @icon="fas fa-box-open" @skin="success" @plain={{true}} />
+    <OSS::Badge @icon="fas fa-box-open" @skin="alert" />
+    <OSS::Badge @icon="fas fa-box-open" @skin="alert" @plain={{true}} />
+    <OSS::Badge @icon="fas fa-box-open" @skin="error" />
+    <OSS::Badge @icon="fas fa-box-open" @skin="error" @plain={{true}} />
+  </div>
+
+  <div class="fx-row fx-gap-px-10 fx-xalign-center">
     <OSS::Badge @text="2x" @size="lg" />
     <OSS::Badge @text="2x" />
     <OSS::Badge @text="2x" @size="sm" />

--- a/tests/integration/components/o-s-s/badge-test.ts
+++ b/tests/integration/components/o-s-s/badge-test.ts
@@ -3,6 +3,8 @@ import { setupRenderingTest } from 'ember-qunit';
 import { render, setupOnerror } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
+import { SkinDefinition } from '@upfluence/oss-components/components/o-s-s/badge';
+
 module('Integration | Component | o-s-s/badge', function (hooks) {
   setupRenderingTest(hooks);
 
@@ -64,7 +66,7 @@ module('Integration | Component | o-s-s/badge', function (hooks) {
       await render(hbs`<OSS::Badge @skin="foo" @text="2x" />`);
     });
 
-    ['primary', 'success', 'alert', 'error'].forEach((skin) => {
+    Object.keys(SkinDefinition).forEach((skin) => {
       test(`it sets the right class when using a supported skin: ${skin}`, async function (assert: Assert) {
         this.skin = skin;
         await render(hbs`<OSS::Badge @skin={{this.skin}} @text="2x" />`);

--- a/tests/integration/components/o-s-s/badge-test.ts
+++ b/tests/integration/components/o-s-s/badge-test.ts
@@ -52,6 +52,35 @@ module('Integration | Component | o-s-s/badge', function (hooks) {
     });
   });
 
+  module('skins', function () {
+    test('it throws an error when an unsupported skin is passed', async function (assert: Assert) {
+      setupOnerror((err: Error) => {
+        assert.equal(
+          err.message,
+          '[component][OSS::Badge] Unknown skin. Available skins are: primary, success, alert, error'
+        );
+      });
+
+      await render(hbs`<OSS::Badge @skin="foo" @text="2x" />`);
+    });
+
+    ['primary', 'success', 'alert', 'error'].forEach((skin) => {
+      test(`it sets the right class when using a supported skin: ${skin}`, async function (assert: Assert) {
+        this.skin = skin;
+        await render(hbs`<OSS::Badge @skin={{this.skin}} @text="2x" />`);
+
+        assert.dom('.upf-badge').exists();
+        assert.dom('.upf-badge').hasClass(`upf-badge--${skin}`);
+      });
+    });
+
+    test('it adds the plain class when passed', async function(assert: Assert) {
+      await render(hbs`<OSS::Badge @skin="primary" @plain={{true}} @text="2x" />`);
+
+        assert.dom('.upf-badge').hasClass('upf-badge--plain');
+    })
+  });
+
   module('content args', function () {
     test('it displays the right icon when using the @icon arg', async function (assert: Assert) {
       await render(hbs`<OSS::Badge @icon="fas fa-users" />`);
@@ -73,7 +102,7 @@ module('Integration | Component | o-s-s/badge', function (hooks) {
 
       assert.dom('.upf-badge').exists();
       assert.dom('.upf-badge img').exists();
-      assert.dom('.upf-badge img').hasAttribute('src', 'http://foo.co/bar.png')
+      assert.dom('.upf-badge img').hasAttribute('src', 'http://foo.co/bar.png');
     });
   });
 });


### PR DESCRIPTION
### What does this PR do?

Add the `@skin` & `@plain` args to the OSS::Badge component

Related to: https://github.com/upfluence/backlog/issues/1195

### What are the observable changes?
<img width="422" alt="Screenshot 2021-12-20 at 18 00 34" src="https://user-images.githubusercontent.com/4022350/146804427-f10d1473-52bb-4831-8010-07cc1beecdd3.png">


<!-- This question could be adequate with multiple use cases, for example: -->

<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [x] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled

### Additional Notes

<!--
    You can add anything you want here, an explanation on the way you built your implementation,
    precisions on the origin of the bug, gotchas you need to mention.
 -->
