### PR TITLE
Fixed: OSS::InputContainer now fills all the available space

### DIFF
--- a/addon/components/o-s-s/input-container.hbs
+++ b/addon/components/o-s-s/input-container.hbs
@@ -1,4 +1,4 @@
-<div class="fx-col">
+<div class="fx-col fx-1">
   <div class="oss-input-container {{if @errorMessage ' oss-input-container--errored'}}
               {{if (has-block "prefix") ' has-prefix'}}
               {{if (has-block "suffix") ' has-suffix'}}"


### PR DESCRIPTION
### What does this PR do?

Fixed: OSS::InputContainer now fills all the available space

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled
