### PR TITLE
Change a to div for OSS::Link

### DIFF
--- a/addon/components/o-s-s/link.hbs
+++ b/addon/components/o-s-s/link.hbs
@@ -1,4 +1,4 @@
-<div class="upf-link" ...attributes>
+<div class="upf-link" role="button" {{on "click" this.goTo}} ...attributes>
   {{#if @icon}}
     <i class={{@icon}}></i>
   {{/if}}

--- a/addon/components/o-s-s/link.hbs
+++ b/addon/components/o-s-s/link.hbs
@@ -1,4 +1,4 @@
-<a href="" class="upf-link" {{on "click" this.preventDefault}} ...attributes>
+<div class="upf-link" ...attributes>
   {{#if @icon}}
     <i class={{@icon}}></i>
   {{/if}}
@@ -6,4 +6,4 @@
   {{#if @label}}
     <span class={{if @icon "margin-left-xxx-sm"}}>{{@label}}</span>
   {{/if}}
-</a>
+</div>

--- a/addon/components/o-s-s/link.stories.js
+++ b/addon/components/o-s-s/link.stories.js
@@ -1,0 +1,68 @@
+import hbs from 'htmlbars-inline-precompile';
+
+export default {
+  title: 'Components/OSS::Link',
+  component: 'link',
+  argTypes: {
+    icon: {
+      type: { required: true },
+      description: 'Icon set on the left position.',
+      table: {
+        type: {
+          summary: 'string'
+        },
+        defaultValue: { summary: 'null' }
+      },
+      control: { type: 'text' }
+    },
+    label: {
+      type: { required: true },
+      description: 'Label of the link.',
+      table: {
+        type: {
+          summary: 'string'
+        },
+        defaultValue: { summary: 'null' }
+      },
+      control: { type: 'text' }
+    },
+    transitionTo: {
+      description: 'Redirect to the route name of the Ember router',
+      table: {
+        type: {
+          summary: 'string'
+        },
+        defaultValue: { summary: 'null' }
+      },
+      control: { type: 'text' }
+    },
+    link: {
+      description:
+        "Object composed of 'href' and 'target' which allows to define the redirection. These are the same attributes as for the HTML element <a />",
+      table: {
+        type: {
+          summary: 'object'
+        },
+        defaultValue: { summary: 'null' }
+      },
+      control: { type: 'object' }
+    }
+  }
+};
+
+const DefaultUsageTemplate = (args) => ({
+  template: hbs`
+      <OSS::Link @icon={{this.icon}} @label={{this.label}} @transitionTo={{this.transitionTo}} @link={{this.link}} />
+  `,
+  context: args
+});
+export const BasicUsage = DefaultUsageTemplate.bind({});
+BasicUsage.args = {
+  icon: 'fas fa-link',
+  label: 'I am link',
+  transitionTo: 'workflow.create',
+  link: {
+    href: 'https://www.google.fr',
+    target: '_blank'
+  }
+};

--- a/addon/components/o-s-s/link.ts
+++ b/addon/components/o-s-s/link.ts
@@ -10,11 +10,7 @@ export default class OSSLink extends Component<OSSLinkArgs> {
     super(owner, args);
 
     if (!args.label && !args.icon) {
-      throw new Error('[component][OSS::Link] You must pass either a @label or an @icon argument.')
+      throw new Error('[component][OSS::Link] You must pass either a @label or an @icon argument.');
     }
-  }
-
-  preventDefault(event: Event) {
-    event.preventDefault();
   }
 }

--- a/addon/components/o-s-s/link.ts
+++ b/addon/components/o-s-s/link.ts
@@ -1,16 +1,38 @@
 import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import { inject as service } from '@ember/service';
+import RouterService from '@ember/routing/router-service';
+
+type LinkType = {
+  href: string;
+  target: '_self' | '_blank' | '_parent' | '_top';
+};
 
 interface OSSLinkArgs {
   icon: string;
   label: string;
+  link?: LinkType;
+  transitionTo?: string;
 }
 
 export default class OSSLink extends Component<OSSLinkArgs> {
+  @service declare router: RouterService;
+
   constructor(owner: unknown, args: OSSLinkArgs) {
     super(owner, args);
 
     if (!args.label && !args.icon) {
       throw new Error('[component][OSS::Link] You must pass either a @label or an @icon argument.');
+    }
+  }
+
+  @action
+  goTo() {
+    if (this.args.link) {
+      window.open(this.args.link.href, this.args.link.target)?.focus();
+    }
+    if (this.args.transitionTo) {
+      this.router.transitionTo(this.args.transitionTo);
     }
   }
 }

--- a/tests/integration/components/o-s-s/link-test.ts
+++ b/tests/integration/components/o-s-s/link-test.ts
@@ -1,7 +1,8 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, setupOnerror } from '@ember/test-helpers';
+import { render, setupOnerror, click } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
+import sinon from 'sinon';
 
 module('Integration | Component | o-s-s/link', function (hooks) {
   setupRenderingTest(hooks);
@@ -32,5 +33,26 @@ module('Integration | Component | o-s-s/link', function (hooks) {
     assert.dom('.upf-link i').hasClass('fa-facebook');
     assert.dom('.upf-link span').hasClass('margin-left-xxx-sm');
     assert.dom('.upf-link span').hasText('Facebook');
+  });
+
+  test('it opens link with href and target', async function (assert: Assert) {
+    let windowOpenStub = sinon.stub(window, 'open');
+
+    await render(hbs`
+      <OSS::Link @icon="fab fa-facebook" @label="Facebook" 
+                 @link={{hash href="https://www.google.fr" target="_blank"}} />
+    `);
+
+    await click('.upf-link');
+    assert.true(windowOpenStub.calledOnceWithExactly('https://www.google.fr', '_blank'));
+  });
+
+  test('it transits to the route', async function (assert: Assert) {
+    let transitionToStub = sinon.stub(this.owner.lookup('service:router'), 'transitionTo');
+
+    await render(hbs`<OSS::Link @icon="fab fa-facebook" @label="Facebook" @transitionTo={{"workflow.create"}} />`);
+
+    await click('.upf-link');
+    assert.true(transitionToStub.calledOnceWithExactly('workflow.create'));
   });
 });


### PR DESCRIPTION
### What does this PR do?

Change a to div for OSS::Link. The `preventEvent` doesn't work when we pass an action with a `router.transitionTo` and use href link

Related to: https://github.com/upfluence/backlog/issues/936

### What are the observable changes?

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled
