### PR TITLE
Add stop-propagation helper

### DIFF
--- a/addon/helpers/stop-propagation.ts
+++ b/addon/helpers/stop-propagation.ts
@@ -1,0 +1,21 @@
+import { helper } from '@ember/component/helper';
+import { assert } from '@ember/debug';
+
+export function stopPropagation([eventHandler]: any) {
+  assert(
+    `Expected '${eventHandler}' to be a function, if present.`,
+    !eventHandler || typeof eventHandler === 'function'
+  );
+
+  return function (event: Event) {
+    assert(
+      `Expected '${event}' to be an Event and have a 'stopPropagation' method.`,
+      event && typeof event.stopPropagation === 'function'
+    );
+
+    event.stopPropagation();
+    eventHandler(event);
+  };
+}
+
+export default helper(stopPropagation);

--- a/app/helpers/stop-propagation.js
+++ b/app/helpers/stop-propagation.js
@@ -1,0 +1,1 @@
+export { default, stopPropagation } from '@upfluence/oss-components/helpers/stop-propagation';

--- a/tests/integration/helpers/stop-propagation-test.ts
+++ b/tests/integration/helpers/stop-propagation-test.ts
@@ -1,0 +1,31 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { click, render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Helper | stop-propagation', function (hooks) {
+  setupRenderingTest(hooks);
+
+  hooks.beforeEach(function () {
+    this.nativeStopPropagation = Event.prototype.stopPropagation;
+  });
+
+  hooks.afterEach(function () {
+    Event.prototype.stopPropagation = this.nativeStopPropagation;
+  });
+
+  test('it renders', async function (assert) {
+    Event.prototype.stopPropagation = () => {
+      assert.ok(true);
+    };
+
+    this.onClick = (arg: string, event: Event) => {
+      assert.equal(arg, 'foo');
+      assert.ok(event instanceof MouseEvent)
+    };
+
+    await render(hbs`<button {{on "click" (stop-propagation (fn this.onClick "foo"))}}>stop propagation</button>`);
+    await click('button');
+    assert.expect(3);
+  });
+});


### PR DESCRIPTION
### What does this PR do?

Because it's something we have to do a lot, this helper will allow us to invoke `event.stopPropagation` directly from the templates.

Whilst this can be useless if we have an action defined in the component JS where we can handle the event, it can be useful when mutating props with `mut` or calling a parent-provided action:
-  `{{on "click" (fn (mut this.myProp) false)}}` ->  `{{on "click" (stop-propagation (fn (mut this.myProp) false))}}`
-  `{{on "click" @parentAction}}` -> `{{on "click" (stop-propagation @parentAction)}}`


### What are the observable changes?
<!-- This question could be adequate with multiple use cases, for example: -->

<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled

### Additional Notes

<!--
    You can add anything you want here, an explanation on the way you built your implementation,
    precisions on the origin of the bug, gotchas you need to mention.
 -->
