### PR TITLE
Fixed: OSS::CodeBlock copy button opaque background

### DIFF
--- a/addon/components/o-s-s/code-block.hbs
+++ b/addon/components/o-s-s/code-block.hbs
@@ -7,9 +7,11 @@
     </pre>
   </div>
   {{#if @copyable}}
-    <OSS::Button class="floating-copy-btn {{if @scrollable 'position-fix'}}" @skin="secondary"
-                 @label={{t "oss-components.code-block.copy"}}
-                 @icon="fa fa-copy" {{on "click" this.copyToClipboard}} />
+    <div class="floating-copy-btn {{if @scrollable 'position-fix'}}">
+      <OSS::Button @skin="secondary"
+                   @label={{t "oss-components.code-block.copy"}}
+                   @icon="fa fa-copy" {{on "click" this.copyToClipboard}} />
+    </div>
   {{/if}}
   {{#if this.collapsable}}
     {{#if this.collapsed}}

--- a/app/styles/code-block.less
+++ b/app/styles/code-block.less
@@ -7,7 +7,7 @@
     position: absolute;
     top: 15px;
     right: 0;
-    background-color: #f9f9f9;
+    background-color: var(--color-gray-50);
     border-radius: @default-radius;
     padding: @spacing-xx-sm;
   }
@@ -52,8 +52,8 @@
       display: flex;
       flex-direction: column;
       padding: 0;
-      background-color: #f9f9f9;
-      color: #8a95a0;
+      background-color: var(--color-gray-50);
+      color: var(--color-gray-500);
     }
     pre.code::before {
       counter-reset: listing;
@@ -62,8 +62,8 @@
       counter-increment: listing;
     }
     pre.code code::before {
-      background-color: #f3f4f6;
-      color: #8a95a0;
+      background-color: var(--color-gray-100);
+      color: var(--color-gray-400);
       content: counter(listing);
       display: inline-block;
       width: 40px;

--- a/app/styles/code-block.less
+++ b/app/styles/code-block.less
@@ -6,7 +6,10 @@
   .floating-copy-btn {
     position: absolute;
     top: 15px;
-    right: 15px;
+    right: 0;
+    background-color: #f9f9f9;
+    border-radius: @default-radius;
+    padding: @spacing-xx-sm;
   }
 
   .floating-collapse-btn {

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -5,7 +5,7 @@
   <OSS::Button @label="Error" @size="md" {{on "click" (fn this.triggerToast "error")}} />
 </div>
 <div class="fx-col fx-gap-px-10 margin-md">
-  <OSS::CodeBlock @content={{this.code4CodeBlock}} @scrollable={{true}}
+  <OSS::CodeBlock @content={{this.code4CodeBlock}} @scrollable={{true}} @copyable={{true}}
                   @collapseHeight={{200}} @onCopyMessage="Copied to clipboard!" />
 </div>
 <div class="fx-col fx-gap-px-10 margin-md">

--- a/tests/integration/components/o-s-s/phone-number-input-test.ts
+++ b/tests/integration/components/o-s-s/phone-number-input-test.ts
@@ -47,7 +47,7 @@ module('Integration | Component | o-s-s/phone-number', function (hooks) {
     await render(hbs`<OSS::PhoneNumberInput @prefix="" @onChange={{this.onChange}} />`);
   });
 
-  test('It throws an error if @number is not passed', async function (assert) {
+  test('It throws an error if @onChange is not passed', async function (assert) {
     setupOnerror((err: any) => {
       assert.equal(
         err.message,


### PR DESCRIPTION
### What does this PR do?

OSS::CodeBlock copy button now has an opaque background to hide the text underneath.

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled