### PR TITLE
OSS::CountrySelector initial value triggers onChange + tests

### DIFF
--- a/addon/components/o-s-s/country-selector.stories.js
+++ b/addon/components/o-s-s/country-selector.stories.js
@@ -87,9 +87,9 @@ export default {
       },
       control: { type: 'array' }
     },
-    initialValue: {
+    value: {
       description:
-        'The initial value applied to the input. Use for instance when the form is already pre-filled with known data',
+        'The value applied to the input. Use for instance when the form is already pre-filled with known data',
       table: {
         type: {
           summary: 'text'

--- a/addon/components/o-s-s/country-selector.ts
+++ b/addon/components/o-s-s/country-selector.ts
@@ -36,6 +36,7 @@ export default class OSSCountrySelector extends Component<OSSCountrySelectorArgs
       this.selectedCountry =
         this.args.sourceList.find((item: Item) => item.name.toLowerCase() === this.args.initialValue!.toLowerCase()) ||
         null;
+      if (this.selectedCountry) this.onItemSelected(this.selectedCountry);
     }
   }
 

--- a/addon/components/o-s-s/country-selector.ts
+++ b/addon/components/o-s-s/country-selector.ts
@@ -6,12 +6,13 @@ import { inject as service } from '@ember/service';
 type Item = {
   name: string;
   id?: string;
+  alpha2?: string;
   code?: string;
 };
 
 interface OSSCountrySelectorArgs {
   sourceList: Item[];
-  initialValue?: string;
+  value?: Item;
   onChange(item: Item): void;
 }
 
@@ -32,11 +33,8 @@ export default class OSSCountrySelector extends Component<OSSCountrySelectorArgs
       throw new Error('[component][OSS::CountrySelector] The @onChange parameter is mandatory');
     }
 
-    if (this.args.initialValue) {
-      this.selectedCountry =
-        this.args.sourceList.find((item: Item) => item.name.toLowerCase() === this.args.initialValue!.toLowerCase()) ||
-        null;
-      if (this.selectedCountry) this.onItemSelected(this.selectedCountry);
+    if (this.args.value) {
+      this._matchValueWithSourceList();
     }
   }
 
@@ -76,5 +74,10 @@ export default class OSSCountrySelector extends Component<OSSCountrySelectorArgs
     this.selectedCountry = value;
     this.closeDropdown();
     this.args.onChange(value);
+  }
+
+  private _matchValueWithSourceList(): void {
+    this.selectedCountry = this.args.sourceList.find((item: Item) => item.alpha2 === this.args.value!.alpha2) || null;
+    if (this.selectedCountry) this.onItemSelected(this.selectedCountry);
   }
 }

--- a/tests/integration/components/o-s-s/country-selector-test.ts
+++ b/tests/integration/components/o-s-s/country-selector-test.ts
@@ -62,29 +62,30 @@ module('Integration | Component | o-s-s/country-selector', function (hooks) {
     assert.dom('.upf-infinite-select').exists();
   });
 
-  module('If @initialValue is passed', () => {
+  module('If @initialValue is passed', function (hooks) {
+    hooks.beforeEach(function () {
+      this.initValue = {
+        id: 'FR',
+        alpha2: 'FR',
+        alpha3: 'FRA',
+        countryCallingCodes: ['33'],
+        currencies: ['EUR'],
+        name: 'France',
+        showOnTop: true
+      };
+    });
     test('If the value matches an entry from the sourceList, then the input is set to the value', async function (assert) {
       await render(
-        hbs`<OSS::CountrySelector @onChange={{this.onchange}} @sourceList={{this.countries}} @initialValue="France" />`
+        hbs`<OSS::CountrySelector @onChange={{this.onchange}} @sourceList={{this.countries}} @value={{this.initValue}} />`
       );
       assert.dom('[data-control-name="country-selector-input"]').hasText('France');
     });
     test('If the value matches an entry from the sourceList, the @onChange function is triggered', async function (assert) {
       this.onchange = sinon.spy();
       await render(
-        hbs`<OSS::CountrySelector @onChange={{this.onchange}} @sourceList={{this.countries}} @initialValue="France" />`
+        hbs`<OSS::CountrySelector @onChange={{this.onchange}} @sourceList={{this.countries}} @value={{this.initValue}} />`
       );
-      assert.ok(
-        this.onchange.calledOnceWith({
-          id: 'FR',
-          alpha2: 'FR',
-          alpha3: 'FRA',
-          countryCallingCodes: ['33'],
-          currencies: ['EUR'],
-          name: 'France',
-          showOnTop: true
-        })
-      );
+      assert.ok(this.onchange.calledOnceWith(this.initValue));
     });
   });
 

--- a/tests/integration/components/o-s-s/country-selector-test.ts
+++ b/tests/integration/components/o-s-s/country-selector-test.ts
@@ -62,6 +62,32 @@ module('Integration | Component | o-s-s/country-selector', function (hooks) {
     assert.dom('.upf-infinite-select').exists();
   });
 
+  module('If @initialValue is passed', () => {
+    test('If the value matches an entry from the sourceList, then the input is set to the value', async function (assert) {
+      await render(
+        hbs`<OSS::CountrySelector @onChange={{this.onchange}} @sourceList={{this.countries}} @initialValue="France" />`
+      );
+      assert.dom('[data-control-name="country-selector-input"]').hasText('France');
+    });
+    test('If the value matches an entry from the sourceList, the @onChange function is triggered', async function (assert) {
+      this.onchange = sinon.spy();
+      await render(
+        hbs`<OSS::CountrySelector @onChange={{this.onchange}} @sourceList={{this.countries}} @initialValue="France" />`
+      );
+      assert.ok(
+        this.onchange.calledOnceWith({
+          id: 'FR',
+          alpha2: 'FR',
+          alpha3: 'FRA',
+          countryCallingCodes: ['33'],
+          currencies: ['EUR'],
+          name: 'France',
+          showOnTop: true
+        })
+      );
+    });
+  });
+
   module('Dropdown menu', () => {
     test('It displays all items from the @sourceList parameter', async function (assert) {
       await render(hbs`<OSS::CountrySelector @onChange={{this.onchange}} @sourceList={{this.countries}} />`);
@@ -84,7 +110,7 @@ module('Integration | Component | o-s-s/country-selector', function (hooks) {
 
   test('if sourceList does not contain ids, then the placeholder is for provinces', async function (assert) {
     await render(hbs`<OSS::CountrySelector @onChange={{this.onchange}} @sourceList={{this.provinces}} />`);
-    assert.dom('[data-control-name="country-selector-input"]').hasText('Select your province');
+    assert.dom('[data-control-name="country-selector-input"]').hasText('Select your province/state');
   });
 
   module('When clicking on an item', () => {

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -23,4 +23,4 @@ oss-components:
     search: Search
     placeholder:
       country: Select your country
-      province: Select your province
+      province: Select your province/state


### PR DESCRIPTION
### What does this PR do?

OSS::CountrySelector initial value triggers onChange + tests
Related to: #[1338](https://github.com/upfluence/backlog/issues/1338)

### What are the observable changes?
@initialValue triggers the onChange method to notify there is a match to the parent.
Tests updated & tests added for initialValue

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled