### PR TITLE
Removed: wave animation 'ff-wave' from components

### DIFF
--- a/addon/components/o-s-s/country-selector.hbs
+++ b/addon/components/o-s-s/country-selector.hbs
@@ -4,7 +4,7 @@
        data-control-name="country-selector-input">
     <div class="fx-row fx-xalign-center fx-gap-px-10">
       {{#if this.selectedCountry.id}}
-        <div class="fflag fflag-{{this.selectedCountry.id}} ff-sm ff-wave ff-rounded"></div>
+        <div class="fflag fflag-{{this.selectedCountry.id}} ff-sm ff-rounded"></div>
       {{/if}}
       <span class="{{unless this.selectedCountry 'text-color-default-light'}}">{{this.inputLabel}}</span>
     </div>
@@ -22,7 +22,7 @@
       <:option as |item|>
         <div class="fx-row fx-xalign-center {{if (eq this.selectedCountry item) 'row-selected'}}">
           {{#if item.id}}
-            <div class="fflag fflag-{{item.id}} ff-sm ff-wave ff-rounded"></div>
+            <div class="fflag fflag-{{item.id}} ff-sm ff-rounded"></div>
           {{/if}}
           <span class="text-color-default-light margin-left-xx-sm">{{item.name}}</span>
           {{#if (eq this.selectedCountry item)}}

--- a/addon/components/o-s-s/phone-number-input.hbs
+++ b/addon/components/o-s-s/phone-number-input.hbs
@@ -1,7 +1,7 @@
 <div class="phone-number-container fx-1" ...attributes>
   <div class="phone-number-input upf-input fx-row fx-1 fx-xalign-center">
     <div class="country-selector fx-row" role="button" {{on "click" this.toggleCountrySelector}}>
-      <div class="fflag fflag-{{this.selectedCountry.id}} ff-sm ff-wave ff-rounded"></div>
+      <div class="fflag fflag-{{this.selectedCountry.id}} ff-sm ff-rounded"></div>
       {{#if this.countrySelectorShown}}
         <i class="fal fa-chevron-up margin-left-xxx-sm"></i>
       {{else}}
@@ -19,7 +19,7 @@
                          {{on-click-outside this.hideCountrySelector}}>
       <:option as |country|>
         <div class="fx-row fx-xalign-center {{if (eq this.selectedCountry country) 'row-selected'}}">
-          <div class="fflag fflag-{{country.id}} ff-sm ff-wave ff-rounded"></div>
+          <div class="fflag fflag-{{country.id}} ff-sm ff-rounded"></div>
           <span class="text-color-default-light margin-left-xx-sm">{{country.name}}</span>
           <span class="text-color-default-light margin-left-xxx-sm fx-1">(+{{get country.countryCallingCodes 0}})</span>
           {{#if (eq this.selectedCountry country)}}


### PR DESCRIPTION
### What does this PR do?

Removed: wave animation 'ff-wave' from components

Related to: #[1338](https://github.com/upfluence/backlog/issues/1338)

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled