### PR TITLE
Add transition-to helper

### DIFF
--- a/addon/helpers/transition-to.ts
+++ b/addon/helpers/transition-to.ts
@@ -27,9 +27,9 @@ export default class extends Helper {
 
     return () => {
       if (model) {
-        router.transitionTo(route, model, { queryParams });
+        router.transitionTo(route, model, { queryParams: queryParams || {} });
       } else if (models) {
-        router.transitionTo(route, ...models, { queryParams });
+        router.transitionTo(route, ...models, { queryParams: queryParams || {} });
       } else {
         router.transitionTo(route, { queryParams: queryParams || {} });
       }

--- a/addon/helpers/transition-to.ts
+++ b/addon/helpers/transition-to.ts
@@ -1,0 +1,38 @@
+import { getOwner } from '@ember/application';
+import Helper from '@ember/component/helper';
+import { assert } from '@ember/debug';
+
+type TransitionToHelperArgs = {
+  route: string;
+  model: any;
+  models: any[];
+  queryParams: { [key: string]: any };
+};
+
+export default class extends Helper {
+  compute(_: any[], named: TransitionToHelperArgs) {
+    const { route, model, models, queryParams } = named;
+
+    assert('[helper][OSS::transition-to] route argument is mandatory', typeof route === 'string');
+    assert(
+      '[helper][OSS::transition-to] only one of model or models argument must be provided',
+      model || models ? [model, models].filter((x) => x).length === 1 : true
+    );
+    assert(
+      '[helper][OSS::transition-to] queryParams argument must be an object',
+      queryParams ? typeof queryParams === 'object' : true
+    );
+
+    const router = getOwner(this).lookup('service:router');
+
+    return () => {
+      if (model) {
+        router.transitionTo(route, model, { queryParams });
+      } else if (models) {
+        router.transitionTo(route, ...models, { queryParams });
+      } else {
+        router.transitionTo(route, { queryParams: queryParams || {} });
+      }
+    };
+  }
+}

--- a/app/helpers/transition-to.js
+++ b/app/helpers/transition-to.js
@@ -1,0 +1,1 @@
+export { default, transitionTo } from '@upfluence/oss-components/helpers/transition-to';

--- a/tests/integration/helpers/transition-to-test.ts
+++ b/tests/integration/helpers/transition-to-test.ts
@@ -69,4 +69,13 @@ module('Integration | Helper | transition-to', function (hooks) {
       assert.ok(this.transitionToStub.calledWithExactly('foo', 'fizz', 'buzz', { queryParams: {} }));
     });
   });
+
+  module('with queryParams', function () {
+    test('it triggers the RouterService#transitionTo method with the route and queryParams', async function (assert) {
+      await render(hbs`<a {{on "click" (transition-to route="foo" queryParams=(hash myParam="bruh"))}}>link</a>`);
+      await click('a');
+
+      assert.ok(this.transitionToStub.calledWithExactly('foo', { queryParams: { myParam: 'bruh' } }));
+    });
+  });
 });

--- a/tests/integration/helpers/transition-to-test.ts
+++ b/tests/integration/helpers/transition-to-test.ts
@@ -1,0 +1,72 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { click, render, setupOnerror } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import sinon from 'sinon';
+
+module('Integration | Helper | transition-to', function (hooks) {
+  setupRenderingTest(hooks);
+
+  hooks.beforeEach(function () {
+    this.transitionToStub = sinon.stub(this.owner.lookup('service:router'), 'transitionTo');
+  });
+
+  module('mandatory arguments checks', function () {
+    test('it throws an error if the route argument is missing', async function (assert) {
+      setupOnerror((err: Error) => {
+        assert.equal(err.message, 'Assertion Failed: [helper][OSS::transition-to] route argument is mandatory');
+      });
+
+      await render(hbs`<a {{on "click" (transition-to)}}>link</a>`);
+    });
+
+    test('it throws an error if both models and model arguments are passed', async function (assert) {
+      setupOnerror((err: Error) => {
+        assert.equal(
+          err.message,
+          'Assertion Failed: [helper][OSS::transition-to] only one of model or models argument must be provided'
+        );
+      });
+
+      await render(hbs`<a {{on "click" (transition-to route="foo" models=(array '1' '2') model='3')}}>link</a>`);
+    });
+
+    test('it throws an error if queryParams argument is passed but is not an object', async function (assert) {
+      setupOnerror((err: Error) => {
+        assert.equal(
+          err.message,
+          'Assertion Failed: [helper][OSS::transition-to] queryParams argument must be an object'
+        );
+      });
+
+      await render(hbs`<a {{on "click" (transition-to route="foo" queryParams='string')}}>link</a>`);
+    });
+  });
+
+  module('only a route has been passed', function () {
+    test('it triggers the RouterService#transitionTo method with the route only', async function (assert) {
+      await render(hbs`<a {{on "click" (transition-to route="foo")}}>link</a>`);
+      await click('a');
+
+      assert.ok(this.transitionToStub.calledWithExactly('foo', { queryParams: {} }));
+    });
+  });
+
+  module('a model has been passed to the transition', function () {
+    test('it triggers the RouterService#transitionTo method with the route only', async function (assert) {
+      await render(hbs`<a {{on "click" (transition-to route="foo" model="1")}}>link</a>`);
+      await click('a');
+
+      assert.ok(this.transitionToStub.calledWithExactly('foo', '1', { queryParams: {} }));
+    });
+  });
+
+  module('multiple models have been passed to the transition', function () {
+    test('it triggers the RouterService#transitionTo method with the route only', async function (assert) {
+      await render(hbs`<a {{on "click" (transition-to route="foo" models=(array 'fizz' 'buzz'))}}>link</a>`);
+      await click('a');
+
+      assert.ok(this.transitionToStub.calledWithExactly('foo', 'fizz', 'buzz', { queryParams: {} }));
+    });
+  });
+});


### PR DESCRIPTION
### What does this PR do?

Because sometimes buttons or other components than LinkTo's do transitions to 😩 . and i was getting tired of creating actions on the JS just to do transitions.

Usage:
```hbs
<OSS::Button {{on "click" (transition-to "route.subroute")}} />
```

### What are the observable changes?
<!-- This question could be adequate with multiple use cases, for example: -->

<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled

### Additional Notes

<!--
    You can add anything you want here, an explanation on the way you built your implementation,
    precisions on the origin of the bug, gotchas you need to mention.
 -->
