### PR TITLE
Add param on OSS::CurrencyInput for show only the currency dd

### DIFF
--- a/addon/components/o-s-s/currency-input.hbs
+++ b/addon/components/o-s-s/currency-input.hbs
@@ -25,7 +25,7 @@
   {{#if this.currencySelectorShown}}
     <OSS::InfiniteSelect @items={{this.filteredCurrencies}} @onSearch={{this.onSearch}} 
                          @onSelect={{this.onSelect}}
-                         @searchPlaceholder={{t "oss-components.currency-input.search" }} 
+                         @searchPlaceholder={{t "oss-components.currency-input.search"}} 
                          {{on-click-outside this.hideCurrencySelector}}>
       <:option as |currency|>
         <div class="fx-row fx-xalign-center {{if (eq this.selectedCurrency currency) 'row-selected'}}">

--- a/addon/components/o-s-s/currency-input.hbs
+++ b/addon/components/o-s-s/currency-input.hbs
@@ -2,40 +2,40 @@
   <div class="currency-input {{if @onlyCurrency " onlycurrency"}} upf-input fx-row fx-1 fx-xalign-center">
     <div class="currency-selector fx-row fx-gap-px-12 fx-malign-space-between" role="button" 
          {{on "click" this.toggleCurrencySelector}}>
+    <div class="currency-selector fx-row fx-gap-px-12 fx-malign-space-between" role="button" {{on "click"
+      this.toggleCurrencySelector}}>
       <div class="fx-col">
         <div class="fx-row fx-gap-px-9">
           <span>{{this.selectedCurrencySymbol}}</span>
           {{#if @onlyCurrency}}
-            <span class="margin-right-px-12">{{this.selectedCurrencyCode}}</span>
+          <span class="margin-right-px-12">{{this.selectedCurrencyCode}}</span>
           {{/if}}
         </div>
       </div>
       {{#if this.currencySelectorShown}}
-        <i class="far fa-chevron-up margin-left-xxx-sm"></i>
+      <i class="far fa-chevron-up margin-left-xxx-sm"></i>
       {{else}}
-        <i class="far fa-chevron-down margin-left-xxx-sm"></i>
+      <i class="far fa-chevron-down margin-left-xxx-sm"></i>
       {{/if}}
     </div>
     {{#unless @onlyCurrency}}
-      <Input class="fx-1" type="number" @value={{this.localValue}} {{on "keydown" this.onlyNumeric}}
-             {{on "keyup" this.notifyChanges}}
-             autocomplete="off" />
+    <Input class="fx-1" type="number" @value={{this.localValue}} {{on "keydown" this.onlyNumeric}} {{on "keyup"
+      this.notifyChanges}} autocomplete="off" />
     {{/unless}}
   </div>
   {{#if this.currencySelectorShown}}
-    <OSS::InfiniteSelect @items={{this.filteredCurrencies}} @onSearch={{this.onSearch}} 
-                         @onSelect={{this.onSelect}}
-                         @searchPlaceholder={{t "oss-components.currency-input.search"}} 
-                         {{on-click-outside this.hideCurrencySelector}}>
-      <:option as |currency|>
-        <div class="fx-row fx-xalign-center {{if (eq this.selectedCurrency currency) 'row-selected'}}">
-          <span class="symbol text-color-default-light margin-left-xx-sm">{{currency.symbol}}</span>
-          <span class="text-color-default-light margin-left-xx-sm fx-1">{{currency.code}}</span>
-          {{#if (eq this.selectedCurrency currency)}}
-            <i class="far fa-check text-color-bright-purple padding-right-px-6"></i>
-          {{/if}}
-        </div>
-      </:option>
-    </OSS::InfiniteSelect>
+  <OSS::InfiniteSelect @items={{this.filteredCurrencies}} 
+                       @onSearch={{this.onSearch}} @onSelect={{this.onSelect}}
+    @searchPlaceholder={{t "oss-components.currency-input.search" }} {{on-click-outside this.hideCurrencySelector}}>
+    <:option as |currency|>
+      <div class="fx-row fx-xalign-center {{if (eq this.selectedCurrency currency) 'row-selected'}}">
+        <span class="symbol text-color-default-light margin-left-xx-sm">{{currency.symbol}}</span>
+        <span class="text-color-default-light margin-left-xx-sm fx-1">{{currency.code}}</span>
+        {{#if (eq this.selectedCurrency currency)}}
+        <i class="far fa-check text-color-bright-purple padding-right-px-6"></i>
+        {{/if}}
+      </div>
+    </:option>
+  </OSS::InfiniteSelect>
   {{/if}}
 </div>

--- a/addon/components/o-s-s/currency-input.hbs
+++ b/addon/components/o-s-s/currency-input.hbs
@@ -1,34 +1,31 @@
 <div class="currency-input-container fx-1" ...attributes>
-  <div class="{{if this.onlyCurrencyInput "currency-input-onlycurrency" "currency-input"}} upf-input fx-row fx-1 fx-xalign-center ">
-    <div class="currency-selector fx-row fx-malign-space-between" role="button" {{on "click" this.toggleCurrencySelector}}>
+  <div class="currency-input {{if @onlyCurrency " onlycurrency"}} upf-input fx-row fx-1 fx-xalign-center">
+    <div class="currency-selector fx-row fx-gap-px-12 fx-malign-space-between" role="button" {{on "click"
+      this.toggleCurrencySelector}}>
       <div class="fx-col">
-        <div class="fx-row fx-gap-px-24">
-          <span class="text-center symbol">{{this.selectedCurrencySymbol}}</span>
-          {{#if this.onlyCurrencyInput}}
-            <span class=" margin-right-px-24 text-center symbol">{{this.selectedCurrencyCode}}</span>
+        <div class="fx-row fx-gap-px-9">
+          {{#if (not-eq this.selectedCurrencyCode "Select")}}
+            <span>{{this.selectedCurrencySymbol}}</span>
+          {{/if}}
+          {{#if @onlyCurrency}}
+            <span class=" margin-right-px-12 {{if (eq this.selectedCurrencyCode "Select") "font-color-gray-500" }}">{{this.selectedCurrencyCode}}</span>
           {{/if}}
         </div>
       </div>
-      <div class="fx-col">
       {{#if this.currencySelectorShown}}
         <i class="far fa-chevron-up margin-left-xxx-sm"></i>
       {{else}}
         <i class="far fa-chevron-down margin-left-xxx-sm"></i>
       {{/if}}
-
-      </div>
     </div>
-    {{#unless this.onlyCurrencyInput}}
-      <Input class="fx-1" type="number" @value={{this.localValue}} {{on "keydown" this.onlyNumeric}}
-             {{on "keyup" this.notifyChanges}}
-             autocomplete="off" />
+    {{#unless @onlyCurrency}}
+      <Input class="fx-1" type="number" @value={{this.localValue}} {{on "keydown" this.onlyNumeric}} {{on "keyup"
+        this.notifyChanges}} autocomplete="off" />
     {{/unless}}
   </div>
   {{#if this.currencySelectorShown}}
-    <OSS::InfiniteSelect @items={{this.filteredCurrencies}} @onSearch={{this.onSearch}}
-                         @onSelect={{this.onSelect}}
-                         @searchPlaceholder={{t "oss-components.currency-input.search"}}
-                         {{on-click-outside this.hideCurrencySelector}}>
+    <OSS::InfiniteSelect @items={{this.filteredCurrencies}} @onSearch={{this.onSearch}} @onSelect={{this.onSelect}}
+      @searchPlaceholder={{t "oss-components.currency-input.search" }} {{on-click-outside this.hideCurrencySelector}}>
       <:option as |currency|>
         <div class="fx-row fx-xalign-center {{if (eq this.selectedCurrency currency) 'row-selected'}}">
           <span class="symbol text-color-default-light margin-left-xx-sm">{{currency.symbol}}</span>

--- a/addon/components/o-s-s/currency-input.hbs
+++ b/addon/components/o-s-s/currency-input.hbs
@@ -2,8 +2,12 @@
   <div class="{{if this.onlyCurrencyInput "currency-input-onlycurrency" "currency-input"}} upf-input fx-row fx-1 fx-xalign-center ">
     <div class="currency-selector fx-row fx-malign-space-between" role="button" {{on "click" this.toggleCurrencySelector}}>
       <div class="fx-col">
-        <span class="margin-right-xxx-sm text-center symbol">{{this.selectedCurrencySymbol}}</span>
-
+        <div class="fx-row fx-gap-px-24">
+          <span class="text-center symbol">{{this.selectedCurrencySymbol}}</span>
+          {{#if this.onlyCurrencyInput}}
+            <span class=" margin-right-px-24 text-center symbol">{{this.selectedCurrencyCode}}</span>
+          {{/if}}
+        </div>
       </div>
       <div class="fx-col">
       {{#if this.currencySelectorShown}}

--- a/addon/components/o-s-s/currency-input.hbs
+++ b/addon/components/o-s-s/currency-input.hbs
@@ -1,14 +1,12 @@
 <div class="currency-input-container fx-1" ...attributes>
   <div class="currency-input {{if @onlyCurrency " onlycurrency"}} upf-input fx-row fx-1 fx-xalign-center">
-    <div class="currency-selector fx-row fx-gap-px-12 fx-malign-space-between" role="button" {{on "click"
-      this.toggleCurrencySelector}}>
+    <div class="currency-selector fx-row fx-gap-px-12 fx-malign-space-between" role="button" 
+         {{on "click" this.toggleCurrencySelector}}>
       <div class="fx-col">
         <div class="fx-row fx-gap-px-9">
-          {{#if (not-eq this.selectedCurrencyCode "Select")}}
-            <span>{{this.selectedCurrencySymbol}}</span>
-          {{/if}}
+          <span>{{this.selectedCurrencySymbol}}</span>
           {{#if @onlyCurrency}}
-            <span class=" margin-right-px-12 {{if (eq this.selectedCurrencyCode "Select") "font-color-gray-500" }}">{{this.selectedCurrencyCode}}</span>
+            <span class="margin-right-px-12">{{this.selectedCurrencyCode}}</span>
           {{/if}}
         </div>
       </div>
@@ -19,13 +17,16 @@
       {{/if}}
     </div>
     {{#unless @onlyCurrency}}
-      <Input class="fx-1" type="number" @value={{this.localValue}} {{on "keydown" this.onlyNumeric}} {{on "keyup"
-        this.notifyChanges}} autocomplete="off" />
+      <Input class="fx-1" type="number" @value={{this.localValue}} {{on "keydown" this.onlyNumeric}}
+             {{on "keyup" this.notifyChanges}}
+             autocomplete="off" />
     {{/unless}}
   </div>
   {{#if this.currencySelectorShown}}
-    <OSS::InfiniteSelect @items={{this.filteredCurrencies}} @onSearch={{this.onSearch}} @onSelect={{this.onSelect}}
-      @searchPlaceholder={{t "oss-components.currency-input.search" }} {{on-click-outside this.hideCurrencySelector}}>
+    <OSS::InfiniteSelect @items={{this.filteredCurrencies}} @onSearch={{this.onSearch}} 
+                         @onSelect={{this.onSelect}}
+                         @searchPlaceholder={{t "oss-components.currency-input.search" }} 
+                         {{on-click-outside this.hideCurrencySelector}}>
       <:option as |currency|>
         <div class="fx-row fx-xalign-center {{if (eq this.selectedCurrency currency) 'row-selected'}}">
           <span class="symbol text-color-default-light margin-left-xx-sm">{{currency.symbol}}</span>

--- a/addon/components/o-s-s/currency-input.hbs
+++ b/addon/components/o-s-s/currency-input.hbs
@@ -18,8 +18,7 @@
     </div>
     {{#unless @onlyCurrency}}
       <Input class="fx-1" type="number" @value={{this.localValue}} {{on "keydown" this.onlyNumeric}}
-             {{on "keyup" this.notifyChanges}}
-             autocomplete="off" />
+             {{on "keyup" this.notifyChanges}} autocomplete="off" />
     {{/unless}}
   </div>
   {{#if this.currencySelectorShown}}

--- a/addon/components/o-s-s/currency-input.hbs
+++ b/addon/components/o-s-s/currency-input.hbs
@@ -1,16 +1,24 @@
 <div class="currency-input-container fx-1" ...attributes>
-  <div class="currency-input upf-input fx-row fx-1 fx-xalign-center">
-    <div class="currency-selector fx-row" role="button" {{on "click" this.toggleCurrencySelector}}>
-      <span class="margin-right-xxx-sm text-center symbol">{{this.selectedCurrencySymbol}}</span>
+  <div class="{{if this.onlyCurrencyInput "currency-input-onlycurrency" "currency-input"}} upf-input fx-row fx-1 fx-xalign-center ">
+    <div class="currency-selector fx-row fx-malign-space-between" role="button" {{on "click" this.toggleCurrencySelector}}>
+      <div class="fx-col">
+        <span class="margin-right-xxx-sm text-center symbol">{{this.selectedCurrencySymbol}}</span>
+
+      </div>
+      <div class="fx-col">
       {{#if this.currencySelectorShown}}
         <i class="far fa-chevron-up margin-left-xxx-sm"></i>
       {{else}}
         <i class="far fa-chevron-down margin-left-xxx-sm"></i>
       {{/if}}
+
+      </div>
     </div>
-    <Input class="fx-1" type="number" @value={{this.localValue}} {{on "keydown" this.onlyNumeric}}
-           {{on "keyup" this.notifyChanges}}
-           autocomplete="off" />
+    {{#unless this.onlyCurrencyInput}}
+      <Input class="fx-1" type="number" @value={{this.localValue}} {{on "keydown" this.onlyNumeric}}
+             {{on "keyup" this.notifyChanges}}
+             autocomplete="off" />
+    {{/unless}}
   </div>
   {{#if this.currencySelectorShown}}
     <OSS::InfiniteSelect @items={{this.filteredCurrencies}} @onSearch={{this.onSearch}}

--- a/addon/components/o-s-s/currency-input.hbs
+++ b/addon/components/o-s-s/currency-input.hbs
@@ -1,41 +1,41 @@
 <div class="currency-input-container fx-1" ...attributes>
   <div class="currency-input {{if @onlyCurrency " onlycurrency"}} upf-input fx-row fx-1 fx-xalign-center">
-    <div class="currency-selector fx-row fx-gap-px-12 fx-malign-space-between" role="button" 
+    <div class="currency-selector fx-row fx-gap-px-12 fx-malign-space-between" role="button"
          {{on "click" this.toggleCurrencySelector}}>
-    <div class="currency-selector fx-row fx-gap-px-12 fx-malign-space-between" role="button" {{on "click"
-      this.toggleCurrencySelector}}>
       <div class="fx-col">
         <div class="fx-row fx-gap-px-9">
           <span>{{this.selectedCurrencySymbol}}</span>
           {{#if @onlyCurrency}}
-          <span class="margin-right-px-12">{{this.selectedCurrencyCode}}</span>
+            <span class="margin-right-px-12">{{this.selectedCurrencyCode}}</span>
           {{/if}}
         </div>
       </div>
       {{#if this.currencySelectorShown}}
-      <i class="far fa-chevron-up margin-left-xxx-sm"></i>
+        <i class="far fa-chevron-up margin-left-xxx-sm"></i>
       {{else}}
-      <i class="far fa-chevron-down margin-left-xxx-sm"></i>
+        <i class="far fa-chevron-down margin-left-xxx-sm"></i>
       {{/if}}
     </div>
     {{#unless @onlyCurrency}}
-    <Input class="fx-1" type="number" @value={{this.localValue}} {{on "keydown" this.onlyNumeric}} {{on "keyup"
-      this.notifyChanges}} autocomplete="off" />
+      <Input class="fx-1" type="number" @value={{this.localValue}} {{on "keydown" this.onlyNumeric}}
+             {{on "keyup" this.notifyChanges}}
+             autocomplete="off" />
     {{/unless}}
   </div>
   {{#if this.currencySelectorShown}}
-  <OSS::InfiniteSelect @items={{this.filteredCurrencies}} 
-                       @onSearch={{this.onSearch}} @onSelect={{this.onSelect}}
-    @searchPlaceholder={{t "oss-components.currency-input.search" }} {{on-click-outside this.hideCurrencySelector}}>
-    <:option as |currency|>
-      <div class="fx-row fx-xalign-center {{if (eq this.selectedCurrency currency) 'row-selected'}}">
-        <span class="symbol text-color-default-light margin-left-xx-sm">{{currency.symbol}}</span>
-        <span class="text-color-default-light margin-left-xx-sm fx-1">{{currency.code}}</span>
-        {{#if (eq this.selectedCurrency currency)}}
-        <i class="far fa-check text-color-bright-purple padding-right-px-6"></i>
-        {{/if}}
-      </div>
-    </:option>
-  </OSS::InfiniteSelect>
+    <OSS::InfiniteSelect @items={{this.filteredCurrencies}} @onSearch={{this.onSearch}}
+                         @onSelect={{this.onSelect}}
+                         @searchPlaceholder={{t "oss-components.currency-input.search"}}
+                         {{on-click-outside this.hideCurrencySelector}}>
+      <:option as |currency|>
+        <div class="fx-row fx-xalign-center {{if (eq this.selectedCurrency currency) 'row-selected'}}">
+          <span class="symbol text-color-default-light margin-left-xx-sm">{{currency.symbol}}</span>
+          <span class="text-color-default-light margin-left-xx-sm fx-1">{{currency.code}}</span>
+          {{#if (eq this.selectedCurrency currency)}}
+            <i class="far fa-check text-color-bright-purple padding-right-px-6"></i>
+          {{/if}}
+        </div>
+      </:option>
+    </OSS::InfiniteSelect>
   {{/if}}
 </div>

--- a/addon/components/o-s-s/currency-input.stories.js
+++ b/addon/components/o-s-s/currency-input.stories.js
@@ -28,13 +28,23 @@ export default {
     onChange: {
       type: { required: true },
       description: 'A callback that sends the modifications of the value & the currency back to the parent component'
+    },
+    onlyCurrency: {
+      description: 'Display only the currency dropdown',
+      table: {
+        type: {
+          summary: 'boolean'
+        },
+        defaultValue: { summary: false }
+      },
+      control: { type: 'boolean' }
     }
   }
 };
 
 const DefaultUsageTemplate = (args) => ({
   template: hbs`
-      <OSS::CurrencyInput @value={{this.value}} @currency={{this.currency}} @onChange={{this.onChange}} />
+      <OSS::CurrencyInput @value={{this.value}} @currency={{this.currency}} @onChange={{this.onChange}} @onlyCurrency={{this.onlyCurrency}} />
   `,
   context: args
 });
@@ -43,5 +53,6 @@ BasicUsage.args = {
   that: this,
   value: 42,
   currency: 'USD',
-  onChange: action('onChange')
+  onChange: action('onChange'),
+  onlyCurrency: false
 };

--- a/addon/components/o-s-s/currency-input.ts
+++ b/addon/components/o-s-s/currency-input.ts
@@ -8,6 +8,7 @@ interface OSSCurrencyInputArgs {
   currency: string;
   value: number;
   onChange(currency: string, value: number): void;
+  onlyCurrency: boolean;
 }
 
 const NUMERIC_ONLY = /^[0-9]$/i;
@@ -29,6 +30,10 @@ export default class OSSCurrencyInput extends Component<OSSCurrencyInputArgs> {
 
   get selectedCurrencySymbol(): string {
     return this.selectedCurrency.symbol || '—';
+  }
+
+  get onlyCurrencyInput(): boolean {
+    return this.args.onlyCurrency || false;
   }
 
   get selectedCurrency() {

--- a/addon/components/o-s-s/currency-input.ts
+++ b/addon/components/o-s-s/currency-input.ts
@@ -7,8 +7,8 @@ import { isEmpty } from '@ember/utils';
 interface OSSCurrencyInputArgs {
   currency: string;
   value: number;
-  onChange(currency: string, value: number): void;
-  onlyCurrency: boolean;
+  onChange(currency: string | undefined, value: number): void;
+  onlyCurrency?: boolean;
 }
 
 const NUMERIC_ONLY = /^[0-9]$/i;
@@ -29,20 +29,18 @@ export default class OSSCurrencyInput extends Component<OSSCurrencyInputArgs> {
   }
 
   get selectedCurrencySymbol(): string {
-    return this.selectedCurrency.symbol || '—';
+    return this.selectedCurrency?.symbol || '—';
   }
 
   get selectedCurrencyCode(): string {
-    return this.selectedCurrency.code || '...';
-  }
-
-  get onlyCurrencyInput(): boolean {
-    return this.args.onlyCurrency || false;
+    return this.selectedCurrency?.code || 'Select';
   }
 
   get selectedCurrency() {
-    if (isEmpty(this.args.currency)) {
+    if (isEmpty(this.args.currency) && this.args.onlyCurrency == false) {
       return this._currencies[0];
+    } else if (isEmpty(this.args.currency) && this.args.onlyCurrency == true) {
+      return null;
     }
 
     return this._currencies.find((currency: Currency) => currency.code === this.args.currency) || this._currencies[0];
@@ -70,7 +68,7 @@ export default class OSSCurrencyInput extends Component<OSSCurrencyInputArgs> {
 
   @action
   notifyChanges(): void {
-    this.args.onChange(this.selectedCurrency.code, this.localValue);
+    this.args.onChange(this.selectedCurrency?.code, this.localValue);
   }
 
   @action

--- a/addon/components/o-s-s/currency-input.ts
+++ b/addon/components/o-s-s/currency-input.ts
@@ -7,7 +7,7 @@ import { isEmpty } from '@ember/utils';
 interface OSSCurrencyInputArgs {
   currency: string;
   value: number;
-  onChange(currency: string | undefined, value: number): void;
+  onChange(currency: string , value: number ): void;
   onlyCurrency?: boolean;
 }
 
@@ -29,21 +29,22 @@ export default class OSSCurrencyInput extends Component<OSSCurrencyInputArgs> {
   }
 
   get selectedCurrencySymbol(): string {
-    return this.selectedCurrency?.symbol || '—';
+    return this.selectedCurrency.symbol || '—';
   }
 
   get selectedCurrencyCode(): string {
-    return this.selectedCurrency?.code || 'Select';
+    return this.selectedCurrency.code || '—';
   }
 
-  get selectedCurrency() {
-    if (isEmpty(this.args.currency) && this.args.onlyCurrency == false) {
+  get selectedCurrency(): Currency {
+    if (this.emptyCurrency) {
       return this._currencies[0];
-    } else if (isEmpty(this.args.currency) && this.args.onlyCurrency == true) {
-      return null;
     }
-
     return this._currencies.find((currency: Currency) => currency.code === this.args.currency) || this._currencies[0];
+  }
+
+  get emptyCurrency(): boolean {
+    return isEmpty(this.args.currency);
   }
 
   @action
@@ -68,7 +69,7 @@ export default class OSSCurrencyInput extends Component<OSSCurrencyInputArgs> {
 
   @action
   notifyChanges(): void {
-    this.args.onChange(this.selectedCurrency?.code, this.localValue);
+    this.args.onChange(this.selectedCurrency.code, this.localValue);
   }
 
   @action

--- a/addon/components/o-s-s/currency-input.ts
+++ b/addon/components/o-s-s/currency-input.ts
@@ -7,7 +7,7 @@ import { isEmpty } from '@ember/utils';
 interface OSSCurrencyInputArgs {
   currency: string;
   value: number;
-  onChange(currency: string , value: number): void;
+  onChange(currency: string, value: number): void;
   onlyCurrency?: boolean;
 }
 

--- a/addon/components/o-s-s/currency-input.ts
+++ b/addon/components/o-s-s/currency-input.ts
@@ -7,7 +7,7 @@ import { isEmpty } from '@ember/utils';
 interface OSSCurrencyInputArgs {
   currency: string;
   value: number;
-  onChange(currency: string , value: number ): void;
+  onChange(currency: string , value: number): void;
   onlyCurrency?: boolean;
 }
 
@@ -37,14 +37,10 @@ export default class OSSCurrencyInput extends Component<OSSCurrencyInputArgs> {
   }
 
   get selectedCurrency(): Currency {
-    if (this.emptyCurrency) {
+    if (isEmpty(this.args.currency)) {
       return this._currencies[0];
     }
     return this._currencies.find((currency: Currency) => currency.code === this.args.currency) || this._currencies[0];
-  }
-
-  get emptyCurrency(): boolean {
-    return isEmpty(this.args.currency);
   }
 
   @action

--- a/addon/components/o-s-s/currency-input.ts
+++ b/addon/components/o-s-s/currency-input.ts
@@ -32,6 +32,10 @@ export default class OSSCurrencyInput extends Component<OSSCurrencyInputArgs> {
     return this.selectedCurrency.symbol || '—';
   }
 
+  get selectedCurrencyCode(): string {
+    return this.selectedCurrency.code || '...';
+  }
+
   get onlyCurrencyInput(): boolean {
     return this.args.onlyCurrency || false;
   }

--- a/app/styles/currency-input.less
+++ b/app/styles/currency-input.less
@@ -31,7 +31,7 @@
       padding-right: var(--spacing-px-12);
       margin-right: var(--spacing-px-12);
     }
-
+    
     input {
       border: none;
       background-color: transparent;
@@ -46,12 +46,13 @@
       border: 1px solid var(--color-border-default);
     }
   }
-  .currency-input.onlycurrency {
-    padding-right: 0px;
+
+  .onlycurrency {
+    padding-right: 0;
+    
     .currency-selector {
       border-right: none;
-      margin-right: 0px;
-      width: 100%;
+      margin-right: 0;
     }
   }
 }

--- a/app/styles/currency-input.less
+++ b/app/styles/currency-input.less
@@ -53,6 +53,7 @@
     .currency-selector {
       border-right: none;
       margin-right: 0;
+      width:100%;
     }
   }
 }

--- a/app/styles/currency-input.less
+++ b/app/styles/currency-input.less
@@ -3,6 +3,7 @@
 
   .upf-infinite-select {
     max-width: 100%;
+    min-width: 150px;
     .padding-xx-sm;
 
     .upf-infinite-select__item {
@@ -29,6 +30,37 @@
       align-items: center;
       padding-right: var(--spacing-px-12);
       margin-right: var(--spacing-px-12);
+    }
+
+    .phone-prefix {
+      white-space: nowrap;
+      .text-color-default-light;
+      .margin-right-xxx-sm;
+    }
+
+    input {
+      border: none;
+      background-color: transparent;
+    }
+
+    input:focus {
+      border: none;
+      outline: none;
+    }
+
+    &:focus-within {
+      border: 1px solid var(--color-border-default);
+    }
+  }
+  .currency-input-onlycurrency {
+    padding-right: 0px;
+    .currency-selector {
+      height: 100%;
+      display: flex;
+      align-items: center;
+      padding-right: var(--spacing-px-12);
+      margin-right: 0px;
+      width: 100%;
     }
 
     .phone-prefix {

--- a/app/styles/currency-input.less
+++ b/app/styles/currency-input.less
@@ -3,6 +3,7 @@
 
   .upf-infinite-select {
     max-width: 100%;
+    min-width:150px;
     .padding-xx-sm;
 
     .upf-infinite-select__item {
@@ -31,12 +32,6 @@
       margin-right: var(--spacing-px-12);
     }
 
-    .phone-prefix {
-      white-space: nowrap;
-      .text-color-default-light;
-      .margin-right-xxx-sm;
-    }
-
     input {
       border: none;
       background-color: transparent;
@@ -51,35 +46,12 @@
       border: 1px solid var(--color-border-default);
     }
   }
-  .currency-input-onlycurrency {
+  .currency-input.onlycurrency {
     padding-right: 0px;
     .currency-selector {
-      height: 100%;
-      display: flex;
-      align-items: center;
-      padding-right: var(--spacing-px-12);
+      border-right: none;
       margin-right: 0px;
       width: 100%;
-    }
-
-    .phone-prefix {
-      white-space: nowrap;
-      .text-color-default-light;
-      .margin-right-xxx-sm;
-    }
-
-    input {
-      border: none;
-      background-color: transparent;
-    }
-
-    input:focus {
-      border: none;
-      outline: none;
-    }
-
-    &:focus-within {
-      border: 1px solid var(--color-border-default);
     }
   }
 }

--- a/app/styles/currency-input.less
+++ b/app/styles/currency-input.less
@@ -3,7 +3,7 @@
 
   .upf-infinite-select {
     max-width: 100%;
-    min-width:150px;
+    min-width: 150px;
     .padding-xx-sm;
 
     .upf-infinite-select__item {

--- a/app/styles/currency-input.less
+++ b/app/styles/currency-input.less
@@ -3,7 +3,6 @@
 
   .upf-infinite-select {
     max-width: 100%;
-    min-width: 150px;
     .padding-xx-sm;
 
     .upf-infinite-select__item {

--- a/tests/dummy/app/controllers/application.js
+++ b/tests/dummy/app/controllers/application.js
@@ -16,15 +16,12 @@ export default class ApplicationController extends Controller {
   @tracked currency = 'EUR';
   @tracked currencyValue = 42.13;
   @tracked showModal = false;
-<<<<<<< HEAD
   @tracked items = [
     { name: 'foo', label: 'foo' },
     { name: 'bar', label: 'bar' }
   ];
   @tracked selectedItem = this.items[0];
-=======
   @tracked currencyOnly = null;
->>>>>>> 36a057f (Update after review)
 
   code4CodeBlock = testScript;
   countries = countries;

--- a/tests/dummy/app/controllers/application.js
+++ b/tests/dummy/app/controllers/application.js
@@ -16,11 +16,15 @@ export default class ApplicationController extends Controller {
   @tracked currency = 'EUR';
   @tracked currencyValue = 42.13;
   @tracked showModal = false;
+<<<<<<< HEAD
   @tracked items = [
     { name: 'foo', label: 'foo' },
     { name: 'bar', label: 'bar' }
   ];
   @tracked selectedItem = this.items[0];
+=======
+  @tracked currencyOnly = null;
+>>>>>>> 36a057f (Update after review)
 
   code4CodeBlock = testScript;
   countries = countries;
@@ -63,6 +67,11 @@ export default class ApplicationController extends Controller {
     console.log('onCurrencyInputChange', currency, value);
     this.currency = currency;
     this.currencyValue = value;
+  }
+
+  @action
+  onCurrencyOnlyChange(currency) {
+    this.currencyOnly = currency;
   }
 
   @action

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -50,6 +50,13 @@
                       @onChange={{this.onCurrencyInputChange}} />
 </div>
 <div class="fx-row fx-1 margin-md">
+  <div class="fx-col">
+  <OSS::CurrencyInput @currency={{this.currency}} @value={{this.currencyValue}}
+                      @onChange={{this.onCurrencyInputChange}} @onlyCurrency={{true}}/>
+
+  </div>
+</div>
+<div class="fx-row fx-1 margin-md">
   <OSS::ArrayInput @values={{this.superHeroes}}
                    @onChange={{this.updateSuperHeroes}} class="fx-1"
                    data-control-name="mailing-edit-template-ccs-input" />

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -51,9 +51,13 @@
 </div>
 <div class="fx-row fx-1 margin-md">
   <div class="fx-col">
-  <OSS::CurrencyInput @currency={{this.currency}} @value={{this.currencyValue}}
-                      @onChange={{this.onCurrencyInputChange}} @onlyCurrency={{true}}/>
-
+    <OSS::CurrencyInput @currency={{this.currency}} @value={{this.currencyValue}}
+                        @onChange={{this.onCurrencyInputChange}} @onlyCurrency={{true}}/>
+  </div>
+</div>
+<div class="fx-row fx-1 margin-md">
+  <div class="fx-col">
+    <OSS::CurrencyInput @currency={{this.currencyOnly}} @onChange={{this.onCurrencyOnlyChange}} @onlyCurrency={{true}}/>
   </div>
 </div>
 <div class="fx-row fx-1 margin-md">

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -52,12 +52,12 @@
 <div class="fx-row fx-1 margin-md">
   <div class="fx-col">
     <OSS::CurrencyInput @currency={{this.currency}} @value={{this.currencyValue}}
-                        @onChange={{this.onCurrencyInputChange}} @onlyCurrency={{true}}/>
+                        @onChange={{this.onCurrencyInputChange}} @onlyCurrency={{true}} />
   </div>
 </div>
 <div class="fx-row fx-1 margin-md">
   <div class="fx-col">
-    <OSS::CurrencyInput @currency={{this.currencyOnly}} @onChange={{this.onCurrencyOnlyChange}} @onlyCurrency={{true}}/>
+    <OSS::CurrencyInput @currency={{this.currencyOnly}} @onChange={{this.onCurrencyOnlyChange}} @onlyCurrency={{true}} />
   </div>
 </div>
 <div class="fx-row fx-1 margin-md">

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -50,10 +50,8 @@
                       @onChange={{this.onCurrencyInputChange}} />
 </div>
 <div class="fx-row fx-1 margin-md">
-  <div class="fx-col">
-    <OSS::CurrencyInput @currency={{this.currency}} @value={{this.currencyValue}}
-                        @onChange={{this.onCurrencyInputChange}} @onlyCurrency={{true}} />
-  </div>
+  <OSS::CurrencyInput @currency={{this.currency}} @value={{this.currencyValue}}
+                      @onChange={{this.onCurrencyInputChange}} @onlyCurrency={{true}} />
 </div>
 <div class="fx-row fx-1 margin-md">
   <div class="fx-col">

--- a/tests/integration/components/o-s-s/currency-input-test.ts
+++ b/tests/integration/components/o-s-s/currency-input-test.ts
@@ -25,6 +25,11 @@ module('Integration | Component | o-s-s/currency-input', function (hooks) {
 
     assert.dom('.currency-input-container').exists();
     assert.dom('.currency-selector ').exists();
+
+    const currencyLabel = await findAll('.currency-selector span');
+    assert.dom(currencyLabel[1]).exists();
+    assert.dom(currencyLabel[1]).hasText('USD');
+
     assert.dom('.currency-input input ').doesNotExist();
   });
 

--- a/tests/integration/components/o-s-s/currency-input-test.ts
+++ b/tests/integration/components/o-s-s/currency-input-test.ts
@@ -51,10 +51,10 @@ module('Integration | Component | o-s-s/currency-input', function (hooks) {
     const currencyLabel = await findAll('.currency-selector span');
 
     assert.dom(currencyLabel[0]).exists();
-    assert.dom(currencyLabel[0]).hasText('Select');
+    assert.dom(currencyLabel[0]).hasText('$');
 
-    assert.dom(currencyLabel[0]).exists();
-    assert.dom(currencyLabel[0]).hasClass('font-color-gray-500');
+    assert.dom(currencyLabel[1]).exists();
+    assert.dom(currencyLabel[1]).hasText('USD');
 
     assert.dom('.currency-input input').doesNotExist();
   });

--- a/tests/integration/components/o-s-s/currency-input-test.ts
+++ b/tests/integration/components/o-s-s/currency-input-test.ts
@@ -16,44 +16,6 @@ module('Integration | Component | o-s-s/currency-input', function (hooks) {
     assert.dom('.currency-input-container').exists();
   });
 
-  test('it renders currency only', async function (assert) {
-    this.onChange = () => {};
-    await render(hbs`<OSS::CurrencyInput @currency="USD" @onlyCurrency={{true}} @onChange={{this.onChange}} />`);
-
-    assert.dom('.currency-input-container').exists();
-    assert.dom('.currency-selector').exists();
-
-    const currencyLabel = await findAll('.currency-selector span');
-
-    assert.dom(currencyLabel[0]).exists();
-    assert.dom(currencyLabel[0]).hasText('$');
-
-    assert.dom(currencyLabel[1]).exists();
-    assert.dom(currencyLabel[1]).hasText('USD');
-
-    assert.dom('.currency-input input').doesNotExist();
-  });
-
-  test('it renders currency only with empty currency param', async function (assert) {
-    this.onChange = () => {};
-    await render(
-      hbs`<OSS::CurrencyInput @currency={{undefined}} @onlyCurrency={{true}} @onChange={{this.onChange}} />`
-    );
-
-    assert.dom('.currency-input-container').exists();
-    assert.dom('.currency-selector').exists();
-
-    const currencyLabel = await findAll('.currency-selector span');
-
-    assert.dom(currencyLabel[0]).exists();
-    assert.dom(currencyLabel[0]).hasText('$');
-
-    assert.dom(currencyLabel[1]).exists();
-    assert.dom(currencyLabel[1]).hasText('USD');
-
-    assert.dom('.currency-input input').doesNotExist();
-  });
-
   test('The passed @value parameter is properly displayed in the input', async function (assert) {
     this.onChange = () => {};
     await render(hbs`<OSS::CurrencyInput @value="12341234" @onChange={{this.onChange}} />`);
@@ -155,6 +117,34 @@ module('Integration | Component | o-s-s/currency-input', function (hooks) {
       // @ts-ignore
       await triggerKeyEvent('input', 'keydown', 'A', { code: 'a' });
       assert.dom('input').hasValue('08');
+    });
+  });
+
+  module('Currency only mode', () => {
+    test('it renders currency only', async function (assert) {
+      this.onChange = () => {};
+      await render(hbs`<OSS::CurrencyInput @currency="USD" @onlyCurrency={{true}} @onChange={{this.onChange}} />`);
+
+      assert.dom('.currency-input-container').exists();
+      assert.dom('.currency-selector').exists();
+
+      assert.dom('.currency-selector').hasText('$ USD');
+
+      assert.dom('.currency-input input').doesNotExist();
+    });
+
+    test('it renders currency only with empty currency param', async function (assert) {
+      this.onChange = () => {};
+      await render(
+        hbs`<OSS::CurrencyInput @currency={{undefined}} @onlyCurrency={{true}} @onChange={{this.onChange}} />`
+      );
+
+      assert.dom('.currency-input-container').exists();
+      assert.dom('.currency-selector').exists();
+
+      assert.dom('.currency-selector').hasText('$ USD');
+
+      assert.dom('.currency-input input').doesNotExist();
     });
   });
 });

--- a/tests/integration/components/o-s-s/currency-input-test.ts
+++ b/tests/integration/components/o-s-s/currency-input-test.ts
@@ -16,6 +16,18 @@ module('Integration | Component | o-s-s/currency-input', function (hooks) {
     assert.dom('.currency-input-container').exists();
   });
 
+  test('it renders currency only', async function (assert) {
+    this.onChange = () => {};
+    this.value = 0;
+    this.currency = '';
+    this.onlyCurrency = true;
+    await render(hbs`<OSS::CurrencyInput @onlyCurrency={{this.onlyCurrency}} @onChange={{this.onChange}} />`);
+
+    assert.dom('.currency-input-container').exists();
+    assert.dom('.currency-selector ').exists();
+    assert.dom('.currency-input input ').doesNotExist();
+  });
+
   test('The passed @value parameter is properly displayed in the input', async function (assert) {
     this.onChange = () => {};
     await render(hbs`<OSS::CurrencyInput @value="12341234" @onChange={{this.onChange}} />`);
@@ -54,7 +66,7 @@ module('Integration | Component | o-s-s/currency-input', function (hooks) {
       this.onChange = (currency: string, _: number) => {
         assert.equal(currency, 'AUD');
         this.set('currency', currency);
-      }
+      };
       sinon.spy(this.onChange);
       await render(hbs`<OSS::CurrencyInput @currency={{this.currency}} @value="" @onChange={{this.onChange}} />`);
       await click('.currency-selector');
@@ -87,7 +99,7 @@ module('Integration | Component | o-s-s/currency-input', function (hooks) {
       this.currency = 'USD';
       await render(hbs`<OSS::CurrencyInput @currency={{this.currency}} @value="" @onChange={{this.onChange}} />`);
       assert.dom('.currency-selector').hasText('$');
-      this.set('currency', 'EUR')
+      this.set('currency', 'EUR');
       assert.dom('.currency-selector').hasText('€');
     });
   });

--- a/tests/integration/components/o-s-s/currency-input-test.ts
+++ b/tests/integration/components/o-s-s/currency-input-test.ts
@@ -18,19 +18,45 @@ module('Integration | Component | o-s-s/currency-input', function (hooks) {
 
   test('it renders currency only', async function (assert) {
     this.onChange = () => {};
-    this.value = 0;
-    this.currency = '';
     this.onlyCurrency = true;
-    await render(hbs`<OSS::CurrencyInput @onlyCurrency={{this.onlyCurrency}} @onChange={{this.onChange}} />`);
+    await render(
+      hbs`<OSS::CurrencyInput @currency="USD" @onlyCurrency={{this.onlyCurrency}} @onChange={{this.onChange}} />`
+    );
 
     assert.dom('.currency-input-container').exists();
-    assert.dom('.currency-selector ').exists();
+    assert.dom('.currency-selector').exists();
 
     const currencyLabel = await findAll('.currency-selector span');
+
+    assert.dom(currencyLabel[0]).exists();
+    assert.dom(currencyLabel[0]).hasText('$');
+
     assert.dom(currencyLabel[1]).exists();
     assert.dom(currencyLabel[1]).hasText('USD');
 
-    assert.dom('.currency-input input ').doesNotExist();
+    assert.dom('.currency-input input').doesNotExist();
+  });
+
+  test('it renders currency only with empty currency param', async function (assert) {
+    this.onChange = () => {};
+    this.onlyCurrency = true;
+    this.currency = null;
+    await render(
+      hbs`<OSS::CurrencyInput @currency={{this.currency}} @onlyCurrency={{this.onlyCurrency}} @onChange={{this.onChange}} />`
+    );
+
+    assert.dom('.currency-input-container').exists();
+    assert.dom('.currency-selector').exists();
+
+    const currencyLabel = await findAll('.currency-selector span');
+
+    assert.dom(currencyLabel[0]).exists();
+    assert.dom(currencyLabel[0]).hasText('Select');
+
+    assert.dom(currencyLabel[0]).exists();
+    assert.dom(currencyLabel[0]).hasClass('font-color-gray-500');
+
+    assert.dom('.currency-input input').doesNotExist();
   });
 
   test('The passed @value parameter is properly displayed in the input', async function (assert) {
@@ -78,6 +104,21 @@ module('Integration | Component | o-s-s/currency-input', function (hooks) {
       const clickableRows = findAll('.upf-infinite-select__item');
       await click(clickableRows[4]);
       assert.dom('.currency-selector').hasText('A$');
+    });
+    test('Selecting a new currency in the Currency selector triggers the onChange method with currency only', async function (assert) {
+      this.currency = '';
+      this.onChange = (currency: string, _: number) => {
+        assert.equal(currency, 'AUD');
+        this.set('currency', currency);
+      };
+      sinon.spy(this.onChange);
+      await render(
+        hbs`<OSS::CurrencyInput @onlyCurrency={{true}} @currency={{this.currency}} @value="" @onChange={{this.onChange}} />`
+      );
+      await click('.currency-selector');
+      const clickableRows = findAll('.upf-infinite-select__item');
+      await click(clickableRows[4]);
+      assert.dom('.currency-selector').hasText('A$ AUD');
     });
     test('Typing in the search input filters the results', async function (assert) {
       this.onChange = sinon.spy();

--- a/tests/integration/components/o-s-s/currency-input-test.ts
+++ b/tests/integration/components/o-s-s/currency-input-test.ts
@@ -18,10 +18,7 @@ module('Integration | Component | o-s-s/currency-input', function (hooks) {
 
   test('it renders currency only', async function (assert) {
     this.onChange = () => {};
-    this.onlyCurrency = true;
-    await render(
-      hbs`<OSS::CurrencyInput @currency="USD" @onlyCurrency={{this.onlyCurrency}} @onChange={{this.onChange}} />`
-    );
+    await render(hbs`<OSS::CurrencyInput @currency="USD" @onlyCurrency={{true}} @onChange={{this.onChange}} />`);
 
     assert.dom('.currency-input-container').exists();
     assert.dom('.currency-selector').exists();
@@ -39,10 +36,8 @@ module('Integration | Component | o-s-s/currency-input', function (hooks) {
 
   test('it renders currency only with empty currency param', async function (assert) {
     this.onChange = () => {};
-    this.onlyCurrency = true;
-    this.currency = null;
     await render(
-      hbs`<OSS::CurrencyInput @currency={{this.currency}} @onlyCurrency={{this.onlyCurrency}} @onChange={{this.onChange}} />`
+      hbs`<OSS::CurrencyInput @currency={{undefined}} @onlyCurrency={{true}} @onChange={{this.onChange}} />`
     );
 
     assert.dom('.currency-input-container').exists();
@@ -94,31 +89,24 @@ module('Integration | Component | o-s-s/currency-input', function (hooks) {
     });
     test('Selecting a new currency in the Currency selector triggers the onChange method', async function (assert) {
       this.currency = '';
-      this.onChange = (currency: string, _: number) => {
-        assert.equal(currency, 'AUD');
-        this.set('currency', currency);
-      };
-      sinon.spy(this.onChange);
+      this.onChange = sinon.stub();
+  
       await render(hbs`<OSS::CurrencyInput @currency={{this.currency}} @value="" @onChange={{this.onChange}} />`);
       await click('.currency-selector');
       const clickableRows = findAll('.upf-infinite-select__item');
       await click(clickableRows[4]);
-      assert.dom('.currency-selector').hasText('A$');
+      assert.true(this.onChange.calledOnceWithExactly('AUD', 0));
     });
     test('Selecting a new currency in the Currency selector triggers the onChange method with currency only', async function (assert) {
       this.currency = '';
-      this.onChange = (currency: string, _: number) => {
-        assert.equal(currency, 'AUD');
-        this.set('currency', currency);
-      };
-      sinon.spy(this.onChange);
+      this.onChange = sinon.stub();
       await render(
         hbs`<OSS::CurrencyInput @onlyCurrency={{true}} @currency={{this.currency}} @value="" @onChange={{this.onChange}} />`
       );
       await click('.currency-selector');
       const clickableRows = findAll('.upf-infinite-select__item');
       await click(clickableRows[4]);
-      assert.dom('.currency-selector').hasText('A$ AUD');
+      assert.true(this.onChange.calledOnceWithExactly('AUD', 0));
     });
     test('Typing in the search input filters the results', async function (assert) {
       this.onChange = sinon.spy();

--- a/tests/integration/components/o-s-s/currency-input-test.ts
+++ b/tests/integration/components/o-s-s/currency-input-test.ts
@@ -90,7 +90,7 @@ module('Integration | Component | o-s-s/currency-input', function (hooks) {
     test('Selecting a new currency in the Currency selector triggers the onChange method', async function (assert) {
       this.currency = '';
       this.onChange = sinon.stub();
-  
+
       await render(hbs`<OSS::CurrencyInput @currency={{this.currency}} @value="" @onChange={{this.onChange}} />`);
       await click('.currency-selector');
       const clickableRows = findAll('.upf-infinite-select__item');


### PR DESCRIPTION
### What does this PR do?

Add param on OSS::CurrencyInput for show only the currency dropdown without number input

Related to: none, advancement for replace in identity web

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [ ] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [x] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled
