### PR TITLE
Use OSS::Chip in OSS::PowerSelect and OSS::ArrayInput

### DIFF
--- a/addon/components/o-s-s/array-input.hbs
+++ b/addon/components/o-s-s/array-input.hbs
@@ -1,11 +1,7 @@
 <div class="array-input-container fx-row fx-xalign-center" ...attributes>
   {{#each this.items as |item index|}}
-    <div class="input-array-tag fx-row fx-xalign-center">
-      {{item}}
-      <i class="fa fa-remove margin-left-xxx-sm text-color-blue-gray" role="button"
-         {{on "click" (fn this.removeItem index)}}></i>
-    </div>
+    <OSS::Chip @label={{item}} @onRemove={{fn this.removeItem index}} />
   {{/each}}
-  <Input @value={{this.currentValue}} @placeholder={{@placeholder}} {{on "keydown" this.keyListener}}
-         autocomplete="off" {{on "blur" this.validateTagOnClickOutside}} />
+  <Input @value={{this.currentValue}} @placeholder={{@placeholder}} {{on "keydown" this.keyListener}} autocomplete="off"
+         {{on "blur" this.validateTagOnClickOutside}} />
 </div>

--- a/addon/components/o-s-s/array-input.hbs
+++ b/addon/components/o-s-s/array-input.hbs
@@ -2,6 +2,6 @@
   {{#each this.items as |item index|}}
     <OSS::Chip @label={{item}} @onRemove={{fn this.removeItem index}} />
   {{/each}}
-  <Input @value={{this.currentValue}} @placeholder={{@placeholder}} {{on "keydown" this.keyListener}} autocomplete="off"
-         {{on "blur" this.validateTagOnClickOutside}} />
+  <Input @value={{this.currentValue}} @placeholder={{@placeholder}} autocomplete="off" 
+         {{on "keydown" this.keyListener}} {{on "blur" this.validateTagOnClickOutside}} />
 </div>

--- a/addon/components/o-s-s/power-select.hbs
+++ b/addon/components/o-s-s/power-select.hbs
@@ -2,14 +2,9 @@
      {{did-insert (fn this.ensureBlockPresence (has-block "selected-item") (has-block "option-item"))}}>
   <div class="upf-power-select__array-container margin-bottom-xxx-sm">
     <div class="array-input-container {{if @selectedItems 'fx-row fx-xalign-center' 'fx-col fx-malign-center'}}"
-      {{scroll-shadow color="field"}}>
+         {{scroll-shadow color="field"}}>
       {{#each @selectedItems as |selectedItem|}}
-        {{!-- <div class="input-array-tag fx-row fx-xalign-center">
-          {{yield selectedItem to="selected-item"}}
-          <i class="fa fa-remove margin-left-xxx-sm text-color-blue-gray" role="button"
-            {{on "click" (fn this.removeItem selectedItem)}}></i>
-        </div> --}}
-        <OSS::Chip @label={{selectedItem}} @onRemove={{fn this.removeItem selectedItem}} />
+        {{yield selectedItem to="selected-item"}}
       {{else}}
         <span class="padding-left-xx-sm text-size-5 text-color-default-light">
           {{this.placeholder}}

--- a/addon/components/o-s-s/power-select.hbs
+++ b/addon/components/o-s-s/power-select.hbs
@@ -4,12 +4,12 @@
     <div class="array-input-container {{if @selectedItems 'fx-row fx-xalign-center' 'fx-col fx-malign-center'}}"
       {{scroll-shadow color="field"}}>
       {{#each @selectedItems as |selectedItem|}}
-        <div class="input-array-tag fx-row fx-xalign-center">
+        {{!-- <div class="input-array-tag fx-row fx-xalign-center">
           {{yield selectedItem to="selected-item"}}
           <i class="fa fa-remove margin-left-xxx-sm text-color-blue-gray" role="button"
             {{on "click" (fn this.removeItem selectedItem)}}></i>
-        </div>
-        {{!-- <OSS::Chip @label="" @onRemove="" /> --}}
+        </div> --}}
+        <OSS::Chip @label={{selectedItem}} @onRemove={{fn this.removeItem selectedItem}} />
       {{else}}
         <span class="padding-left-xx-sm text-size-5 text-color-default-light">
           {{this.placeholder}}

--- a/addon/components/o-s-s/power-select.hbs
+++ b/addon/components/o-s-s/power-select.hbs
@@ -9,6 +9,7 @@
           <i class="fa fa-remove margin-left-xxx-sm text-color-blue-gray" role="button"
             {{on "click" (fn this.removeItem selectedItem)}}></i>
         </div>
+        {{!-- <OSS::Chip @label="" @onRemove="" /> --}}
       {{else}}
         <span class="padding-left-xx-sm text-size-5 text-color-default-light">
           {{this.placeholder}}

--- a/addon/components/o-s-s/power-select.ts
+++ b/addon/components/o-s-s/power-select.ts
@@ -7,12 +7,11 @@ type OperationType = 'selection' | 'deletion';
 interface OSSPowerSelectArgs {
   items: any[];
   selectedItems: any[];
-  onChange: (item: any, operation: OperationType) => void;
-
   loading?: boolean;
   loadingMore?: boolean;
   placeholder?: string;
   searchPlaceholder?: string;
+  onChange: (item: any, operation: OperationType) => void;
   onSearch?: (keyword: string) => void;
   onBottomReached?: () => void;
 }
@@ -26,11 +25,6 @@ export default class OSSPowerSelect extends Component<OSSPowerSelectArgs> {
   ensureBlockPresence(hasSelectedItem: boolean, hasOptionItem: boolean): void | never {
     assert(`[component][OSS::PowerSelect] You must pass selected-item named block`, hasSelectedItem);
     assert(`[component][OSS::PowerSelect] You must pass option-item named block`, hasOptionItem);
-  }
-
-  @action
-  removeItem(item: any): void {
-    this.args.onChange(item, 'deletion');
   }
 
   @action

--- a/app/styles/array-input.less
+++ b/app/styles/array-input.less
@@ -9,7 +9,6 @@
   flex-wrap: wrap;
   max-height: 90px;
   overflow-y: auto;
-  align-items: start;
 
   .input-array-tag:extend(.upf-tag) {
     height: 30px;

--- a/app/styles/array-input.less
+++ b/app/styles/array-input.less
@@ -10,15 +10,6 @@
   max-height: 90px;
   overflow-y: auto;
 
-  .input-array-tag:extend(.upf-tag) {
-    height: 30px;
-    line-height: 30px;
-    margin-left: 4px;
-    background-color: @upf-gray-light;
-    margin-top: 2px;
-    margin-bottom: 2px;
-  }
-
   input {
     height: 35px;
     background-color: transparent;

--- a/app/styles/atoms/chip.less
+++ b/app/styles/atoms/chip.less
@@ -7,6 +7,7 @@
   gap: var(--spacing-px-6);
   color: var(--color-white);
   box-shadow: var(--box-shadow-sm), var(--box-shadow-sm);
+  margin: var(--spacing-px-3);
 
   .chip-ellipsis {
     overflow: hidden;

--- a/tests/dummy/app/controllers/application.js
+++ b/tests/dummy/app/controllers/application.js
@@ -94,6 +94,16 @@ export default class ApplicationController extends Controller {
   }
 
   @action
+  onPowerSelectChange(item,operation) {
+    console.log('onCrossChipClick :', item, operation);
+  }
+
+  @action
+  onPowerSelectSearch(keyword) {
+    console.log('onCrossChipClick :', keyword);
+  }
+
+  @action
   onPhoneNumberChange(prefix, phoneNumber) {
     console.log('onPhoneNumberChange', prefix, phoneNumber);
     this.phonePrefix = prefix;

--- a/tests/dummy/app/controllers/application.js
+++ b/tests/dummy/app/controllers/application.js
@@ -95,12 +95,12 @@ export default class ApplicationController extends Controller {
 
   @action
   onPowerSelectChange(item,operation) {
-    console.log('onCrossChipClick :', item, operation);
+    console.log('onPowerSelectChange :', item, operation);
   }
 
   @action
   onPowerSelectSearch(keyword) {
-    console.log('onCrossChipClick :', keyword);
+    console.log('onPowerSelectSearch :', keyword);
   }
 
   @action

--- a/tests/dummy/app/controllers/application.js
+++ b/tests/dummy/app/controllers/application.js
@@ -94,7 +94,7 @@ export default class ApplicationController extends Controller {
   }
 
   @action
-  onPowerSelectChange(item,operation) {
+  onPowerSelectChange(item, operation) {
     console.log('onPowerSelectChange :', item, operation);
   }
 

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -1,5 +1,13 @@
 <div class="fx-row fx-gap-px-10 margin-md">
-  <OSS::PowerSelect @item={{this.superHeroes}} @selectedItem={{this.superHeroes}} @onChange={{this.onPowerSelectChange}} @onSearch={{this.onPowerSelectSearch}} />
+  <OSS::PowerSelect @item={{this.superHeroes}} @selectedItem={{this.superHeroes}} @onChange={{this.onPowerSelectChange}}
+                    @onSearch={{this.onPowerSelectSearch}}>
+    <:selected-item as |selectedItem|>
+      {{selectedItem}}
+    </:selected-item>
+    <:option-item as |item|>
+      {{item}}
+    </:option-item>
+  </OSS::PowerSelect>
 </div>
 
 <div class="fx-row fx-gap-px-10 margin-md">
@@ -9,9 +17,12 @@
   <OSS::Chip @skin="success" @label="Chip" @onRemove={{this.onCrossChipClick}} />
   <OSS::Chip @skin="danger" @label="Chip" @onRemove={{this.onCrossChipClick}} />
   <OSS::Chip @skin="danger" @label="Chip" @disabled={{true}} @onRemove={{this.onCrossChipClick}} />
-  <OSS::Chip @skin="success" @label="Chip with a huge label" @disabled={{false}} @maxDisplayWidth={{100}} @onRemove={{this.onCrossChipClick}} />
-  <OSS::Chip @skin="danger" @label="Chip with a huge label" @disabled={{false}} @maxDisplayWidth={{160}} @onRemove={{this.onCrossChipClick}} />
-  <OSS::ChipNFish @skin="danger" @label="Chip with a huge label" @disabled={{true}} @onRemove={{this.onCrossChipClick}} @maxDisplayWidth={{50}} />
+  <OSS::Chip @skin="success" @label="Chip with a huge label" @disabled={{false}} @maxDisplayWidth={{100}}
+             @onRemove={{this.onCrossChipClick}} />
+  <OSS::Chip @skin="danger" @label="Chip with a huge label" @disabled={{false}} @maxDisplayWidth={{160}}
+             @onRemove={{this.onCrossChipClick}} />
+  <OSS::ChipNFish @skin="danger" @label="Chip with a huge label" @disabled={{true}} @onRemove={{this.onCrossChipClick}}
+                  @maxDisplayWidth={{50}} />
 </div>
 
 <div class="fx-row fx-gap-px-10 margin-md">
@@ -40,13 +51,15 @@
       </:option>
     </OSS::Select>
 
-    <OSS::Select @value={{this.selectedItem}} @items={{this.items}} @onChange={{this.onSelect}} @errorMessage="This is an error">
+    <OSS::Select @value={{this.selectedItem}} @items={{this.items}} @onChange={{this.onSelect}}
+                 @errorMessage="This is an error">
       <:option as |item|>
         {{item.name}}
       </:option>
     </OSS::Select>
 
-    <OSS::Select @value={{this.selectedItem}} @items={{this.items}} @onChange={{this.onSelect}} @successMessage="It works">
+    <OSS::Select @value={{this.selectedItem}} @items={{this.items}} @onChange={{this.onSelect}}
+                 @successMessage="It works">
       <:option as |item|>
         {{item.name}}
       </:option>
@@ -66,17 +79,17 @@
                       @onChange={{this.onCurrencyInputChange}} />
 </div>
 <div class="fx-row fx-1 margin-md">
-  <OSS::CurrencyInput @currency={{this.currency}} @value={{this.currencyValue}}
-                      @onChange={{this.onCurrencyInputChange}} @onlyCurrency={{true}} />
+  <OSS::CurrencyInput @currency={{this.currency}} @value={{this.currencyValue}} @onChange={{this.onCurrencyInputChange}}
+                      @onlyCurrency={{true}} />
 </div>
 <div class="fx-row fx-1 margin-md">
   <div class="fx-col">
-    <OSS::CurrencyInput @currency={{this.currencyOnly}} @onChange={{this.onCurrencyOnlyChange}} @onlyCurrency={{true}} />
+    <OSS::CurrencyInput @currency={{this.currencyOnly}} @onChange={{this.onCurrencyOnlyChange}}
+                        @onlyCurrency={{true}} />
   </div>
 </div>
 <div class="fx-row fx-1 margin-md">
-  <OSS::ArrayInput @values={{this.superHeroes}}
-                   @onChange={{this.updateSuperHeroes}} class="fx-1"
+  <OSS::ArrayInput @values={{this.superHeroes}} @onChange={{this.updateSuperHeroes}} class="fx-1"
                    data-control-name="mailing-edit-template-ccs-input" />
 </div>
 <div class="fx-row fx-gap-px-12 margin-md">
@@ -109,12 +122,11 @@
   <OSS::Button @label="Error" @size="md" {{on "click" (fn this.triggerToast "error")}} />
 </div>
 <div class="fx-col fx-gap-px-12 margin-md">
-  <OSS::CodeBlock @content={{this.code4CodeBlock}} @scrollable={{true}} @copyable={{true}}
-                  @collapseHeight={{200}} @onCopyMessage="Copied to clipboard!" />
+  <OSS::CodeBlock @content={{this.code4CodeBlock}} @scrollable={{true}} @copyable={{true}} @collapseHeight={{200}}
+                  @onCopyMessage="Copied to clipboard!" />
 </div>
 <div class="fx-col fx-gap-px-12 margin-md">
-  <OSS::Button @skin="primary" @size="md" @label="Open MODAL" @icon="fa fa-unicorn"
-               {{on "click" this.openModal}} />
+  <OSS::Button @skin="primary" @size="md" @label="Open MODAL" @icon="fa fa-unicorn" {{on "click" this.openModal}} />
   {{#if this.showModal}}
     <OSS::ModalDialog @title="Example modal" @subtitle="subtitle" @close={{this.closeModal}} @size="md">
       <:content>

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -1,8 +1,8 @@
 <div class="fx-row fx-gap-px-10 margin-md">
-  <OSS::PowerSelect @items={{this.superHeroes}} @selectedItems={{this.superHeroes}} @onChange={{this.onPowerSelectChange}}
-                    @onSearch={{this.onPowerSelectSearch}}>
-    <:selected-item as |selectedItem|>
-      {{selectedItem}}
+  <OSS::PowerSelect @items={{this.superHeroes}} @selectedItems={{this.superHeroes}}
+                    @onChange={{this.onPowerSelectChange}} @onSearch={{this.onPowerSelectSearch}}>
+    <:selected-item as |selectedProduct|>
+      <OSS::Chip @label={{selectedProduct}} @onRemove={{fn this.onPowerSelectChange }} @maxDisplayWidth={{100}} />
     </:selected-item>
     <:option-item as |item|>
       {{item}}

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -1,4 +1,8 @@
 <div class="fx-row fx-gap-px-10 margin-md">
+  <OSS::PowerSelect @item={{this.superHeroes}} @selectedItem={{this.superHeroes}} @onChange={{this.onPowerSelectChange}} @onSearch={{this.onPowerSelectSearch}} />
+</div>
+
+<div class="fx-row fx-gap-px-10 margin-md">
   <OSS::Chip @label="Chip" @onRemove={{this.onCrossChipClick}} />
   <OSS::Chip @skin="default" @label="Chip" @onRemove={{this.onCrossChipClick}} />
   <OSS::Chip @skin="primary" @label="Chip" @onRemove={{this.onCrossChipClick}} />

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -1,5 +1,5 @@
 <div class="fx-row fx-gap-px-10 margin-md">
-  <OSS::PowerSelect @item={{this.superHeroes}} @selectedItem={{this.superHeroes}} @onChange={{this.onPowerSelectChange}}
+  <OSS::PowerSelect @items={{this.superHeroes}} @selectedItems={{this.superHeroes}} @onChange={{this.onPowerSelectChange}}
                     @onSearch={{this.onPowerSelectSearch}}>
     <:selected-item as |selectedItem|>
       {{selectedItem}}

--- a/tests/integration/components/o-s-s/array-input-test.js
+++ b/tests/integration/components/o-s-s/array-input-test.js
@@ -120,7 +120,6 @@ module('Integration | Component | OSS::ArrayInput', function (hooks) {
     this.loadedValues = ['value1', 'value2'];
     await render(hbs`<OSS::ArrayInput @values={{this.loadedValues}} />`);
     let domTagsRemove = findAll('.upf-chip');
-    console.log(domTagsRemove);
     assert.equal(domTagsRemove.length, 2);
     await click('.upf-chip i');
     domTagsRemove = findAll('.upf-chip');

--- a/tests/integration/components/o-s-s/array-input-test.js
+++ b/tests/integration/components/o-s-s/array-input-test.js
@@ -26,8 +26,8 @@ module('Integration | Component | OSS::ArrayInput', function (hooks) {
     });
 
     test('Passing @values parameter displays the items', async function (assert) {
-      await render(hbs`<OSS::ArrayInput @values={{this.loadedValues}}/>`);
-      const domTags = await findAll('.input-array-tag');
+      await render(hbs`<OSS::ArrayInput @values={{this.loadedValues}} />`);
+      const domTags = await findAll('.upf-chip');
       assert.dom(domTags[0]).hasText('value1');
       assert.dom(domTags[1]).hasText('value2');
     });
@@ -39,22 +39,22 @@ module('Integration | Component | OSS::ArrayInput', function (hooks) {
     });
 
     test('it is triggered on keyword addition', async function (assert) {
-      await render(hbs`<OSS::ArrayInput @onChange={{this.onChange}}/>`);
+      await render(hbs`<OSS::ArrayInput @onChange={{this.onChange}} />`);
       await fillInputAndValidate();
       assert.ok(onChange.calledWith(['keyword']));
     });
 
     test('it is triggered on keyword deletion', async function (assert) {
-      await render(hbs`<OSS::ArrayInput @onChange={{this.onChange}}/>`);
+      await render(hbs`<OSS::ArrayInput @onChange={{this.onChange}} />`);
       await fillInputAndValidate();
       assert.ok(onChange.calledWith(['keyword']));
-      await click('.input-array-tag .fa-remove');
-      assert.dom('.input-array-tag').doesNotExist();
+      await click('.upf-chip i');
+      assert.dom('.upf-chip').doesNotExist();
       assert.ok(onChange.calledWith([]));
     });
 
     test('it is triggered on keyword edition', async function (assert) {
-      await render(hbs`<OSS::ArrayInput @onChange={{this.onChange}}/>`);
+      await render(hbs`<OSS::ArrayInput @onChange={{this.onChange}} />`);
       await fillInputAndValidate();
       assert.ok(onChange.calledWith(['keyword']));
       await triggerKeyEvent('.array-input-container input', 'keydown', 'Backspace', { code: 'Backspace' });
@@ -69,27 +69,28 @@ module('Integration | Component | OSS::ArrayInput', function (hooks) {
     });
 
     test('it is triggered on keyword addition', async function (assert) {
-      await render(hbs`<OSS::ArrayInput @validator={{this.validator}}/>`);
+      await render(hbs`<OSS::ArrayInput @validator={{this.validator}} />`);
       await fillInputAndValidate('hashtag');
       assert.ok(validator.calledWith('hashtag'));
     });
 
     test('WHEN the validator is truthy, the value is added as a tag', async function (assert) {
       validator.returns(true);
-      await render(hbs`<OSS::ArrayInput @validator={{this.validator}}/>`);
+      await render(hbs`<OSS::ArrayInput @validator={{this.validator}} />`);
       await fillInputAndValidate('hashtag');
       assert.ok(validator.calledWith('hashtag'));
       assert.ok(validator.returned(true));
-      assert.dom('.input-array-tag').hasText('hashtag');
+      assert.dom('.upf-chip').exists();
+      assert.dom('.array-input-container').hasText('hashtag');
     });
 
     test('WHEN the validator is falsy, the value is not added', async function (assert) {
       validator.returns(false);
-      await render(hbs`<OSS::ArrayInput @validator={{this.validator}}/>`);
+      await render(hbs`<OSS::ArrayInput @validator={{this.validator}} />`);
       await fillInputAndValidate('hashtag');
       assert.ok(validator.calledWith('hashtag'));
       assert.ok(validator.returned(false));
-      assert.dom('.input-array-tag').doesNotExist();
+      assert.dom('.upf-chip').doesNotExist();
     });
   });
 
@@ -104,12 +105,12 @@ module('Integration | Component | OSS::ArrayInput', function (hooks) {
 
     test('If there are tags, the last one is removed and is passed to edit mode', async function (assert) {
       this.loadedValues = ['value1', 'value2'];
-      await render(hbs`<OSS::ArrayInput @values={{this.loadedValues}}/>`);
-      let domTags = findAll('.input-array-tag');
+      await render(hbs`<OSS::ArrayInput @values={{this.loadedValues}} />`);
+      let domTags = findAll('.upf-chip');
       assert.equal(domTags.length, 2);
       assert.dom(domTags[1]).hasText('value2');
       await triggerKeyEvent('.array-input-container input', 'keydown', 'Backspace', { code: 'Backspace' });
-      domTags = findAll('.input-array-tag');
+      domTags = findAll('.upf-chip');
       assert.equal(domTags.length, 1);
       assert.dom('.array-input-container input').hasValue('value2');
     });
@@ -117,12 +118,13 @@ module('Integration | Component | OSS::ArrayInput', function (hooks) {
 
   test('Clicking on the remove icon suppresses the target entry', async function (assert) {
     this.loadedValues = ['value1', 'value2'];
-    await render(hbs`<OSS::ArrayInput @values={{this.loadedValues}}/>`);
-    let domTagsRemove = findAll('.input-array-tag .fa-remove');
+    await render(hbs`<OSS::ArrayInput @values={{this.loadedValues}} />`);
+    let domTagsRemove = findAll('.upf-chip');
+    console.log(domTagsRemove);
     assert.equal(domTagsRemove.length, 2);
-    await click('.input-array-tag .fa-remove');
-    domTagsRemove = findAll('.input-array-tag .fa-remove');
+    await click('.upf-chip i');
+    domTagsRemove = findAll('.upf-chip');
     assert.equal(domTagsRemove.length, 1);
-    assert.dom('.input-array-tag').hasText('value2');
+    assert.dom('.upf-chip').hasText('value2');
   });
 });

--- a/tests/integration/components/o-s-s/array-input-test.js
+++ b/tests/integration/components/o-s-s/array-input-test.js
@@ -81,7 +81,7 @@ module('Integration | Component | OSS::ArrayInput', function (hooks) {
       assert.ok(validator.calledWith('hashtag'));
       assert.ok(validator.returned(true));
       assert.dom('.upf-chip').exists();
-      assert.dom('.array-input-container').hasText('hashtag');
+      assert.dom('.upf-chip').hasText('hashtag');
     });
 
     test('WHEN the validator is falsy, the value is not added', async function (assert) {

--- a/tests/integration/components/o-s-s/array-input-test.js
+++ b/tests/integration/components/o-s-s/array-input-test.js
@@ -58,7 +58,7 @@ module('Integration | Component | OSS::ArrayInput', function (hooks) {
       await fillInputAndValidate();
       assert.ok(onChange.calledWith(['keyword']));
       await triggerKeyEvent('.array-input-container input', 'keydown', 'Backspace', { code: 'Backspace' });
-      assert.dom('.input-array-tag').doesNotExist();
+      assert.dom('.upf-chip').doesNotExist();
       assert.ok(onChange.calledWith([]));
     });
   });
@@ -98,7 +98,7 @@ module('Integration | Component | OSS::ArrayInput', function (hooks) {
     test('If there are no tags, nothing happens', async function (assert) {
       await render(hbs`<OSS::ArrayInput />`);
       await triggerKeyEvent('.array-input-container input', 'keydown', 'Backspace', { code: 'Backspace' });
-      assert.dom('.input-array-tag').doesNotExist();
+      assert.dom('.upf-chip').doesNotExist();
       assert.dom('.array-input-container').exists();
       assert.dom('.array-input-container input').exists();
     });

--- a/tests/integration/components/o-s-s/power-select-test.ts
+++ b/tests/integration/components/o-s-s/power-select-test.ts
@@ -52,9 +52,9 @@ module('Integration | Component | o-s-s/power-select', function (hooks) {
       });
 
       await render(hbs`
-        <OSS::PowerSelect @onSearch={{this.onSearch}}>
+        <OSS::PowerSelect @selectedItems={{this.selectedItems}} @onSearch={{this.onSearch}}>
           <:selected-item as |selectedItem|>
-            {{selectedItem.name}}
+            {{selectedItem}}
           </:selected-item>
         </OSS::PowerSelect>
       `);
@@ -77,9 +77,7 @@ module('Integration | Component | o-s-s/power-select', function (hooks) {
         </OSS::PowerSelect>
       `);
 
-      const domTags = findAll('.input-array-tag');
-      assert.dom(domTags[0]).hasText('value1');
-      assert.dom(domTags[1]).hasText('value2');
+      assert.dom('.array-input-container').hasText('value1 value2');
     });
 
     test('Passing empty @selectedItems parameter displays nothing', async function (assert) {
@@ -144,24 +142,6 @@ module('Integration | Component | o-s-s/power-select', function (hooks) {
       this.selectedItems = ['value1', 'value2'];
       this.items = ['value1', 'value2'];
       this.onChange = onChange;
-    });
-
-    test('deleting selected item triggers onChange with delete operation', async function (assert) {
-      await render(hbs`
-        <OSS::PowerSelect @selectedItems={{this.selectedItems}} @items={{this.items}}
-                          @onSearch={{this.onSearch}} @onChange={{this.onChange}}>
-          <:selected-item as |selectedItem|>
-            {{selectedItem}}
-          </:selected-item>
-          <:option-item as |item|>
-            {{item}}
-          </:option-item>
-        </OSS::PowerSelect>
-      `);
-
-      await click('.input-array-tag:nth-child(2) i');
-
-      assert.ok(this.onChange.calledWith('value2', 'deletion'));
     });
 
     test('selecting item triggers onChange with selection operation', async function (assert) {

--- a/tests/integration/components/o-s-s/power-select-test.ts
+++ b/tests/integration/components/o-s-s/power-select-test.ts
@@ -69,7 +69,7 @@ module('Integration | Component | o-s-s/power-select', function (hooks) {
         <OSS::PowerSelect @selectedItems={{this.selectedItems}} @items={{this.items}}
                           @onSearch={{this.onSearch}}>
           <:selected-item as |selectedItem|>
-            {{selectedItem}}
+            <span>{{selectedItem}}</span>
           </:selected-item>
           <:option-item as |item|>
             {{item}}
@@ -77,7 +77,9 @@ module('Integration | Component | o-s-s/power-select', function (hooks) {
         </OSS::PowerSelect>
       `);
 
-      assert.dom('.array-input-container').hasText('value1 value2');
+      const domTags = findAll('.array-input-container span');
+      assert.dom(domTags[0]).hasText('value1');
+      assert.dom(domTags[1]).hasText('value2');
     });
 
     test('Passing empty @selectedItems parameter displays nothing', async function (assert) {
@@ -85,7 +87,7 @@ module('Integration | Component | o-s-s/power-select', function (hooks) {
         <OSS::PowerSelect @selectedItems={{this.selectedItems}} @items={{this.items}}
                           @onSearch={{this.onSearch}}>
           <:selected-item as |selectedItem|>
-            {{selectedItem}}
+            <span id="selectedItemTest">{{selectedItem}}</span>
           </:selected-item>
           <:option-item as |item|>
             {{item}}
@@ -93,7 +95,7 @@ module('Integration | Component | o-s-s/power-select', function (hooks) {
         </OSS::PowerSelect>
       `);
 
-      assert.dom('.upf-chip').doesNotExist();
+      assert.dom('.array-input-container #selectedItemTest').doesNotExist();
     });
 
     test('Passing empty @selectedItems and @placeholder parameters displays placeholder', async function (assert) {

--- a/tests/integration/components/o-s-s/power-select-test.ts
+++ b/tests/integration/components/o-s-s/power-select-test.ts
@@ -54,7 +54,7 @@ module('Integration | Component | o-s-s/power-select', function (hooks) {
       await render(hbs`
         <OSS::PowerSelect @selectedItems={{this.selectedItems}} @onSearch={{this.onSearch}}>
           <:selected-item as |selectedItem|>
-            {{selectedItem}}
+            {{selectedItem.name}}
           </:selected-item>
         </OSS::PowerSelect>
       `);
@@ -93,7 +93,7 @@ module('Integration | Component | o-s-s/power-select', function (hooks) {
         </OSS::PowerSelect>
       `);
 
-      assert.dom('.input-array-tag').doesNotExist();
+      assert.dom('.upf-chip').doesNotExist();
     });
 
     test('Passing empty @selectedItems and @placeholder parameters displays placeholder', async function (assert) {

--- a/tests/integration/components/o-s-s/power-select-test.ts
+++ b/tests/integration/components/o-s-s/power-select-test.ts
@@ -52,7 +52,7 @@ module('Integration | Component | o-s-s/power-select', function (hooks) {
       });
 
       await render(hbs`
-        <OSS::PowerSelect @selectedItems={{this.selectedItems}} @onSearch={{this.onSearch}}>
+        <OSS::PowerSelect @onSearch={{this.onSearch}}>
           <:selected-item as |selectedItem|>
             {{selectedItem.name}}
           </:selected-item>


### PR DESCRIPTION
### What does this PR do?

Replace code in OSS::PowerSelect and OSS::ArrayInput for use OSS::Chip when you display the items

Related to: https://github.com/upfluence/backlog/issues/1706
### What are the observable changes?

We use OSS::Chip Component in selected-item name block of OSS::PowerSelect so OSS::PowerSelect didn't need the onChange(item, 'deletion') function anymore

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [x] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled
