### PR TITLE
Phone input validation

### DIFF
--- a/addon/components/o-s-s/phone-number-input.hbs
+++ b/addon/components/o-s-s/phone-number-input.hbs
@@ -9,8 +9,8 @@
       {{/if}}
     </div>
     <span class="phone-prefix">{{@prefix}}</span>
-    <Input class="fx-1" type="tel" @value={{@number}} {{on "keydown" this.onlyNumeric}}
-           placeholder="81726354" />
+    <Input class="fx-1" type="tel" @value={{@number}} placeholder="81726354"
+           {{on "keydown" this.onlyNumeric}} {{on "blur" this.onlyNumeric}} />
   </div>
 
   {{#if this.invalidInputError}}

--- a/addon/components/o-s-s/phone-number-input.hbs
+++ b/addon/components/o-s-s/phone-number-input.hbs
@@ -10,8 +10,15 @@
     </div>
     <span class="phone-prefix">{{@prefix}}</span>
     <Input class="fx-1" type="tel" @value={{@number}} {{on "keydown" this.onlyNumeric}}
-           placeholder="81726354" autocomplete="off" />
+           placeholder="81726354" />
   </div>
+
+  {{#if this.invalidInputError}}
+    <div class="font-color-error-500 margin-top-px-6">
+      {{this.invalidInputError}}
+    </div>
+  {{/if}}
+
   {{#if this.countrySelectorShown}}
     <OSS::InfiniteSelect @items={{this.filteredCountries}} @onSearch={{this.onSearch}}
                          @onSelect={{this.onSelect}}

--- a/addon/components/o-s-s/phone-number-input.ts
+++ b/addon/components/o-s-s/phone-number-input.ts
@@ -46,9 +46,9 @@ export default class OSSPhoneNumberInput extends Component<OSSPhoneNumberInputAr
   }
 
   @action
-  onlyNumeric(event: KeyboardEvent): void {
+  onlyNumeric(event: KeyboardEvent | FocusEvent): void {
     const authorizedInputs = ['Backspace', 'Delete', 'ArrowLeft', 'ArrowRight', 'Tab', 'Shift', 'Control'];
-    if (/^[0-9]$/i.test(event.key) || authorizedInputs.find((key: string) => key === event.key)) {
+    if (event instanceof FocusEvent || /^[0-9]$/i.test(event.key) || authorizedInputs.find((key: string) => key === event.key)) {
       this.args.onChange('+' + this.selectedCountry.countryCallingCodes[0], this.args.number);
     } else {
       event.preventDefault();

--- a/addon/components/o-s-s/phone-number-input.ts
+++ b/addon/components/o-s-s/phone-number-input.ts
@@ -64,10 +64,9 @@ export default class OSSPhoneNumberInput extends Component<OSSPhoneNumberInputAr
 
   @action
   onlyNumeric(event: KeyboardEvent | FocusEvent): void {
-    const authorizedInputs = ['Backspace', 'Delete', 'ArrowLeft', 'ArrowRight', 'Tab', 'Shift', 'Control', 'Keydown'];
+    const authorizedInputs = ['Backspace', 'Delete', 'ArrowLeft', 'ArrowRight', 'Tab', 'Shift'];
 
     if (
-      event.type === 'keydown' ||
       event instanceof FocusEvent ||
       /^[0-9]$/i.test(event.key) ||
       authorizedInputs.find((key: string) => key === event.key)

--- a/tests/integration/components/o-s-s/phone-number-input-test.ts
+++ b/tests/integration/components/o-s-s/phone-number-input-test.ts
@@ -131,5 +131,25 @@ module('Integration | Component | o-s-s/phone-number', function (hooks) {
       await triggerKeyEvent('input', 'keydown', 'A', { code: 'a' });
       assert.dom('input').hasValue('8');
     });
+
+    test('it displays an error if the number contains a + symbol', async function (assert) {
+      this.prefix = '+1';
+      this.number = '';
+
+      this.onChange = (prefix: string, number: number) => {
+        this.set('prefix', prefix);
+        this.set('number', number);
+      };
+      this.onValidation = sinon.spy();
+
+      await render(
+        hbs`<OSS::PhoneNumberInput @prefix={{this.prefix}} @number={{this.number}} @onChange={{this.onChange}} @validates={{this.onValidation}} />`
+      );
+      await typeIn('input', '+1');
+      await settled();
+
+      assert.ok(this.onValidation.calledWithExactly(false));
+      assert.dom('.font-color-error-500').exists();
+    });
   });
 });

--- a/tests/integration/components/o-s-s/phone-number-input-test.ts
+++ b/tests/integration/components/o-s-s/phone-number-input-test.ts
@@ -116,19 +116,27 @@ module('Integration | Component | o-s-s/phone-number', function (hooks) {
   module('Phone Number Input', () => {
     test('Typing numbers in the Phone input triggers the onChange method', async function (assert) {
       this.onChange = sinon.spy();
-      await render(hbs`<OSS::PhoneNumberInput @prefix="" @number="" @onChange={{this.onChange}} />`);
+      this.onValidation = sinon.spy();
+      await render(
+        hbs`<OSS::PhoneNumberInput @prefix="" @number="" @onChange={{this.onChange}} @validates={{this.onValidation}} />`
+      );
       await typeIn('input', '8');
       assert.ok(this.onChange.calledOnce);
+      assert.ok(this.onValidation.calledWithExactly(true));
       assert.dom('input').hasValue('8');
     });
 
     test('Typing non-numeric characters does not apply changes', async function (assert) {
       this.onChange = sinon.spy();
-      await render(hbs`<OSS::PhoneNumberInput @prefix="" @number="" @onChange={{this.onChange}} />`);
+      this.onValidation = sinon.spy();
+      await render(
+        hbs`<OSS::PhoneNumberInput @prefix="" @number="" @onChange={{this.onChange}} @validates={{this.onValidation}} />`
+      );
       await typeIn('input', '8');
       assert.ok(this.onChange.calledOnce);
       // @ts-ignore
       await triggerKeyEvent('input', 'keydown', 'A', { code: 'a' });
+      assert.ok(this.onValidation.calledWithExactly(true));
       assert.dom('input').hasValue('8');
     });
 

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -12,7 +12,7 @@ oss-components:
   password-input:
     regex_error: 'Your password should have at least 8 characters with at least one lower-case character, one upper-case character and one digit.'
   phone-input:
-    invalid_input: 'Please select your country from the selector'
+    invalid_input: Please select your country from the selector
   email-input:
     regex_error: Please enter a valid email address.
   button:

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -11,6 +11,8 @@ oss-components:
     empty_img_alt: Empty content
   password-input:
     regex_error: 'Your password should have at least 8 characters with at least one lower-case character, one upper-case character and one digit.'
+  phone-input:
+    invalid_input: 'Please select your country from the selector'
   email-input:
     regex_error: Please enter a valid email address.
   button:


### PR DESCRIPTION
### What does this PR do?

Allow the focus input (triggered when using autocompletion) to be handled, but add a validation to ensure that the user didn't type the country prefix in the phone numbeR.

### What are the observable changes?
<!-- This question could be adequate with multiple use cases, for example: -->

<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled

### Additional Notes

<!--
    You can add anything you want here, an explanation on the way you built your implementation,
    precisions on the origin of the bug, gotchas you need to mention.
 -->
