### PR TITLE
Add helper for running URL redirections

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -3,7 +3,7 @@ const path = require('path');
 const root = path.join(__dirname, '../');
 const node_modules = path.join(root, 'node_modules');
 const namedBlockPolyfill = require('ember-named-blocks-polyfill/lib/named-blocks-polyfill-plugin');
-d.
+
 module.exports = {
   stories: [
     '../stories/**/*.stories.mdx',

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -3,7 +3,7 @@ const path = require('path');
 const root = path.join(__dirname, '../');
 const node_modules = path.join(root, 'node_modules');
 const namedBlockPolyfill = require('ember-named-blocks-polyfill/lib/named-blocks-polyfill-plugin');
-
+d.
 module.exports = {
   stories: [
     '../stories/**/*.stories.mdx',
@@ -12,6 +12,8 @@ module.exports = {
     '../addon/components/**/*.stories.@(js|jsx|ts|tsx)',
     '../addon/modifiers/**/*.stories.mdx',
     '../addon/modifiers/**/*.stories.@(js|jsx|ts|tsx)',
+    '../addon/helpers/**/*.stories.mdx',
+    '../addon/helpers/**/*.stories.@(js|jsx|ts|tsx)',
     '../app/styles/**/*.stories.mdx'
   ],
 

--- a/addon/helpers/Helpers.stories.mdx
+++ b/addon/helpers/Helpers.stories.mdx
@@ -1,0 +1,61 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+
+<Meta
+  title="Helpers & Modifiers/Helpers"
+  parameters={{
+    viewMode: 'docs',
+    previewTabs: { canvas: { hidden: true } }
+  }}
+/>
+
+# Helpers
+
+## transition-to
+
+Transition to a valid Ember JS router
+
+Args:
+
+- route: the route to transition to as it would be passed to `RouterService#transitionTo`
+- model (optional): a model to pass the route
+- models (optional): an array of models to pass the route
+- queryParams (optional): a query params object
+
+Usage:
+
+```handlebars
+With route only
+<OSS::Button @label='Button that transitions' {{on 'click' (transition-to route='my-route')}} />
+
+<OSS::Button @label='Button that transitions' {{on 'click' (transition-to route='my-route' model={{this.model}})}} />
+
+<OSS::Button
+  @label='Button that transitions'
+  {{on 'click' (transition-to route='my-route' models={{array this.firstModel this.secondModel}})}} />
+
+<OSS::Button
+  @label='Button that transitions'
+  {{on 'click' (transition-to route='my-route' queryParams={{hash search="keyword"}})}} />
+```
+
+## redirect-to
+
+Redirect to any URL just like `window.open` would.
+
+Args:
+
+- url: the URL to redirect
+- target: a valid redirection target as specified in https://www.w3schools.com/tags/att_a_target.asp
+
+Usage:
+
+```handlebars
+With route only
+<OSS::Button
+  @label='Button that opens link on current tab'
+  {{on 'click' (redirect-to url='https://github.com/upfluence/oss-components')}} />
+
+<OSS::Button
+  @label='Button that opens link on target'
+  {{on 'click' (redirect-to url='https://github.com/upfluence/oss-components' target="_blank")}} />
+```

--- a/addon/helpers/redirect-to.ts
+++ b/addon/helpers/redirect-to.ts
@@ -1,0 +1,25 @@
+import Helper from '@ember/component/helper';
+import { assert } from '@ember/debug';
+
+type RedirectToHelperArgs = {
+  url: string;
+  target?: string;
+};
+
+const REDIRECTION_TARGETS: string[] = ['_blank', '_self', '_parent', '_top', 'framename'];
+
+export default class extends Helper {
+  compute(_: any[], named: RedirectToHelperArgs) {
+    const { url, target } = named;
+
+    assert('[helper][OSS::redirect-to] url argument is mandatory.', typeof url === 'string');
+    assert(
+      '[helper][OSS::redirect-to] the target argument must be a valid one: https://www.w3schools.com/tags/att_a_target.asp.',
+      target ? REDIRECTION_TARGETS.includes(target) : true
+    );
+
+    return () => {
+      window.open(url, target ?? '_self');
+    };
+  }
+}

--- a/app/helpers/redirect-to.js
+++ b/app/helpers/redirect-to.js
@@ -1,0 +1,1 @@
+export { default, redirectTo } from '@upfluence/oss-components/helpers/redirect-to';

--- a/tests/integration/components/o-s-s/link-test.ts
+++ b/tests/integration/components/o-s-s/link-test.ts
@@ -48,6 +48,7 @@ module('Integration | Component | o-s-s/link', function (hooks) {
 
     await click('.upf-link');
     assert.true(windowOpenStub.calledOnceWithExactly('https://www.google.fr', '_blank'));
+    sinon.restore();
   });
 
   test('it transits to the route', async function (assert: Assert) {

--- a/tests/integration/helpers/redirect-to-test.ts
+++ b/tests/integration/helpers/redirect-to-test.ts
@@ -12,10 +12,6 @@ module('Integration | Helper | redirect-to', function (hooks) {
     this.url = 'https://github.com/upfluence/oss-components';
   });
 
-  hooks.afterEach(function () {
-    sinon.restore();
-  });
-
   module('mandatory arguments checks', function () {
     test('it throws an error if the url argument is missing', async function (assert) {
       setupOnerror((err: Error) => {
@@ -41,11 +37,13 @@ module('Integration | Helper | redirect-to', function (hooks) {
     await render(hbs`<div {{on "click" (redirect-to url=this.url)}}>link</div>`);
     await click('div');
     assert.ok(this.redirectStub.calledOnceWithExactly(this.url, '_self'));
+    sinon.restore();
   });
 
   test('it redirects to the url on the provided target', async function (assert) {
     await render(hbs`<div {{on "click" (redirect-to url=this.url target="_blank")}}>link</div>`);
     await click('div');
     assert.ok(this.redirectStub.calledOnceWithExactly(this.url, '_blank'));
+    sinon.restore();
   });
 });

--- a/tests/integration/helpers/redirect-to-test.ts
+++ b/tests/integration/helpers/redirect-to-test.ts
@@ -8,7 +8,6 @@ module('Integration | Helper | redirect-to', function (hooks) {
   setupRenderingTest(hooks);
 
   hooks.beforeEach(function () {
-    this.redirectStub = sinon.stub(window, 'open');
     this.url = 'https://github.com/upfluence/oss-components';
   });
 
@@ -34,6 +33,7 @@ module('Integration | Helper | redirect-to', function (hooks) {
   });
 
   test('it redirects to the url on the current tab if not target is passed', async function (assert) {
+    this.redirectStub = sinon.stub(window, 'open');
     await render(hbs`<div {{on "click" (redirect-to url=this.url)}}>link</div>`);
     await click('div');
     assert.ok(this.redirectStub.calledOnceWithExactly(this.url, '_self'));
@@ -41,6 +41,7 @@ module('Integration | Helper | redirect-to', function (hooks) {
   });
 
   test('it redirects to the url on the provided target', async function (assert) {
+    this.redirectStub = sinon.stub(window, 'open');
     await render(hbs`<div {{on "click" (redirect-to url=this.url target="_blank")}}>link</div>`);
     await click('div');
     assert.ok(this.redirectStub.calledOnceWithExactly(this.url, '_blank'));

--- a/tests/integration/helpers/redirect-to-test.ts
+++ b/tests/integration/helpers/redirect-to-test.ts
@@ -1,0 +1,51 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { click, render, setupOnerror } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import sinon from 'sinon';
+
+module('Integration | Helper | redirect-to', function (hooks) {
+  setupRenderingTest(hooks);
+
+  hooks.beforeEach(function () {
+    this.redirectStub = sinon.stub(window, 'open');
+    this.url = 'https://github.com/upfluence/oss-components';
+  });
+
+  hooks.afterEach(function () {
+    sinon.restore();
+  });
+
+  module('mandatory arguments checks', function () {
+    test('it throws an error if the url argument is missing', async function (assert) {
+      setupOnerror((err: Error) => {
+        assert.equal(err.message, 'Assertion Failed: [helper][OSS::redirect-to] url argument is mandatory.');
+      });
+
+      await render(hbs`<div {{on "click" (redirect-to)}}>link</div>`);
+    });
+
+    test('it throws an error if the target is not a valid one', async function (assert) {
+      setupOnerror((err: Error) => {
+        assert.equal(
+          err.message,
+          'Assertion Failed: [helper][OSS::redirect-to] the target argument must be a valid one: https://www.w3schools.com/tags/att_a_target.asp.'
+        );
+      });
+
+      await render(hbs`<div {{on "click" (redirect-to url=this.url target="_foo")}}>link</div>`);
+    });
+  });
+
+  test('it redirects to the url on the current tab if not target is passed', async function (assert) {
+    await render(hbs`<div {{on "click" (redirect-to url=this.url)}}>link</div>`);
+    await click('div');
+    assert.ok(this.redirectStub.calledOnceWithExactly(this.url, '_self'));
+  });
+
+  test('it redirects to the url on the provided target', async function (assert) {
+    await render(hbs`<div {{on "click" (redirect-to url=this.url target="_blank")}}>link</div>`);
+    await click('div');
+    assert.ok(this.redirectStub.calledOnceWithExactly(this.url, '_blank'));
+  });
+});


### PR DESCRIPTION
### What does this PR do?

Add helper for running URL redirections just like a `window.open` would

### What are the observable changes?
<!-- This question could be adequate with multiple use cases, for example: -->

<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [x] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled

### Additional Notes

<!--
    You can add anything you want here, an explanation on the way you built your implementation,
    precisions on the origin of the bug, gotchas you need to mention.
 -->
