### PR TITLE
Align buttons & inputs to the same height: 36px

### DIFF
--- a/.storybook/styles/stories/variables.less
+++ b/.storybook/styles/stories/variables.less
@@ -12,10 +12,6 @@
   height: @input-size-sm
 }
 
-.input-size-x-sm {
-  height: @input-size-x-sm
-}
-
 .border-box {
   border-radius: @default-radius;
   border: 1px solid;

--- a/addon/components/expanding-search.hbs
+++ b/addon/components/expanding-search.hbs
@@ -3,6 +3,4 @@
   class="expanding-search__submit"
   {{action "expandOrErase" bubbles=false}} /> 
 
-{{input
-  type="text" class=(concat "form-control upf-input expanding-search__input" (if small ' upf-input--small'))
-  placeholder=placeholder value=searchQuery}}
+{{input type="text" class="form-control upf-input expanding-search__input" placeholder=this.placeholder value=this.searchQuery}}

--- a/addon/components/expanding-search.hbs
+++ b/addon/components/expanding-search.hbs
@@ -3,4 +3,6 @@
   class="expanding-search__submit"
   {{action "expandOrErase" bubbles=false}} /> 
 
-{{input type="text" class="form-control upf-input expanding-search__input" placeholder=this.placeholder value=this.searchQuery}}
+<Input
+  @type="text" @placeholder={{this.placeholder}} @value={{this.searchQuery}}
+  class="upf-input expanding-search__input" />

--- a/app/styles/array-input.less
+++ b/app/styles/array-input.less
@@ -4,7 +4,7 @@
   }
 
   height: auto;
-  min-height: 37px;
+  min-height: var(--spacing-px-36);
   padding: 0;
   flex-wrap: wrap;
   max-height: 90px;

--- a/app/styles/atoms/button.less
+++ b/app/styles/atoms/button.less
@@ -30,18 +30,18 @@
 
   &--xs,
   &--sm {
-    height: 24px;
-    width: 24px;
+    height: var(--spacing-px-24);
+    width: var(--spacing-px-24);
   }
 
   &--md {
-    height: 34px;
-    width: 34px;
+    height: var(--spacing-px-36);
+    width: var(--spacing-px-36);
   }
 
   &--lg {
-    height: 48px;
-    width: 48px;
+    height: var(--spacing-px-48);
+    width: var(--spacing-px-48);
     .text-size-7;
   }
 

--- a/app/styles/base/_buttons.less
+++ b/app/styles/base/_buttons.less
@@ -34,7 +34,7 @@
   display: inline-block;
 
   line-height: 1rem;
-  height: 37px;
+  height: var(--spacing-px-36);
   padding: @spacing-xxx-sm @spacing-x-sm;
 
   text-align: center;

--- a/app/styles/base/_buttons.less
+++ b/app/styles/base/_buttons.less
@@ -230,7 +230,7 @@
 }
 
 .upf-btn--medium, .upf-btn--md {
-  height: 34px;
+  height: var(--spacing-px-36);
 }
 
 .upf-btn--large, .upf-btn--lg {

--- a/app/styles/base/_datatables.less
+++ b/app/styles/base/_datatables.less
@@ -45,7 +45,7 @@
     font-size: 18/@rem;
 
     line-height: 1.4;
-    height: 34px;
+    height: var(--spacing-px-36);
     padding: @spacing-xxx-sm @spacing-xx-sm;
 
     text-align: center;

--- a/app/styles/base/_expanding-search.less
+++ b/app/styles/base/_expanding-search.less
@@ -2,12 +2,6 @@
   display: inline-flex;
 }
 
-.expanding-search--small {
-  .expanding-search__submit {
-    height: 34px;
-  }
-}
-
 .expanding-search__input {
   overflow: hidden;
   width: 0;
@@ -17,7 +11,7 @@
 
 .expanding-search__submit {
   margin-left: 0;
-  height: 37px;
+  height: var(--spacing-px-36);
 }
 
 .expanding-search,

--- a/app/styles/base/_inputs.less
+++ b/app/styles/base/_inputs.less
@@ -20,7 +20,7 @@ label {
 .upf-input {
   border: 1px solid transparent;
   border-radius: @default-radius;
-  height: @input-size-default;
+  height: var(--spacing-px-36);
   padding: 0 1em;
   color: @color-text;
   background-color: @field-background-color;
@@ -66,7 +66,7 @@ label {
   background-repeat: no-repeat;
   background-size: 10px;
 
-  height: 37px;
+  height: var(--spacing-px-36);
   padding-top: 0;
   padding-bottom: 0;
 
@@ -81,7 +81,7 @@ label {
 // --------------------------------------------------
 
 .upf-input--small, .upf-select--small {
-  height: @input-size-sm;
+  height: var(--spacing-px-24);
 }
 
 //
@@ -93,13 +93,13 @@ label {
 .upf-input-container {
   // Override selectize height
   .selectize-input {
-    height: @input-size-default;
-    border-radius: @default-radius;
+    height: var(--spacing-px-36);
+    border-radius: var(--border-radius-sm);
   }
 }
 
 .selectize-control.multi .selectize-input > div {
-  border-radius: @default-radius;
+  border-radius: var(--border-radius-sm);
   padding-left: 8px;
 }
 

--- a/app/styles/core/_variables.less
+++ b/app/styles/core/_variables.less
@@ -1,7 +1,6 @@
 @default-radius: 4px;
-@input-size-default: 37px;
-@input-size-sm: 34px;
-@input-size-x-sm: 22px;
+@input-size-default: 36px;
+@input-size-sm: @input-size-default;
 
 //
 // Font stacks

--- a/app/styles/core/_variables.stories.mdx
+++ b/app/styles/core/_variables.stories.mdx
@@ -70,7 +70,6 @@ In case you need to custom the height of an input, these are the one you might n
 |  Name                       | Value     |
 | --------------------------- | --------- |
 | input-size-default          | 36px      |
-| input-size-sm               | 34px      |
 
 <Canvas>
   <input type="text" class="upf-input" placeholder="input-size-default" />

--- a/app/styles/core/_variables.stories.mdx
+++ b/app/styles/core/_variables.stories.mdx
@@ -69,14 +69,12 @@ In case you need to custom the height of an input, these are the one you might n
 
 |  Name                       | Value     |
 | --------------------------- | --------- |
-| input-size-default          | 37px      |
+| input-size-default          | 36px      |
 | input-size-sm               | 34px      |
-| input-size-x-sm             | 22px      |
 
 <Canvas>
-  <input type="text" class="input-size-default" placeholder="input-size-default" />
+  <input type="text" class="upf-input" placeholder="input-size-default" />
   <input type="text" class="input-size-sm" placeholder="input-size-sm" />
-  <input type="text" class="input-size-x-sm" placeholder="input-size-x-sm" />
 </Canvas>
 
 ## Borders

--- a/app/styles/molecules/button-dropdown.less
+++ b/app/styles/molecules/button-dropdown.less
@@ -5,11 +5,11 @@
     background-color: var(--color-white);
     border: 1px solid @upf-primary-rock-blue;
     border-radius: var(--border-radius-sm);
-    height: 37px;
+    height: var(--spacing-px-36);
     padding: var(--spacing-px-6) 0;
 
     div {
-      height: 37px;
+      height: var(--spacing-px-36);
       padding: 0 var(--spacing-px-18);
 
       &:last-child {


### PR DESCRIPTION
### What does this PR do?

Till now, we had an inconsistency on the `height` rule of multiple components including:
- buttons
- inputs
- components built on top of them

This PR makes sure that they all converge to using `36px` (from the 6px based grid).
Because some parts of the software use the `input-size-X` variables defined before, they have just been updated for now we remove all mention of them.

### What are the observable changes?
<!-- This question could be adequate with multiple use cases, for example: -->

<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [ ] Added/updated tests
- [x] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled

### Additional Notes

<!--
    You can add anything you want here, an explanation on the way you built your implementation,
    precisions on the origin of the bug, gotchas you need to mention.
 -->
