### PR TITLE
Add extra-content named block for OSS::Alert

### DIFF
--- a/addon/components/o-s-s/alert.hbs
+++ b/addon/components/o-s-s/alert.hbs
@@ -11,6 +11,9 @@
       {{#if @subtitle}}
         <span class="subtitle">{{@subtitle}}</span>
       {{/if}}
+      {{#if (has-block "extra-content")}}
+        {{yield to="extra-content"}}
+      {{/if}}
     </div>
   </div>
 </div>

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -121,6 +121,16 @@
 </div>
 
 <div class="fx-row fx-gap-px-12 margin-md">
+  <OSS::Alert @title="Title" @subtitle="Subtitle">
+    <:extra-content>
+      <div class="fx-row fx-gap-px-12">
+        <OSS::Link @label="Super Label" />
+        <OSS::Link @label="Super Label 2" />
+      </div>
+    </:extra-content>
+  </OSS::Alert>
+</div>
+<div class="fx-row fx-gap-px-12 margin-md">
   <OSS::Alert @title="Title" @subtitle="Subtitle" />
   <OSS::Alert @skin="error" @title="Title" @subtitle="Subtitle" />
 </div>

--- a/tests/integration/components/o-s-s/alert-test.ts
+++ b/tests/integration/components/o-s-s/alert-test.ts
@@ -39,4 +39,10 @@ module('Integration | Component | o-s-s/alert', function (hooks) {
       assert.dom('.upf-alert .subtitle').hasText(`Subitle ${skin}`);
     });
   });
+
+  test('it render the extra-content named block', async function (assert) {
+    await render(hbs`<OSS::Alert><:extra-content><div>Hello</div></:extra-content></OSS::Alert>`);
+
+    assert.dom('.upf-alert .text-container div').hasText('Hello');
+  });
 });


### PR DESCRIPTION
### What does this PR do?

Add named block `extra-content` for OSS::Alery

Related to: https://github.com/upfluence/backlog/issues/1811

### What are the observable changes?
![Screenshot from 2022-09-21 18-27-21](https://user-images.githubusercontent.com/43567222/191559631-e7d6fcef-ff51-4510-9456-06d1c14f9bbb.png)

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled
