### PR TITLE
Update OSS::Alert component

### DIFF
--- a/addon/components/o-s-s/alert.hbs
+++ b/addon/components/o-s-s/alert.hbs
@@ -1,6 +1,6 @@
 <div class={{concat "upf-alert " this.skinClass}} {{did-insert this.initSelf}} ...attributes>
   <div class="indicator"></div>
-  <div class="main-container {{if @plain 'main-container--plain'}}">
+  <div class="main-container {{if this.plain 'main-container--plain'}}">
     <span class="icon">
       <i class={{concat "far " this.iconClass}}></i>
     </span>

--- a/addon/components/o-s-s/alert.hbs
+++ b/addon/components/o-s-s/alert.hbs
@@ -1,6 +1,6 @@
-<div class={{concat "upf-alert " this.skinClass}} ...attributes>
+<div class={{concat "upf-alert " this.skinClass}} {{did-insert this.initSelf}} ...attributes>
   <div class="indicator"></div>
-  <div class="main-container">
+  <div class="main-container {{if @plain 'main-container--plain'}}">
     <span class="icon">
       <i class={{concat "far " this.iconClass}}></i>
     </span>
@@ -15,5 +15,10 @@
         {{yield to="extra-content"}}
       {{/if}}
     </div>
+    {{#if @closable}}
+      <div class="fx-col" >
+        <i role="button" class="far fa-times" {{on "click" this.removeSelf}}></i>
+      </div>
+    {{/if}}
   </div>
 </div>

--- a/addon/components/o-s-s/alert.hbs
+++ b/addon/components/o-s-s/alert.hbs
@@ -16,7 +16,7 @@
       {{/if}}
     </div>
     {{#if @closable}}
-      <div class="fx-col" >
+      <div class="fx-col">
         <i role="button" class="far fa-times" {{on "click" this.removeSelf}}></i>
       </div>
     {{/if}}

--- a/addon/components/o-s-s/alert.stories.js
+++ b/addon/components/o-s-s/alert.stories.js
@@ -83,7 +83,8 @@ BasicUsage.args = {
 
 const BasicUsageExtraContentTemplate = (args) => ({
   template: hbs`
-      <OSS::Alert @skin={{this.skin}} @title={{this.title}} @subtitle={{this.subtitle}}>
+      <OSS::Alert @skin={{this.skin}} @title={{this.title}}
+                  @subtitle={{this.subtitle}} @plain={{this.plain}} @closable={{this.closable}}>
         <:extra-content>
           <div class="fx-row fx-gap-px-12">
             <OSS::Link @label="Link1" />
@@ -99,5 +100,7 @@ export const UsageExtraContent = BasicUsageExtraContentTemplate.bind({});
 UsageExtraContent.args = {
   skin: 'info',
   title: 'Title',
-  subtitle: 'I am a subtitle in the alert'
+  subtitle: 'I am a subtitle in the alert',
+  plain: true,
+  closable: false
 };

--- a/addon/components/o-s-s/alert.stories.js
+++ b/addon/components/o-s-s/alert.stories.js
@@ -38,10 +38,10 @@ export default {
       control: { type: 'text' }
     },
     plain: {
-      description: 'When true, a white background color is displayed',
+      description: 'When false, a white background color is displayed',
       table: {
         type: { summary: 'boolean' },
-        defaultValue: { summary: 'false' }
+        defaultValue: { summary: 'true' }
       },
       control: {
         type: 'boolean'

--- a/addon/components/o-s-s/alert.stories.js
+++ b/addon/components/o-s-s/alert.stories.js
@@ -38,7 +38,7 @@ export default {
       control: { type: 'text' }
     },
     plain: {
-      description: 'When value is true, then display a background-color white in alert instead of grey',
+      description: 'When true, a white background color is displayed',
       table: {
         type: { summary: 'boolean' },
         defaultValue: { summary: 'false' }
@@ -48,7 +48,7 @@ export default {
       }
     },
     closable: {
-      description: 'When value is true, then display a cross that delete the alert when you click on it ',
+      description: 'When enabled, the alert can be closed by clicking on the cross icon',
       table: {
         type: { summary: 'boolean' },
         defaultValue: { summary: 'false' }

--- a/addon/components/o-s-s/alert.stories.js
+++ b/addon/components/o-s-s/alert.stories.js
@@ -36,6 +36,26 @@ export default {
         defaultValue: { summary: '' }
       },
       control: { type: 'text' }
+    },
+    plain: {
+      description: 'When value is true, then display a background-color white in alert instead of grey',
+      table: {
+        type: { summary: 'boolean' },
+        defaultValue: { summary: 'false' }
+      },
+      control: {
+        type: 'boolean'
+      }
+    },
+    closable: {
+      description: 'When value is true, then display a cross that delete the alert when you click on it ',
+      table: {
+        type: { summary: 'boolean' },
+        defaultValue: { summary: 'false' }
+      },
+      control: {
+        type: 'boolean'
+      }
     }
   },
   parameters: {
@@ -56,6 +76,27 @@ const DefaultUsageTemplate = (args) => ({
 
 export const BasicUsage = DefaultUsageTemplate.bind({});
 BasicUsage.args = {
+  skin: 'info',
+  title: 'Title',
+  subtitle: 'I am a subtitle in the alert'
+};
+
+const BasicUsageExtraContentTemplate = (args) => ({
+  template: hbs`
+      <OSS::Alert @skin={{this.skin}} @title={{this.title}} @subtitle={{this.subtitle}}>
+        <:extra-content>
+          <div class="fx-row fx-gap-px-12">
+            <OSS::Link @label="Link1" />
+            <OSS::Link @label="Link2" />
+          </div>
+        </:extra-content>
+      </OSS::Alert>
+  `,
+  context: args
+});
+
+export const UsageExtraContent = BasicUsageExtraContentTemplate.bind({});
+UsageExtraContent.args = {
   skin: 'info',
   title: 'Title',
   subtitle: 'I am a subtitle in the alert'

--- a/addon/components/o-s-s/alert.stories.js
+++ b/addon/components/o-s-s/alert.stories.js
@@ -38,7 +38,7 @@ export default {
       control: { type: 'text' }
     },
     plain: {
-      description: 'When false, a white background color is displayed',
+      description: 'When plain is true, a gray background color is displayed, otherwise a white one',
       table: {
         type: { summary: 'boolean' },
         defaultValue: { summary: 'true' }

--- a/addon/components/o-s-s/alert.ts
+++ b/addon/components/o-s-s/alert.ts
@@ -20,6 +20,10 @@ export default class OSSAlert extends Component<OSSAlertArgs> {
     return `upf-alert--${this.args.skin || DEFAULT_SKIN}`;
   }
 
+  get plain(): boolean {
+    return this.args.plain ?? true;
+  }
+
   get iconClass(): string {
     switch (this.args.skin) {
       case 'success':

--- a/addon/components/o-s-s/alert.ts
+++ b/addon/components/o-s-s/alert.ts
@@ -1,4 +1,5 @@
 import Component from '@glimmer/component';
+import { action } from '@ember/object';
 
 type skinType = 'success' | 'error' | 'warning';
 
@@ -8,9 +9,13 @@ interface OSSAlertArgs {
   skin?: skinType;
   title?: string;
   subtitle?: string;
+  plain?: boolean;
+  closable?: boolean;
 }
 
 export default class OSSAlert extends Component<OSSAlertArgs> {
+  private declare _DOMElement: HTMLElement;
+
   get skinClass(): string {
     return `upf-alert--${this.args.skin || DEFAULT_SKIN}`;
   }
@@ -26,5 +31,15 @@ export default class OSSAlert extends Component<OSSAlertArgs> {
       default:
         return 'fa-info-circle';
     }
+  }
+
+  @action
+  initSelf(element: HTMLElement): void {
+    this._DOMElement = element;
+  }
+
+  @action
+  removeSelf(): void {
+    this._DOMElement?.remove();
   }
 }

--- a/app/styles/alert.less
+++ b/app/styles/alert.less
@@ -13,6 +13,10 @@
     padding: @spacing-xx-sm;
     gap: @spacing-xx-sm;
     background-color: var(--color-gray-50);
+
+    &--plain {
+      background-color: var(--color-white);
+    }
   }
 
   .text-container {

--- a/app/styles/alert.less
+++ b/app/styles/alert.less
@@ -12,10 +12,10 @@
     flex: 1;
     padding: @spacing-xx-sm;
     gap: @spacing-xx-sm;
-    background-color: var(--color-gray-50);
+    background-color: var(--color-white);
 
     &--plain {
-      background-color: var(--color-white);
+      background-color: var(--color-gray-50);
     }
   }
 

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -131,6 +131,7 @@
   </OSS::Alert>
 </div>
 <div class="fx-row fx-gap-px-12 margin-md">
+  <OSS::Alert @title="TitleTest" @subtitle="SubtitleTest" @plain={{true}} @closable={{true}} />
   <OSS::Alert @title="Title" @subtitle="Subtitle" />
   <OSS::Alert @skin="error" @title="Title" @subtitle="Subtitle" />
 </div>

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -131,7 +131,7 @@
   </OSS::Alert>
 </div>
 <div class="fx-row fx-gap-px-12 margin-md">
-  <OSS::Alert @title="TitleTest" @subtitle="SubtitleTest" @plain={{true}} @closable={{true}} />
+  <OSS::Alert @title="TitleTest" @subtitle="SubtitleTest" @plain={{false}} @closable={{true}} />
   <OSS::Alert @title="Title" @subtitle="Subtitle" />
   <OSS::Alert @skin="error" @title="Title" @subtitle="Subtitle" />
 </div>

--- a/tests/integration/components/o-s-s/alert-test.ts
+++ b/tests/integration/components/o-s-s/alert-test.ts
@@ -70,6 +70,20 @@ module('Integration | Component | o-s-s/alert', function (hooks) {
     assert.dom('.upf-alert').doesNotExist();
   });
 
+  test('the cross icon is not displayed when @closable is false', async function (assert) {
+    await render(hbs`<OSS::Alert @closable={{false}} />`);
+
+    assert.dom('.upf-alert').exists();
+    assert.dom('.upf-alert .main-container .fx-col i').doesNotExist();
+  });
+
+  test('the cross icon is not displayed when @closable is undefined', async function (assert) {
+    await render(hbs`<OSS::Alert />`);
+
+    assert.dom('.upf-alert').exists();
+    assert.dom('.upf-alert .main-container .fx-col i').doesNotExist();
+  });
+
   test('it renders the extra-content named block', async function (assert) {
     await render(hbs`<OSS::Alert><:extra-content><div>Hello</div></:extra-content></OSS::Alert>`);
 

--- a/tests/integration/components/o-s-s/alert-test.ts
+++ b/tests/integration/components/o-s-s/alert-test.ts
@@ -39,51 +39,53 @@ module('Integration | Component | o-s-s/alert', function (hooks) {
       assert.dom('.upf-alert .subtitle').hasText(`Subitle ${skin}`);
     });
   });
+  module('@plain parameter', function () {
+    test('If true, the background-color is grey', async function (assert) {
+      await render(hbs`<OSS::Alert @plain={{true}} />`);
 
-  test('it renders the background-color white in alert when @plain is false', async function (assert) {
-    await render(hbs`<OSS::Alert @plain={{false}} />`);
+      assert.dom('.upf-alert .main-container').hasClass('main-container--plain');
+    });
 
-    assert.dom('.upf-alert .main-container').hasNoClass('main-container--plain');
+    test('If false, the background-color is white', async function (assert) {
+      await render(hbs`<OSS::Alert @plain={{false}} />`);
+
+      assert.dom('.upf-alert .main-container').hasNoClass('main-container--plain');
+    });
+
+    test('If undefined, the background-color is grey', async function (assert) {
+      await render(hbs`<OSS::Alert />`);
+
+      assert.dom('.upf-alert .main-container').hasClass('main-container--plain');
+    });
   });
 
-  test('it renders the background-color grey in alert when @plain is true', async function (assert) {
-    await render(hbs`<OSS::Alert @plain={{true}} />`);
+  module('@closable parameter', function () {
+    test('it renders the cross which delete alert when you click on it, when @closable is true', async function (assert) {
+      await render(hbs`<div><OSS::Alert @closable={{true}} /></div>`);
 
-    assert.dom('.upf-alert .main-container').hasClass('main-container--plain');
+      assert.dom('.upf-alert').exists();
+      assert.dom('.upf-alert .main-container .fx-col i').exists();
+      assert.dom('.upf-alert .main-container .fx-col i').hasClass('fa-times');
+
+      await click('.upf-alert .main-container .fx-col i');
+
+      assert.dom('.upf-alert').doesNotExist();
+    });
+
+    test('the cross icon is not displayed when @closable is false', async function (assert) {
+      await render(hbs`<OSS::Alert @closable={{false}} />`);
+
+      assert.dom('.upf-alert').exists();
+      assert.dom('.upf-alert .main-container .fx-col i').doesNotExist();
+    });
+
+    test('the cross icon is not displayed when @closable is undefined', async function (assert) {
+      await render(hbs`<OSS::Alert />`);
+
+      assert.dom('.upf-alert').exists();
+      assert.dom('.upf-alert .main-container .fx-col i').doesNotExist();
+    });
   });
-
-  test('it renders the background-color grey in alert when @plain is undefined', async function (assert) {
-    await render(hbs`<OSS::Alert />`);
-
-    assert.dom('.upf-alert .main-container').hasClass('main-container--plain');
-  });
-
-  test('it renders the cross which delete alert when you click on it, when @closable is true', async function (assert) {
-    await render(hbs`<div><OSS::Alert @closable={{true}} /></div>`);
-
-    assert.dom('.upf-alert').exists();
-    assert.dom('.upf-alert .main-container .fx-col i').exists();
-    assert.dom('.upf-alert .main-container .fx-col i').hasClass('fa-times');
-
-    await click('.upf-alert .main-container .fx-col i');
-
-    assert.dom('.upf-alert').doesNotExist();
-  });
-
-  test('the cross icon is not displayed when @closable is false', async function (assert) {
-    await render(hbs`<OSS::Alert @closable={{false}} />`);
-
-    assert.dom('.upf-alert').exists();
-    assert.dom('.upf-alert .main-container .fx-col i').doesNotExist();
-  });
-
-  test('the cross icon is not displayed when @closable is undefined', async function (assert) {
-    await render(hbs`<OSS::Alert />`);
-
-    assert.dom('.upf-alert').exists();
-    assert.dom('.upf-alert .main-container .fx-col i').doesNotExist();
-  });
-
   test('it renders the extra-content named block', async function (assert) {
     await render(hbs`<OSS::Alert><:extra-content><div>Hello</div></:extra-content></OSS::Alert>`);
 

--- a/tests/integration/components/o-s-s/alert-test.ts
+++ b/tests/integration/components/o-s-s/alert-test.ts
@@ -40,19 +40,19 @@ module('Integration | Component | o-s-s/alert', function (hooks) {
     });
   });
   module('@plain parameter', function () {
-    test('If true, the background-color is grey', async function (assert) {
+    test('if true, the background-color is grey', async function (assert) {
       await render(hbs`<OSS::Alert @plain={{true}} />`);
 
       assert.dom('.upf-alert .main-container').hasClass('main-container--plain');
     });
 
-    test('If false, the background-color is white', async function (assert) {
+    test('if false, the background-color is white', async function (assert) {
       await render(hbs`<OSS::Alert @plain={{false}} />`);
 
       assert.dom('.upf-alert .main-container').hasNoClass('main-container--plain');
     });
 
-    test('If undefined, the background-color is grey', async function (assert) {
+    test('if undefined, the background-color is grey', async function (assert) {
       await render(hbs`<OSS::Alert />`);
 
       assert.dom('.upf-alert .main-container').hasClass('main-container--plain');
@@ -60,7 +60,7 @@ module('Integration | Component | o-s-s/alert', function (hooks) {
   });
 
   module('@closable parameter', function () {
-    test('it renders the cross which delete alert when you click on it, when @closable is true', async function (assert) {
+    test('if true, display the cross icon which delete alert when you click on it', async function (assert) {
       await render(hbs`<div><OSS::Alert @closable={{true}} /></div>`);
 
       assert.dom('.upf-alert').exists();
@@ -72,20 +72,21 @@ module('Integration | Component | o-s-s/alert', function (hooks) {
       assert.dom('.upf-alert').doesNotExist();
     });
 
-    test('the cross icon is not displayed when @closable is false', async function (assert) {
+    test('if false, the cross icon is not displayed', async function (assert) {
       await render(hbs`<OSS::Alert @closable={{false}} />`);
 
       assert.dom('.upf-alert').exists();
       assert.dom('.upf-alert .main-container .fx-col i').doesNotExist();
     });
 
-    test('the cross icon is not displayed when @closable is undefined', async function (assert) {
+    test('if undefined, the cross icon is not displayed', async function (assert) {
       await render(hbs`<OSS::Alert />`);
 
       assert.dom('.upf-alert').exists();
       assert.dom('.upf-alert .main-container .fx-col i').doesNotExist();
     });
   });
+
   test('it renders the extra-content named block', async function (assert) {
     await render(hbs`<OSS::Alert><:extra-content><div>Hello</div></:extra-content></OSS::Alert>`);
 

--- a/tests/integration/components/o-s-s/alert-test.ts
+++ b/tests/integration/components/o-s-s/alert-test.ts
@@ -41,14 +41,14 @@ module('Integration | Component | o-s-s/alert', function (hooks) {
   });
 
   test('it render the background-color white in alert when @plain is true', async function (assert) {
-    await render(hbs`<OSS::Alert @plain={{true}}></OSS::Alert>`);
+    await render(hbs`<OSS::Alert @plain={{true}} />`);
 
     assert.dom('.upf-alert .main-container').hasClass('main-container--plain');
     assert.dom('.upf-alert .main-container').hasStyle({ backgroundColor: 'rgb(255, 255, 255)' });
   });
 
   test('it render the cross which delete alert when you click on it, when @closable is true', async function (assert) {
-    await render(hbs`<div><OSS::Alert @closable={{true}}></OSS::Alert></div>`);
+    await render(hbs`<div><OSS::Alert @closable={{true}} /></div>`);
 
     assert.dom('.upf-alert').exists();
     assert.dom('.upf-alert .main-container .fx-col i').exists();

--- a/tests/integration/components/o-s-s/alert-test.ts
+++ b/tests/integration/components/o-s-s/alert-test.ts
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@ember/test-helpers';
+import { render, click } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 const ALERT_SKINS = ['success', 'error', 'info', 'warning'];
@@ -38,6 +38,25 @@ module('Integration | Component | o-s-s/alert', function (hooks) {
       assert.dom('.upf-alert .title').hasText(`Title ${skin}`);
       assert.dom('.upf-alert .subtitle').hasText(`Subitle ${skin}`);
     });
+  });
+
+  test('it render the background-color white in alert when @plain is true', async function (assert) {
+    await render(hbs`<OSS::Alert @plain={{true}}></OSS::Alert>`);
+
+    assert.dom('.upf-alert .main-container').hasClass('main-container--plain');
+    assert.dom('.upf-alert .main-container').hasStyle({ backgroundColor: 'rgb(255, 255, 255)' });
+  });
+
+  test('it render the cross which delete alert when you click on it, when @closable is true', async function (assert) {
+    await render(hbs`<div><OSS::Alert @closable={{true}}></OSS::Alert></div>`);
+
+    assert.dom('.upf-alert').exists();
+    assert.dom('.upf-alert .main-container .fx-col i').exists();
+    assert.dom('.upf-alert .main-container .fx-col i').hasClass('fa-times');
+
+    await click('.upf-alert .main-container .fx-col i');
+
+    assert.dom('.upf-alert').doesNotExist();
   });
 
   test('it render the extra-content named block', async function (assert) {

--- a/tests/integration/components/o-s-s/alert-test.ts
+++ b/tests/integration/components/o-s-s/alert-test.ts
@@ -40,14 +40,14 @@ module('Integration | Component | o-s-s/alert', function (hooks) {
     });
   });
 
-  test('it render the background-color white in alert when @plain is true', async function (assert) {
+  test('it renders the background-color white in alert when @plain is true', async function (assert) {
     await render(hbs`<OSS::Alert @plain={{true}} />`);
 
     assert.dom('.upf-alert .main-container').hasClass('main-container--plain');
     assert.dom('.upf-alert .main-container').hasStyle({ backgroundColor: 'rgb(255, 255, 255)' });
   });
 
-  test('it render the cross which delete alert when you click on it, when @closable is true', async function (assert) {
+  test('it renders the cross which delete alert when you click on it, when @closable is true', async function (assert) {
     await render(hbs`<div><OSS::Alert @closable={{true}} /></div>`);
 
     assert.dom('.upf-alert').exists();
@@ -59,7 +59,7 @@ module('Integration | Component | o-s-s/alert', function (hooks) {
     assert.dom('.upf-alert').doesNotExist();
   });
 
-  test('it render the extra-content named block', async function (assert) {
+  test('it renders the extra-content named block', async function (assert) {
     await render(hbs`<OSS::Alert><:extra-content><div>Hello</div></:extra-content></OSS::Alert>`);
 
     assert.dom('.upf-alert .text-container div').hasText('Hello');

--- a/tests/integration/components/o-s-s/alert-test.ts
+++ b/tests/integration/components/o-s-s/alert-test.ts
@@ -39,6 +39,7 @@ module('Integration | Component | o-s-s/alert', function (hooks) {
       assert.dom('.upf-alert .subtitle').hasText(`Subitle ${skin}`);
     });
   });
+
   module('@plain parameter', function () {
     test('if true, the background-color is grey', async function (assert) {
       await render(hbs`<OSS::Alert @plain={{true}} />`);

--- a/tests/integration/components/o-s-s/alert-test.ts
+++ b/tests/integration/components/o-s-s/alert-test.ts
@@ -40,11 +40,22 @@ module('Integration | Component | o-s-s/alert', function (hooks) {
     });
   });
 
-  test('it renders the background-color white in alert when @plain is true', async function (assert) {
+  test('it renders the background-color white in alert when @plain is false', async function (assert) {
+    await render(hbs`<OSS::Alert @plain={{false}} />`);
+
+    assert.dom('.upf-alert .main-container').hasNoClass('main-container--plain');
+  });
+
+  test('it renders the background-color grey in alert when @plain is true', async function (assert) {
     await render(hbs`<OSS::Alert @plain={{true}} />`);
 
     assert.dom('.upf-alert .main-container').hasClass('main-container--plain');
-    assert.dom('.upf-alert .main-container').hasStyle({ backgroundColor: 'rgb(255, 255, 255)' });
+  });
+
+  test('it renders the background-color grey in alert when @plain is undefined', async function (assert) {
+    await render(hbs`<OSS::Alert />`);
+
+    assert.dom('.upf-alert .main-container').hasClass('main-container--plain');
   });
 
   test('it renders the cross which delete alert when you click on it, when @closable is true', async function (assert) {


### PR DESCRIPTION
### What does this PR do?

The goal is to update the alert component to add 3 new props: A closable prop, a plain prop and a link prop (name block).
- Closable parameter, to delete the alert when you click on cross
- Plain parameter, for display a background-color white in the alert when it is false
- New name bloc named extra-content, which allow us to have some content in the alert like links

Related to: [#1811](https://github.com/upfluence/backlog/issues/1811)

### What are the observable changes?
Picture with plain equal false and closable equal true : 

![oss_alert_plain_cloasable](https://user-images.githubusercontent.com/104398916/191938482-18fee5c7-d04d-46e8-9100-9dfa09087dea.png)

Picture with extra content and default value for plain and closable:

![oss_alert_extra_content](https://user-images.githubusercontent.com/104398916/191939355-7284c080-87c5-4248-a573-bea4350edb48.png)

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [x] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled
