### PR TITLE
Added: OSS::ModalDialog responsiveness

### DIFF
--- a/addon/components/o-s-s/modal-dialog.stories.js
+++ b/addon/components/o-s-s/modal-dialog.stories.js
@@ -42,7 +42,10 @@ export default {
   parameters: {
     docs: {
       description: {
-        component: 'A lightweight version of the OSS Modal. Used mostly to confirm user actions.'
+        component: `A lightweight version of the OSS Modal. Used mostly to confirm user actions.<br><br>
+        Notes:<br>
+        - The footer part of the component defaults to fx-row fx-gap-px-12 in desktop mode.<br>
+        - In mobile mode it defaults to fx-col (with column-reverse to have the cancel buttons at the bottom) and fx-gap-px-9`
       }
     }
   }

--- a/app/styles/modal-dialog.less
+++ b/app/styles/modal-dialog.less
@@ -27,7 +27,8 @@
   box-shadow: var(--box-shadow-lg);
   border-radius: var(--border-radius-md);
 
-  header, footer {
+  header,
+  footer {
     padding: @spacing-xx-sm @spacing-x-sm;
   }
 
@@ -37,6 +38,10 @@
 
   footer {
     border-top: 1px solid var(--color-gray-200);
+    flex-direction: row;
+    flex: 1;
+    gap: var(--spacing-px-12);
+    justify-content: flex-end;
   }
 
   header .title {
@@ -51,6 +56,8 @@
 
   &--content {
     padding: @spacing-sm;
+    max-height: calc(100vh - 124px);
+    overflow-y: auto;
   }
 }
 
@@ -63,5 +70,24 @@
   100% {
     opacity: 1;
     transform: translateY(0);
+  }
+}
+
+@media screen and (max-device-width: 480px) and (orientation: portrait) {
+  .oss-modal-dialog {
+    height: 90vh;
+    margin-top: 10vh;
+    border-bottom-left-radius: 0;
+    border-bottom-right-radius: 0;
+
+    footer {
+      gap: var(--spacing-px-9);
+      flex-direction: column-reverse;
+      flex: 0;
+
+      .upf-btn {
+        width: 100%;
+      }
+    }
   }
 }

--- a/app/styles/modal-dialog.less
+++ b/app/styles/modal-dialog.less
@@ -56,7 +56,7 @@
 
   &--content {
     padding: @spacing-sm;
-    max-height: calc(100vh - 124px);
+    max-height: calc(100vh - 148px);
     overflow-y: auto;
   }
 }


### PR DESCRIPTION
### What does this PR do?

Handles the responsiveness of the ModalDialog components for mobile layout.

Related to: #[1945](https://github.com/upfluence/backlog/issues/1945)
Related to: #[827](https://github.com/upfluence/cs/issues/827)

### What are the observable changes?

Notes have been added to storybook to explain that:
- the footer defaults to `fx-row fx-gap-px-12` in desktop mode
- the footer defaults to `fx-col fx-gap-px-9` with column-reverse set in order to have our cancel buttons on the bottom of the options.

![Screenshot 2022-09-28 at 11 38 18](https://user-images.githubusercontent.com/5032005/192746503-e938a941-14e8-45ab-b507-c362411bd14b.png)

Here's an example render in creators-web : 
[Mobile mode]
![Screenshot 2022-09-28 at 11 42 59](https://user-images.githubusercontent.com/5032005/192746800-0c13b360-b786-4548-84a9-811f72fa12b1.png)

[Unchanged Desktop mode]
![Screenshot 2022-09-28 at 11 42 47](https://user-images.githubusercontent.com/5032005/192746761-0547d6a8-1756-4932-96ba-5628a332d2cf.png)

FYI, in the offer-acceptance-modal in creators web; here are the changes made to have the proper layout:

[original footer code]
```
  <:footer>
    <div class="fx-row fx-1 fx-gap-px-12 fx-malign-end">
      <OSS::Button .../>
      <OSS::Button
        @skin="primary" ..../>
    </div>
  </:footer>
```

[changes - encapsulating div has been removed, everything is handle from ModalDialog's css]
```
  <:footer>
      <OSS::Button ... />
      <OSS::Button
        @skin="primary" .../>
  </:footer>
```

### Good PR checklist
- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [ ] Added/updated tests
- [x] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled
