### PR TITLE
Fixed: CurrencyInput error focus border

### DIFF
--- a/app/styles/currency-input.less
+++ b/app/styles/currency-input.less
@@ -12,9 +12,10 @@
         outline: none;
       }
     }
-  }
-  .currency-input.upf-input:focus-within {
-    .border-color-error;
+
+    .currency-input.upf-input:focus-within {
+      .border-color-error;
+    }
   }
 
   .upf-infinite-select {


### PR DESCRIPTION
### What does this PR do?

The input showed the border red on focus even when not "errored"

Related to: #[2000](https://github.com/upfluence/backlog/issues/2000)

### Good PR checklist
- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled