### PR TITLE
Addon tree caching setup

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@
 const mergeTrees = require('broccoli-merge-trees');
 const Funnel = require('broccoli-funnel');
 const fs = require('fs');
+const cacheKeyForTree = require('calculate-cache-key-for-tree');
 const { name, version } = require('./package');
 
 let faPath = 'node_modules/@fortawesome/fontawesome-pro';
@@ -47,6 +48,7 @@ module.exports = {
   },
 
   treeForPublic() {
+    console.log('=====>', 'treeForPublic oss-components')
     const publicTree = this._super.treeForPublic.apply(this, arguments);
     const trees = [];
 
@@ -75,5 +77,9 @@ module.exports = {
     );
 
     return mergeTrees(trees);
+  },
+
+  cacheKeyForTree(treeType) {
+    return cacheKeyForTree(treeType, this, this.pkg);
   }
 };

--- a/index.js
+++ b/index.js
@@ -48,7 +48,6 @@ module.exports = {
   },
 
   treeForPublic() {
-    console.log('=====>', 'treeForPublic oss-components')
     const publicTree = this._super.treeForPublic.apply(this, arguments);
     const trees = [];
 

--- a/package.json
+++ b/package.json
@@ -32,8 +32,11 @@
   },
   "dependencies": {
     "@embroider/macros": "^1.7.1",
+    "@fortawesome/fontawesome-free": "^5.x",
     "@fortawesome/fontawesome-pro": "^5.15.4",
     "babel-plugin-debug-macros": "^0.3.1",
+    "bootstrap": "^3.3.7",
+    "countdown.js": "git+https://git@github.com/gumroad/countdown.js.git",
     "ember-cli-babel": "^7.19.0",
     "ember-cli-htmlbars": "^4.3.1",
     "ember-cli-ifa": "^0.10.0",
@@ -44,9 +47,6 @@
     "ember-star-rating": "^3.0.0",
     "ember-truth-helpers": "^3.0.0",
     "ion-rangeslider": "^2.3.1",
-    "@fortawesome/fontawesome-free": "^5.x",
-    "bootstrap": "^3.3.7",
-    "countdown.js": "git+https://git@github.com/gumroad/countdown.js.git",
     "money-formatter": "^0.1.4"
   },
   "devDependencies": {
@@ -90,6 +90,7 @@
     "babel-eslint": "^10.1.0",
     "babel-loader": "^8.1.0",
     "broccoli-asset-rev": "^3.0.0",
+    "calculate-cache-key-for-tree": "^2.0.0",
     "ember-auto-import": "^1.5.3",
     "ember-cli": "~3.18.0",
     "ember-cli-dependency-checker": "^3.2.0",


### PR DESCRIPTION
### What does this PR do?

As defined in the following [RFC](https://rfcs.emberjs.com/id/0090-addon-tree-caching/), this adds caching to the addon when its tree in being built. At the moment, each apps or engine declaring `@upfluence/oss-components` as a dependency build its tree even if it's been done already by another app or engine.

### What are the observable changes?
<!-- This question could be adequate with multiple use cases, for example: -->

<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->

### Good PR checklist
- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled
