### PR TITLE
Add new Instagram accent color

### DIFF
--- a/.storybook/styles/stories/colors-v2.less
+++ b/.storybook/styles/stories/colors-v2.less
@@ -30,23 +30,23 @@
   .generate-colors(@i - 1);
   @color: extract(@colors, @i);
   .color-@{color}-50 {
-    background-color: var(~"--color-@{color}-50");
+    background-color: var(~'--color-@{color}-50');
     color: var(--color-black);
   }
   .color-@{color}-400 {
-    background-color: var(~"--color-@{color}-400");
+    background-color: var(~'--color-@{color}-400');
     color: var(--color-black);
   }
   .color-@{color}-500 {
-    background-color: var(~"--color-@{color}-500");
+    background-color: var(~'--color-@{color}-500');
     color: var(--color-white);
   }
   .color-@{color}-600 {
-    background-color: var(~"--color-@{color}-600");
+    background-color: var(~'--color-@{color}-600');
     color: var(--color-white);
   }
   .color-@{color}-900 {
-    background-color: var(~"--color-@{color}-900");
+    background-color: var(~'--color-@{color}-900');
     color: var(--color-white);
   }
 }
@@ -57,15 +57,19 @@
   .generate-colors-socials(@i - 1);
   @color-socials: extract(@colors-socials, @i);
   .color-@{color-socials}-50 {
-    background-color: var(~"--color-@{color-socials}-50");
+    background-color: var(~'--color-@{color-socials}-50');
     color: var(--color-black);
   }
   .color-@{color-socials}-500 {
-    background-color: var(~"--color-@{color-socials}-500");
+    background-color: var(~'--color-@{color-socials}-500');
     color: var(--color-white);
   }
 }
 .generate-colors-socials();
+
+.color-instagram-accent {
+  background: var(--color-instagram-accent);
+}
 
 .color-primary-400 {
   color: var(--color-white);

--- a/app/styles/core-v2/_colors.less
+++ b/app/styles/core-v2/_colors.less
@@ -1,209 +1,373 @@
 :root {
-  --color-primary-50: #ECECFD;
-  --color-primary-400: #3232F6;
-  --color-primary-500: #0D0DE6;
-  --color-primary-600: #0404C7;
+  --color-primary-50: #ececfd;
+  --color-primary-400: #3232f6;
+  --color-primary-500: #0d0de6;
+  --color-primary-600: #0404c7;
   --color-primary-900: #060666;
 
-  --color-accent: #FF4331;
+  --color-accent: #ff4331;
 
-  --color-white: #FFFFFF;
+  --color-white: #ffffff;
   --color-black: #000000;
 
-  --color-gray-50: #F9FAFB;
-  --color-gray-100: #F3F4F6;
-  --color-gray-200: #E5E7EB;
-  --color-gray-300: #D1D5DB;
-  --color-gray-400: #9CA3AF;
-  --color-gray-500: #6B7280;
-  --color-gray-900: #1B1E21;
+  --color-gray-50: #f9fafb;
+  --color-gray-100: #f3f4f6;
+  --color-gray-200: #e5e7eb;
+  --color-gray-300: #d1d5db;
+  --color-gray-400: #9ca3af;
+  --color-gray-500: #6b7280;
+  --color-gray-900: #1b1e21;
 
-  --color-success-50: #ECFDF5;
-  --color-success-400: #34D399;
-  --color-success-500: #10B981;
+  --color-success-50: #ecfdf5;
+  --color-success-400: #34d399;
+  --color-success-500: #10b981;
   --color-success-600: #059669;
-  --color-success-900: #064E3B;
+  --color-success-900: #064e3b;
 
-  --color-info-50: #F0FDFA;
-  --color-info-400: #2DD4BF;
-  --color-info-500: #14B8A6;
-  --color-info-600: #0D9488;
-  --color-info-900: #134E4A;
+  --color-info-50: #f0fdfa;
+  --color-info-400: #2dd4bf;
+  --color-info-500: #14b8a6;
+  --color-info-600: #0d9488;
+  --color-info-900: #134e4a;
 
-  --color-warning-50: #FFFBEB;
-  --color-warning-400: #FBBF24;
-  --color-warning-500: #F59E0B;
-  --color-warning-600: #D97706;
-  --color-warning-900: #78350F;
+  --color-warning-50: #fffbeb;
+  --color-warning-400: #fbbf24;
+  --color-warning-500: #f59e0b;
+  --color-warning-600: #d97706;
+  --color-warning-900: #78350f;
 
-  --color-error-50: #FEF2F2;
-  --color-error-400: #F87171;
-  --color-error-500: #EF4444;
-  --color-error-600: #DC2626;
-  --color-error-900: #7F1D1D;
+  --color-error-50: #fef2f2;
+  --color-error-400: #f87171;
+  --color-error-500: #ef4444;
+  --color-error-600: #dc2626;
+  --color-error-900: #7f1d1d;
 
-  --color-orange-50: #FFF7ED;
-  --color-orange-400: #FB923C;
-  --color-orange-500: #F97316;
-  --color-orange-600: #EA580C;
-  --color-orange-900: #7C2D12;
+  --color-orange-50: #fff7ed;
+  --color-orange-400: #fb923c;
+  --color-orange-500: #f97316;
+  --color-orange-600: #ea580c;
+  --color-orange-900: #7c2d12;
 
-  --color-yellow-50: #FEFCE8;
-  --color-yellow-400: #FACC15;
-  --color-yellow-500: #EAB308;
-  --color-yellow-600: #CA8A04;
-  --color-yellow-900: #713F12;
+  --color-yellow-50: #fefce8;
+  --color-yellow-400: #facc15;
+  --color-yellow-500: #eab308;
+  --color-yellow-600: #ca8a04;
+  --color-yellow-900: #713f12;
 
-  --color-lime-50: #F7FEE7;
-  --color-lime-400: #A3E635;
-  --color-lime-500: #84CC16;
-  --color-lime-600: #65A30D;
+  --color-lime-50: #f7fee7;
+  --color-lime-400: #a3e635;
+  --color-lime-500: #84cc16;
+  --color-lime-600: #65a30d;
   --color-lime-900: #365314;
 
-  --color-cyan-50: #ECFEFF;
-  --color-cyan-400: #22D3EE;
-  --color-cyan-500: #06B6D4;
-  --color-cyan-600: #0891B2;
-  --color-cyan-900: #164E63;
+  --color-cyan-50: #ecfeff;
+  --color-cyan-400: #22d3ee;
+  --color-cyan-500: #06b6d4;
+  --color-cyan-600: #0891b2;
+  --color-cyan-900: #164e63;
 
-  --color-blue-50: #EFF6FF;
-  --color-blue-400: #60A5FA;
-  --color-blue-500: #3B82F6;
-  --color-blue-600: #2563EB;
-  --color-blue-900: #1E3A8A;
+  --color-blue-50: #eff6ff;
+  --color-blue-400: #60a5fa;
+  --color-blue-500: #3b82f6;
+  --color-blue-600: #2563eb;
+  --color-blue-900: #1e3a8a;
 
-  --color-violet-50: #F5F3FF;
-  --color-violet-400: #A78BFA;
-  --color-violet-500: #8B5CF6;
-  --color-violet-600: #7C3AED;
-  --color-violet-900: #4C1D95;
+  --color-violet-50: #f5f3ff;
+  --color-violet-400: #a78bfa;
+  --color-violet-500: #8b5cf6;
+  --color-violet-600: #7c3aed;
+  --color-violet-900: #4c1d95;
 
-  --color-instagram-50: #F9EBF3;
-  --color-instagram-500: #C13584;
+  --color-instagram-50: #f9ebf3;
+  --color-instagram-500: #c13584;
+  --color-instagram-accent: radial-gradient(
+      51.8% 49.8% at 36.25% 96.55%,
+      #ffd600 0%,
+      #ff6930 48.44%,
+      #fe3b36 73.44%,
+      rgba(254, 59, 54, 0) 100%
+    ),
+    radial-gradient(
+      182.65% 122.8% at 84.5% 113.5%,
+      #ff1b90 24.39%,
+      #f80261 43.67%,
+      #ed00c0 68.85%,
+      #c500e9 77.68%,
+      #7017ff 89.32%
+    );
 
-  --color-facebook-50: #E8F1FE;
-  --color-facebook-500: #1778F2;
+  --color-facebook-50: #e8f1fe;
+  --color-facebook-500: #1778f2;
 
-  --color-youtube-50: #F8EAE9;
-  --color-youtube-500: #CD201F;
+  --color-youtube-50: #f8eae9;
+  --color-youtube-500: #cd201f;
 
-  --color-twitter-50: #ECF5FD;
-  --color-twitter-500: #1DA1F2;
+  --color-twitter-50: #ecf5fd;
+  --color-twitter-500: #1da1f2;
 
-  --color-tiktok-50: #EAEAEA;
+  --color-tiktok-50: #eaeaea;
   --color-tiktok-500: #333333;
 
-  --color-blog-50: #F5F5F5;
+  --color-blog-50: #f5f5f5;
   --color-blog-500: #999999;
 
-  --color-twitch-50: #EFECF6;
-  --color-twitch-500: #6441A5;
+  --color-twitch-50: #efecf6;
+  --color-twitch-500: #6441a5;
 
-  --color-pinterest-50: #FAE9EA;
-  --color-pinterest-500: #C8232C;
+  --color-pinterest-50: #fae9ea;
+  --color-pinterest-500: #c8232c;
 }
 
 // Easy to use background-colors as classes
-.background-color-primary-50 { background-color: var(--color-primary-50) }
-.background-color-primary-500 { background-color: var(--color-primary-500) }
-.background-color-primary-900 { background-color: var(--color-primary-900) }
+.background-color-primary-50 {
+  background-color: var(--color-primary-50);
+}
+.background-color-primary-500 {
+  background-color: var(--color-primary-500);
+}
+.background-color-primary-900 {
+  background-color: var(--color-primary-900);
+}
 
-.background-color-accent { background-color: var(--color-accent) }
+.background-color-accent {
+  background-color: var(--color-accent);
+}
 
-.background-color-white { background-color: var(--color-white) }
+.background-color-white {
+  background-color: var(--color-white);
+}
 
-.background-color-gray-50 { background-color: var(--color-gray-50) }
-.background-color-gray-100 { background-color: var(--color-gray-100) }
-.background-color-gray-500 { background-color: var(--color-gray-500) }
-.background-color-gray-900 { background-color: var(--color-gray-900) }
+.background-color-gray-50 {
+  background-color: var(--color-gray-50);
+}
+.background-color-gray-100 {
+  background-color: var(--color-gray-100);
+}
+.background-color-gray-500 {
+  background-color: var(--color-gray-500);
+}
+.background-color-gray-900 {
+  background-color: var(--color-gray-900);
+}
 
-.background-color-success-50 { background-color: var(--color-success-50) }
-.background-color-success-500 { background-color: var(--color-success-500) }
+.background-color-success-50 {
+  background-color: var(--color-success-50);
+}
+.background-color-success-500 {
+  background-color: var(--color-success-500);
+}
 
-.background-color-info-50 { background-color: var(--color-info-50) }
-.background-color-info-500 { background-color: var(--color-info-500) }
+.background-color-info-50 {
+  background-color: var(--color-info-50);
+}
+.background-color-info-500 {
+  background-color: var(--color-info-500);
+}
 
-.background-color-warning-50 { background-color: var(--color-warning-50) }
-.background-color-warning-500 { background-color: var(--color-warning-500) }
+.background-color-warning-50 {
+  background-color: var(--color-warning-50);
+}
+.background-color-warning-500 {
+  background-color: var(--color-warning-500);
+}
 
-.background-color-error-50 { background-color: var(--color-error-50) }
-.background-color-error-500 { background-color: var(--color-error-500) }
+.background-color-error-50 {
+  background-color: var(--color-error-50);
+}
+.background-color-error-500 {
+  background-color: var(--color-error-500);
+}
 
-.background-color-orange-50 { background-color: var(--color-orange-50) }
-.background-color-orange-500 { background-color: var(--color-orange-500) }
+.background-color-orange-50 {
+  background-color: var(--color-orange-50);
+}
+.background-color-orange-500 {
+  background-color: var(--color-orange-500);
+}
 
-.background-color-yellow-50 { background-color: var(--color-yellow-50) }
-.background-color-yellow-500 { background-color: var(--color-yellow-500) }
+.background-color-yellow-50 {
+  background-color: var(--color-yellow-50);
+}
+.background-color-yellow-500 {
+  background-color: var(--color-yellow-500);
+}
 
-.background-color-lime-50 { background-color: var(--color-lime-50) }
-.background-color-lime-500 { background-color: var(--color-lime-500) }
+.background-color-lime-50 {
+  background-color: var(--color-lime-50);
+}
+.background-color-lime-500 {
+  background-color: var(--color-lime-500);
+}
 
-.background-color-lime-50 { background-color: var(--color-lime-50) }
-.background-color-lime-500 { background-color: var(--color-lime-500) }
+.background-color-lime-50 {
+  background-color: var(--color-lime-50);
+}
+.background-color-lime-500 {
+  background-color: var(--color-lime-500);
+}
 
-.background-color-cyan-50 { background-color: var(--color-cyan-50) }
-.background-color-cyan-500 { background-color: var(--color-cyan-500) }
+.background-color-cyan-50 {
+  background-color: var(--color-cyan-50);
+}
+.background-color-cyan-500 {
+  background-color: var(--color-cyan-500);
+}
 
-.background-color-blue-50 { background-color: var(--color-blue-50) }
-.background-color-blue-500 { background-color: var(--color-blue-500) }
+.background-color-blue-50 {
+  background-color: var(--color-blue-50);
+}
+.background-color-blue-500 {
+  background-color: var(--color-blue-500);
+}
 
-.background-color-violet-50 { background-color: var(--color-violet-50) }
-.background-color-violet-500 { background-color: var(--color-violet-500) }
+.background-color-violet-50 {
+  background-color: var(--color-violet-50);
+}
+.background-color-violet-500 {
+  background-color: var(--color-violet-500);
+}
 
-.background-color-instagram-50 { background-color: var(--color-instagram-50) }
-.background-color-instagram-500 { background-color: var(--color-instagram-500) }
+.background-color-instagram-50 {
+  background-color: var(--color-instagram-50);
+}
+.background-color-instagram-500 {
+  background-color: var(--color-instagram-500);
+}
+.background-instagram-accent {
+  background: var(--color-instagram-accent);
+}
 
-.background-color-facebook-50 { background-color: var(--color-facebook-50) }
-.background-color-facebook-500 { background-color: var(--color-facebook-500) }
+.background-color-facebook-50 {
+  background-color: var(--color-facebook-50);
+}
+.background-color-facebook-500 {
+  background-color: var(--color-facebook-500);
+}
 
-.background-color-youtube-50 { background-color: var(--color-youtube-50) }
-.background-color-youtube-500 { background-color: var(--color-youtube-500) }
+.background-color-youtube-50 {
+  background-color: var(--color-youtube-50);
+}
+.background-color-youtube-500 {
+  background-color: var(--color-youtube-500);
+}
 
-.background-color-twitter-50 { background-color: var(--color-twitter-50) }
-.background-color-twitter-500 { background-color: var(--color-twitter-500) }
+.background-color-twitter-50 {
+  background-color: var(--color-twitter-50);
+}
+.background-color-twitter-500 {
+  background-color: var(--color-twitter-500);
+}
 
-.background-color-tiktok-50 { background-color: var(--color-tiktok-50) }
-.background-color-tiktok-500 { background-color: var(--color-tiktok-500) }
+.background-color-tiktok-50 {
+  background-color: var(--color-tiktok-50);
+}
+.background-color-tiktok-500 {
+  background-color: var(--color-tiktok-500);
+}
 
-.background-color-blog-50 { background-color: var(--color-blog-50) }
-.background-color-blog-500 { background-color: var(--color-blog-500) }
+.background-color-blog-50 {
+  background-color: var(--color-blog-50);
+}
+.background-color-blog-500 {
+  background-color: var(--color-blog-500);
+}
 
-.background-color-twitch-50 { background-color: var(--color-twitch-50) }
-.background-color-twitch-500 { background-color: var(--color-twitch-500) }
+.background-color-twitch-50 {
+  background-color: var(--color-twitch-50);
+}
+.background-color-twitch-500 {
+  background-color: var(--color-twitch-500);
+}
 
-.background-color-pinterest-50 { background: var(--color-pinterest-50) }
-.background-color-pinterest-500 { background: var(--color-pinterest-500) }
+.background-color-pinterest-50 {
+  background-color: var(--color-pinterest-50);
+}
+.background-color-pinterest-500 {
+  background-color: var(--color-pinterest-500);
+}
 
 // Easy to use font-colors as classes
-.font-color-primary-50 { color: var(--color-primary-50) }
-.font-color-primary-500 { color: var(--color-primary-500) }
+.font-color-primary-50 {
+  color: var(--color-primary-50);
+}
+.font-color-primary-500 {
+  color: var(--color-primary-500);
+}
 
-.font-color-accent { color: var(--color-accent) }
+.font-color-accent {
+  color: var(--color-accent);
+}
 
-.font-color-white { color: var(--color-white) }
-.font-color-black { color: var(--color-black) }
+.font-color-white {
+  color: var(--color-white);
+}
+.font-color-black {
+  color: var(--color-black);
+}
 
-.font-color-gray-300 { color: var(--color-gray-300) }
-.font-color-gray-500 { color: var(--color-gray-500) }
-.font-color-gray-900 { color: var(--color-gray-900) }
+.font-color-gray-300 {
+  color: var(--color-gray-300);
+}
+.font-color-gray-500 {
+  color: var(--color-gray-500);
+}
+.font-color-gray-900 {
+  color: var(--color-gray-900);
+}
 
-.font-color-success-500 { color: var(--color-success-500) }
-.font-color-info-500 { color: var(--color-info-500) }
-.font-color-warning-500 { color: var(--color-warning-500) }
-.font-color-error-500 { color: var(--color-error-500) }
+.font-color-success-500 {
+  color: var(--color-success-500);
+}
+.font-color-info-500 {
+  color: var(--color-info-500);
+}
+.font-color-warning-500 {
+  color: var(--color-warning-500);
+}
+.font-color-error-500 {
+  color: var(--color-error-500);
+}
 
-.font-color-orange-500 { color: var(--color-orange-500) }
-.font-color-yellow-500 { color: var(--color-yellow-500) }
-.font-color-lime-500 { color: var(--color-lime-500) }
-.font-color-cyan-500 { color: var(--color-cyan-500) }
-.font-color-blue-500 { color: var(--color-blue-500) }
-.font-color-violet-500 { color: var(--color-violet-500) }
+.font-color-orange-500 {
+  color: var(--color-orange-500);
+}
+.font-color-yellow-500 {
+  color: var(--color-yellow-500);
+}
+.font-color-lime-500 {
+  color: var(--color-lime-500);
+}
+.font-color-cyan-500 {
+  color: var(--color-cyan-500);
+}
+.font-color-blue-500 {
+  color: var(--color-blue-500);
+}
+.font-color-violet-500 {
+  color: var(--color-violet-500);
+}
 
-.font-color-instagram-500 { color: var(--color-instagram-500) }
-.font-color-facebook-500 { color: var(--color-facebook-500) }
-.font-color-youtube-500 { color: var(--color-youtube-500) }
-.font-color-twitter-500 { color: var(--color-twitter-500) }
-.font-color-tiktok-500 { color: var(--color-tiktok-500) }
-.font-color-blog-500 { color: var(--color-blog-500) }
-.font-color-twitch-500 { color: var(--color-twitch-500) }
-.font-color-pinterest-500 { color: var(--color-pinterest-500) }
+.font-color-instagram-500 {
+  color: var(--color-instagram-500);
+}
+.font-color-facebook-500 {
+  color: var(--color-facebook-500);
+}
+.font-color-youtube-500 {
+  color: var(--color-youtube-500);
+}
+.font-color-twitter-500 {
+  color: var(--color-twitter-500);
+}
+.font-color-tiktok-500 {
+  color: var(--color-tiktok-500);
+}
+.font-color-blog-500 {
+  color: var(--color-blog-500);
+}
+.font-color-twitch-500 {
+  color: var(--color-twitch-500);
+}
+.font-color-pinterest-500 {
+  color: var(--color-pinterest-500);
+}

--- a/app/styles/core-v2/_colors.stories.mdx
+++ b/app/styles/core-v2/_colors.stories.mdx
@@ -335,6 +335,9 @@ All social media colors
         <span>--color-instagram-500</span>
         <span>#C13584</span>
       </div>
+      <div class="color-container-v2 color-instagram-accent">
+        <span>--color-instagram-accent</span>
+      </div>
     </div>
     <div class="palette-container">
       <div class="color-container-v2 color-facebook-50">


### PR DESCRIPTION
### What does this PR do?
Add new Instagram accent color:
- add `--color-instagram-accent` CSS variable
- add `.background-instagram-accent` class. I don't set `color` in the name because the color is apply on `background` and not `background-color`. `radial-gradient` only work in background attribute
- first time we use prettier on these files, ok 🤷‍♂️

Related to: Victor (see [OSS Tokens](https://www.figma.com/file/i92PsCj4g8zHhZ5OsrFAcV/1.0-OSS-Tokens-%F0%9F%8C%88) update)

### What are the observable changes?
![Screenshot from 2022-10-12 17-02-58](https://user-images.githubusercontent.com/43567222/195390806-9fc6e6cc-bef9-4eb7-ac85-134ccd92f977.png)

### Good PR checklist
- [x] Title makes sense
- [x] Is against the correct branch
- [ ] Only addresses one issue
- [x] Properly assigned
- [ ] Added/updated tests
- [x] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled
