### PR TITLE
Removed ModalDialog responsiveness :(

### DIFF
--- a/app/styles/modal-dialog.less
+++ b/app/styles/modal-dialog.less
@@ -56,8 +56,6 @@
 
   &--content {
     padding: @spacing-sm;
-    max-height: calc(~'100vh - 148px');
-    overflow-y: auto;
   }
 }
 


### PR DESCRIPTION
### What does this PR do?

Removing ModalDialog responsiveness due to issues it creates with dropdowns inside the modals.

Related to: #[2021](https://github.com/upfluence/backlog/issues/2021)

### Good PR checklist
- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled