### PR TITLE
Added: min-width0 on fx-1 to prevent usage of allow-text-overflow-on-children

### DIFF
--- a/app/styles/utilities/_flex.less
+++ b/app/styles/utilities/_flex.less
@@ -1,5 +1,8 @@
 .fx {
-  &-1 { flex: 1 }
+  &-1 {
+    flex: 1;
+    min-width: 0; // prevents adding "allow-text-overflow-on-children" class everywhere needed
+  }
 
   // Flex Direction definition
   &-row {


### PR DESCRIPTION
…children

### What does this PR do?
Added: min-width0 on fx-1 to prevent usage of allow-text-overflow-on-children

Related to: #[2052](https://github.com/upfluence/backlog/issues/2052)

### Good PR checklist
- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled