### PR TITLE
Alerts: allow an optional method to be called when the alert is closed

### DIFF
--- a/addon/components/o-s-s/alert.stories.js
+++ b/addon/components/o-s-s/alert.stories.js
@@ -56,6 +56,15 @@ export default {
       control: {
         type: 'boolean'
       }
+    },
+    onClose: {
+      type: { required: false },
+      description: 'Function to be called with the alert is closed',
+      table: {
+        type: {
+          summary: 'onClose(): void'
+        }
+      }
     }
   },
   parameters: {

--- a/addon/components/o-s-s/alert.ts
+++ b/addon/components/o-s-s/alert.ts
@@ -11,6 +11,7 @@ interface OSSAlertArgs {
   subtitle?: string;
   plain?: boolean;
   closable?: boolean;
+  onClose?(): void;
 }
 
 export default class OSSAlert extends Component<OSSAlertArgs> {
@@ -44,6 +45,7 @@ export default class OSSAlert extends Component<OSSAlertArgs> {
 
   @action
   removeSelf(): void {
+    this.args.onClose?.();
     this._DOMElement?.remove();
   }
 }

--- a/tests/integration/components/o-s-s/alert-test.ts
+++ b/tests/integration/components/o-s-s/alert-test.ts
@@ -1,7 +1,8 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render, click } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
+import sinon from 'sinon';
 
 const ALERT_SKINS = ['success', 'error', 'info', 'warning'];
 const ICONS: { [index: string]: string } = {
@@ -85,6 +86,14 @@ module('Integration | Component | o-s-s/alert', function (hooks) {
 
       assert.dom('.upf-alert').exists();
       assert.dom('.upf-alert .main-container .fx-col i').doesNotExist();
+    });
+
+    test('clicking the cross icon also calls the onClose argument provided', async function (assert) {
+      this.onClose = sinon.stub();
+      await render(hbs`<div><OSS::Alert @closable={{true}} @onClose={{this.onClose}} /></div>`);
+      await click('.upf-alert .main-container .fx-col i');
+      assert.ok(this.onClose.calledOnce);
+      assert.dom('.upf-alert').doesNotExist();
     });
   });
 


### PR DESCRIPTION
### What does this PR do?

Adds support for telling the parent context that an alert has been closed.

### What are the observable changes?
<!-- This question could be adequate with multiple use cases, for example: -->

<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->

### Good PR checklist
- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [x] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled
