### PR TITLE
Update Code-block component visuals

### DIFF
--- a/addon/components/o-s-s/code-block.hbs
+++ b/addon/components/o-s-s/code-block.hbs
@@ -7,10 +7,10 @@
     </pre>
   </div>
   {{#if @copyable}}
-    <div class="floating-copy-btn {{if @scrollable 'position-fix'}}">
-      <OSS::Button @skin="secondary"
+    <div class="floating-copy-btn">
+      <OSS::Button @skin="default" @size="sm"
                    @label={{t "oss-components.code-block.copy"}}
-                   @icon="fa fa-copy" {{on "click" this.copyToClipboard}} />
+                   {{on "click" this.copyToClipboard}} />
     </div>
   {{/if}}
   {{#if this.collapsable}}

--- a/app/styles/code-block.less
+++ b/app/styles/code-block.less
@@ -5,11 +5,10 @@
 
   .floating-copy-btn {
     position: absolute;
-    top: 1px;
-    right: 1px;
     background-color: var(--color-gray-50);
     border-radius: @default-radius;
-    padding: @spacing-xx-sm;
+    top: 0;
+    right: 0;
   }
 
   .floating-collapse-btn {
@@ -21,10 +20,6 @@
     right: 0;
     text-align: center;
     width: 120px;
-  }
-
-  .position-fix {
-    right: 30px;
   }
 
   .code-container.scrollable {
@@ -60,6 +55,7 @@
     }
     pre.code code {
       counter-increment: listing;
+      white-space: pre;
     }
     pre.code code::before {
       background-color: var(--color-gray-100);


### PR DESCRIPTION
### What does this PR do?
Updated: code block component visuals

Old visuals :
![Screenshot 2022-10-20 at 11 25 55](https://user-images.githubusercontent.com/5032005/196910828-5c036ed8-15e8-453b-9508-01660b6475f1.png)

New visuals :
![Screenshot 2022-10-20 at 11 25 32](https://user-images.githubusercontent.com/5032005/196910877-285d50e9-caad-4e1a-8194-dfe8e4543196.png)


Related to: #https://github.com/upfluence/backlog/issues/2045

### Good PR checklist
- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled