### PR TITLE
Add OSS::InputGroup component

### DIFF
--- a/addon/components/o-s-s/input-container.stories.js
+++ b/addon/components/o-s-s/input-container.stories.js
@@ -35,6 +35,16 @@ export default {
       },
       control: { type: 'text' }
     },
+    errorMessage: {
+      description: 'An error message that will be displayed below the input-group.',
+      table: {
+        type: {
+          summary: 'string'
+        },
+        defaultValue: { summary: false }
+      },
+      control: { type: 'text' }
+    },
     onChange: {
       type: { name: 'Method' },
       description: 'Method called every time the input is updated',
@@ -57,13 +67,18 @@ export default {
 
 const DefaultUsageTemplate = (args) => ({
   template: hbs`
-      <OSS::InputContainer class="margin-bottom-sm" @value={{this.value}} />
+      <OSS::InputContainer @value={{this.value}} @disabled={{this.disabled}} @placeholder={{this.placeholder}}
+                           @errorMessage={{this.errorMessage}} @onChange={{this.onChange}} />
   `,
   context: args
 });
 export const BasicUsage = DefaultUsageTemplate.bind({});
 BasicUsage.args = {
-  value: 'John'
+  value: 'John',
+  disabled: false,
+  placeholder: 'this is the placeholder',
+  errorMessage: '',
+  onChange: action('')
 };
 
 const BasicWithParametersTemplate = (args) => ({

--- a/addon/components/o-s-s/input-group.hbs
+++ b/addon/components/o-s-s/input-group.hbs
@@ -1,0 +1,18 @@
+<div class="oss-input-group fx-1 fx-col" ...attributes>
+  <div class="fx-1 fx-row fx-xalign-center oss-input-group-row {{if @errorMessage 'oss-input-group-row--error'}}">
+    {{#if @prefix}}
+      <div class="oss-input-group-row-prefix">{{@prefix}}</div>
+    {{/if}}
+    <div class="fx-1">
+      <OSS::InputContainer @value={{@value}} @disabled={{@disabled}}
+                           @placeholder={{@placeholder}} @onChange={{@onChange}}
+                           class="{{if @prefix 'prefix-radius-fix'}} {{if @suffix 'suffix-radius-fix'}}" />
+    </div>
+    {{#if @suffix}}
+      <div class="oss-input-group-row-suffix">{{@suffix}}</div>
+    {{/if}}
+  </div>
+  {{#if @errorMessage}}
+    <span class="text-color-error margin-top-xxx-sm">{{@errorMessage}}</span>
+  {{/if}}
+</div>

--- a/addon/components/o-s-s/input-group.stories.js
+++ b/addon/components/o-s-s/input-group.stories.js
@@ -1,0 +1,82 @@
+import hbs from 'htmlbars-inline-precompile';
+import { action } from '@storybook/addon-actions';
+
+export default {
+  title: 'Components/OSS::InputGroup',
+  component: 'input-group',
+  argTypes: {
+    value: {
+      description: 'Value of the input',
+      table: {
+        type: {
+          summary: 'string'
+        },
+        defaultValue: { summary: false }
+      },
+      control: { type: 'text' }
+    },
+    disabled: {
+      description: 'Disable the default input (when not passing an input named block)',
+      table: {
+        type: {
+          summary: 'boolean'
+        },
+        defaultValue: { summary: false }
+      },
+      control: { type: 'boolean' }
+    },
+    placeholder: {
+      description: 'Placeholder of the input',
+      table: {
+        type: {
+          summary: 'string'
+        },
+        defaultValue: { summary: false }
+      },
+      control: { type: 'text' }
+    },
+    errorMessage: {
+      description: 'An error message that will be displayed below the input-group.',
+      table: {
+        type: {
+          summary: 'string'
+        },
+        defaultValue: { summary: false }
+      },
+      control: { type: 'text' }
+    },
+    onChange: {
+      type: { name: 'Method' },
+      description: 'Method called every time the input is updated',
+      table: {
+        type: {
+          summary: 'onChange(value: string): void'
+        }
+      },
+      control: { type: null }
+    }
+  },
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'The OSS version of the input-group component. This component exposes the same arguments as the input-container as well as a suffix & a prefix.'
+      }
+    }
+  }
+};
+
+const DefaultUsageTemplate = (args) => ({
+  template: hbs`
+      <OSS::InputGroup @prefix={{this.prefix}} @suffix={{this.suffix}} @value={{this.value}}
+                       @errorMessage={{this.errorMessage}} />
+  `,
+  context: args
+});
+export const BasicUsage = DefaultUsageTemplate.bind({});
+BasicUsage.args = {
+  value: 'John',
+  prefix: 'email',
+  suffix: '@domain.com',
+  errorMessage: ''
+};

--- a/addon/components/o-s-s/input-group.ts
+++ b/addon/components/o-s-s/input-group.ts
@@ -1,0 +1,23 @@
+import Component from '@glimmer/component';
+import { assert } from '@ember/debug';
+
+interface OSSInputGroupArgs {
+  value?: string;
+  disabled?: boolean;
+  errorMessage?: string;
+  placeholder?: string;
+  prefix?: string;
+  suffix?: string;
+  onChange?(value: string): void;
+}
+
+export default class OSSInputGroup extends Component<OSSInputGroupArgs> {
+  constructor(owner: unknown, args: OSSInputGroupArgs) {
+    super(owner, args);
+
+    assert(
+      '[component][OSS::InputGroup] No @prefix or @suffix parameter were passed. If you are not going to use any, you might as well use an OSS::InputContainer. You little piece of shit. :)',
+      args.prefix || args.suffix
+    );
+  }
+}

--- a/app/components/o-s-s/input-group.js
+++ b/app/components/o-s-s/input-group.js
@@ -1,0 +1,1 @@
+export { default } from '@upfluence/oss-components/components/o-s-s/input-group';

--- a/app/styles/base/_inputs.less
+++ b/app/styles/base/_inputs.less
@@ -28,7 +28,7 @@ label {
 
   &:focus {
     .remove-outline;
-    border: 1px solid @border-color;
+    border: 1px solid var(--color-gray-300);
   }
 
   &::placeholder { color: @color-text-lighter }

--- a/app/styles/input-group.less
+++ b/app/styles/input-group.less
@@ -1,0 +1,66 @@
+.oss-input-group {
+  .oss-input-group-row {
+    &-prefix,
+    &-suffix {
+      display: flex;
+      align-items: center;
+      border: 1px solid var(--color-gray-100);
+      height: @input-size-default;
+      padding-left: var(--spacing-px-12);
+      padding-right: var(--spacing-px-12);
+    }
+
+    &-prefix {
+      border-top-left-radius: var(--border-radius-sm);
+      border-bottom-left-radius: var(--border-radius-sm);
+    }
+
+    &-suffix {
+      border-top-right-radius: var(--border-radius-sm);
+      border-bottom-right-radius: var(--border-radius-sm);
+    }
+
+    .suffix-radius-fix input {
+      border-top-right-radius: 0;
+      border-bottom-right-radius: 0;
+    }
+
+    .prefix-radius-fix input {
+      border-top-left-radius: 0;
+      border-bottom-left-radius: 0;
+    }
+
+    &--error {
+      input {
+        .border;
+        .border-color-error;
+        .border-radius-default;
+      }
+
+      .oss-input-group-row-prefix {
+        .border-color-error;
+        border-right: 0;
+      }
+
+      .oss-input-group-row-suffix {
+        .border-color-error;
+        border-left: 0;
+      }
+    }
+  }
+
+  &:focus-within .oss-input-group-row-suffix {
+    border-color: var(--color-gray-300);
+    border-left: 0;
+  }
+
+  &:focus-within .oss-input-group-row-prefix {
+    border-color: var(--color-gray-300);
+    border-right: 0;
+  }
+
+  &-row--error:focus-within .oss-input-group-row-prefix,
+  &-row--error:focus-within .oss-input-group-row-suffix {
+    .border-color-error;
+  }
+}

--- a/app/styles/oss-components.less
+++ b/app/styles/oss-components.less
@@ -10,6 +10,7 @@
 
 @import 'toggle-switch';
 @import 'input-container';
+@import 'input-group';
 @import 'array-input';
 @import 'power-select';
 @import 'toast';

--- a/tests/dummy/app/controllers/application.js
+++ b/tests/dummy/app/controllers/application.js
@@ -58,6 +58,7 @@ export default class ApplicationController extends Controller {
   @tracked loading = false;
   @tracked phonePrefix = '+33';
   @tracked phoneNumber = '782828282';
+  @tracked inputValue = '';
   @tracked currency = 'EUR';
   @tracked currencyValue = 42.13;
   @tracked showModal = false;

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -1,3 +1,9 @@
+<div class="fx-row fx-xalign-start fx-gap-px-10 margin-md">
+  <OSS::InputGroup @value={{this.inputValue}} @prefix="This" @placeholder="makes no" @suffix="sense"
+                   @errorMessage="This is an error message" />
+  <OSS::InputGroup @value={{this.inputValue}} @prefix="@" @placeholder="Username" />
+  <OSS::InputGroup @value={{this.inputValue}} @suffix="@example.com" @placeholder="john.doe" />
+</div>
 <div class="fx-row fx-gap-px-10 margin-md">
   <OSS::RadioButton @selected={{this.radio1}} @onChange={{fn this.onRadioBtnChange "radio1"}} />
   <OSS::RadioButton @selected={{this.radio2}} @onChange={{fn this.onRadioBtnChange "radio2"}} />

--- a/tests/integration/components/o-s-s/input-group-test.ts
+++ b/tests/integration/components/o-s-s/input-group-test.ts
@@ -1,0 +1,58 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render, setupOnerror } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Component | o-s-s/input-group', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function (assert) {
+    await render(hbs`<OSS::InputGroup @prefix="username" />`);
+    assert.dom('.oss-input-group').exists();
+  });
+
+  test('it fails if no prefix or suffix parameters are passed', async function (assert: Assert) {
+    setupOnerror((err: Error) => {
+      assert.equal(
+        err.message,
+        'Assertion Failed: [component][OSS::InputGroup] No @prefix or @suffix parameter were passed. If you are not going to use any, you might as well use an OSS::InputContainer. You little piece of shit. :)'
+      );
+    });
+
+    await render(hbs`<OSS::InputGroup />`);
+  });
+
+  test('Passing the @prefix parameter displays the input prefix', async function (assert) {
+    await render(hbs`<OSS::InputGroup @prefix="username" />`);
+    assert.dom('.oss-input-group-row-prefix').hasText('username');
+  });
+
+  test('Passing the @suffix parameter displays the input suffix', async function (assert) {
+    await render(hbs`<OSS::InputGroup @suffix="@domain.com" />`);
+    assert.dom('.oss-input-group-row-suffix').hasText('@domain.com');
+  });
+
+  test('Passing the @suffix parameter displays the input suffix', async function (assert) {
+    await render(hbs`<OSS::InputGroup @prefix="email" @suffix="@domain.com" />`);
+    assert.dom('.oss-input-group-row-prefix').hasText('email');
+    assert.dom('.oss-input-group-row-suffix').hasText('@domain.com');
+  });
+
+  test('Passing the @errorMessage parameter displays the error message', async function (assert) {
+    await render(hbs`<OSS::InputGroup @suffix="@domain.com" @errorMessage="This is an error." />`);
+    assert.dom('.oss-input-group-row--error').exists();
+    assert.dom('.oss-input-group span').hasText('This is an error.');
+  });
+
+  test('Passing the @errorMessage sets an error border on the whole compoenent', async function (assert) {
+    await render(hbs`<OSS::InputGroup @prefix="random" @suffix="@domain.com" @errorMessage="This is an error." />`);
+    assert.dom('.oss-input-group-row--error').exists();
+    assert.dom('input').hasStyle({ borderColor: 'rgb(254, 37, 24)' });
+    assert
+      .dom('.oss-input-group-row-prefix')
+      .hasStyle({ borderColor: 'rgb(254, 37, 24) rgb(27, 30, 33) rgb(254, 37, 24) rgb(254, 37, 24)' });
+    assert
+      .dom('.oss-input-group-row-suffix')
+      .hasStyle({ borderColor: 'rgb(254, 37, 24) rgb(254, 37, 24) rgb(254, 37, 24) rgb(27, 30, 33)' });
+  });
+});


### PR DESCRIPTION
### What does this PR do?
Add OSS::InputGroup compo
![Screenshot 2022-10-21 at 15 30 13](https://user-images.githubusercontent.com/5032005/197212696-a1277038-b617-4d5f-8041-34cddc12df45.png)
nent

Related to: #https://github.com/upfluence/backlog/issues/2016

### Good PR checklist
- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [x] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled