### PR TITLE
Add support for a named-block to display the selected item

### DIFF
--- a/addon/components/o-s-s/select.hbs
+++ b/addon/components/o-s-s/select.hbs
@@ -4,7 +4,11 @@
   <div class="upf-input fx-row fx-1 fx-xalign-center">
     <div class="fx-row fx-1 fx-malign-space-between fx-xalign-center" role="button" {{on "click" this.toggleSelector}}>
       {{#if @value}}
-        <span>{{get @value this.targetValue}}</span>
+        {{#if (has-block "selected")}}
+          {{yield @value to="selected"}}
+        {{else}}
+          <span>{{get @value this.targetValue}}</span>
+        {{/if}}
       {{else}}
         <span class="text-color-default-light">{{this.placeholder}}</span>
       {{/if}}

--- a/addon/components/o-s-s/select.stories.js
+++ b/addon/components/o-s-s/select.stories.js
@@ -136,6 +136,27 @@ const Template = (args) => ({
   context: args
 });
 
+const WithSelectedNamedBlockTemplate = (args) => ({
+  template: hbs`
+  <div style="width: 400px">
+    <OSS::Select
+      @items={{this.items}} @value={{this.value}} @placeholder={{this.placeholder}}
+      @disabled={{this.disabled}} @errorMessage={{this.errorMessage}} @successMessage={{this.successMessage}}
+      @onSearch={{this.onSearch}} @onChange={{this.onChange}}>
+      <:selected as |option|>
+        With named block — {{option.name}}
+      </:selected>
+      <:option as |item|>
+        {{item.name}}
+      </:option>
+    </OSS::Select>
+  </div>
+  `,
+  context: args
+});
+export const WithSelectedNamedBlock = WithSelectedNamedBlockTemplate.bind({});
+WithSelectedNamedBlock.args = defaultArgs;
+
 export const Default = Template.bind({});
 Default.args = {
   ...defaultArgs

--- a/tests/integration/components/o-s-s/select-test.ts
+++ b/tests/integration/components/o-s-s/select-test.ts
@@ -151,6 +151,24 @@ module('Integration | Component | o-s-s/select', function (hooks) {
       assert.dom('.upf-infinite-select .upf-infinite-select__item:first-child .item-wrapper').hasClass('selected');
       assert.dom('.upf-infinite-select .upf-infinite-select__item:first-child .item-wrapper i.far.fa-check').exists();
     });
+
+    test('the selected value is displayed using the selected named block if provided', async function (assert) {
+      this.value = this.items[0];
+      await render(
+        hbs`
+          <OSS::Select @onChange={{this.onChange}} @items={{this.items}} @value={{this.value}} @placeholder="my placeholder">
+            <:selected as |value|>
+              Selected value: {{value.name}}
+            </:selected>
+            <:option as |item|>
+              {{item.name}}
+            </:option>
+          </OSS::Select>
+        `
+      );
+
+      assert.dom('.upf-input').hasText('Selected value: foo');
+    });
   });
 
   module('disabled state', function () {


### PR DESCRIPTION
### What does this PR do?

Add support for a named-block to display the selected item as currently only a string label is supported. This will allow us to have more visual selected items just like in the options.

### What are the observable changes?
<!-- This question could be adequate with multiple use cases, for example: -->

<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->

### Good PR checklist
- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [x] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled
