### PR TITLE
OSS::Alert - Stop propagation of closable event

### DIFF
--- a/addon/components/o-s-s/alert.ts
+++ b/addon/components/o-s-s/alert.ts
@@ -44,7 +44,8 @@ export default class OSSAlert extends Component<OSSAlertArgs> {
   }
 
   @action
-  removeSelf(): void {
+  removeSelf(event: PointerEvent): void {
+    event.stopPropagation();
     this.args.onClose?.();
     this._DOMElement?.remove();
   }


### PR DESCRIPTION
### What does this PR do?

Stop propagation of closable event. A bug appear when alert is in modal and close it too.

Related to: https://github.com/upfluence/backlog/issues/2166

### What are the observable changes?

### Good PR checklist
- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled
