### PR TITLE
Fix tooltip not destroyed & distortion on right placement

### DIFF
--- a/addon/utils/dope.ts
+++ b/addon/utils/dope.ts
@@ -19,6 +19,9 @@ export default class DynamicObjectPlacement {
   declare elementOptions: ElementOptions;
   declare arrowOptions: ArrowOptions;
 
+  elementWidth = 0;
+  elementHeight = 0;
+
   computePosition(
     element: HTMLElement,
     target: HTMLElement,
@@ -27,8 +30,10 @@ export default class DynamicObjectPlacement {
   ): void {
     this.elementOptions = elementOptions;
     this.arrowOptions = arrowOptions;
+    this.elementHeight = element.offsetHeight;
+    this.elementWidth = element.offsetWidth;
 
-    this.overflowPlacementCorrection(element, target);
+    this.overflowPlacementCorrection(target);
     this.computeElementPosition(element, target);
     this.verticalAdjustmentRelativeToViewPort(element);
     this.horizontalAdjustmentRelativeToViewPort(element);
@@ -38,12 +43,12 @@ export default class DynamicObjectPlacement {
   }
 
   private computeElementPosition(element: HTMLElement, target: HTMLElement) {
-    const elementTop = this.computedElementTopPosition(element, target);
+    const elementTop = this.computedElementTopPosition(target);
+    const elementLeft = this.computedElementLeftPosition(target);
     element.style.setProperty(
       `${CSS_VARIABLE_NAME_PREFIX}${this.elementOptions.cssVariableName}-top`,
       `${elementTop}px`
     );
-    const elementLeft = this.computedElementLeftPosition(element, target);
     element.style.setProperty(
       `${CSS_VARIABLE_NAME_PREFIX}${this.elementOptions.cssVariableName}-left`,
       `${elementLeft}px`
@@ -69,11 +74,10 @@ export default class DynamicObjectPlacement {
     );
   }
 
-  private overflowPlacementCorrection(element: HTMLElement, target: HTMLElement): void {
+  private overflowPlacementCorrection(target: HTMLElement): void {
     const elementTotalHeight =
-      element.offsetHeight + this.elementOptions.viewportOffset + this.elementOptions.targetOffset;
-    const elementTotalWidth =
-      element.offsetWidth + this.elementOptions.viewportOffset + this.elementOptions.targetOffset;
+      this.elementHeight + this.elementOptions.viewportOffset + this.elementOptions.targetOffset;
+    const elementTotalWidth = this.elementWidth + this.elementOptions.viewportOffset + this.elementOptions.targetOffset;
 
     if (this.elementOptions.placement === 'top' && target.getBoundingClientRect().top < elementTotalHeight) {
       this.elementOptions.placement = 'bottom';
@@ -92,37 +96,37 @@ export default class DynamicObjectPlacement {
     }
   }
 
-  private computedElementLeftPosition(element: HTMLElement, target: HTMLElement): number {
+  private computedElementLeftPosition(target: HTMLElement): number {
     const targetBoundingClientRect = target.getBoundingClientRect();
     const targetLeftRelativeToDocument = targetBoundingClientRect.left + document.documentElement.scrollLeft;
 
     switch (this.elementOptions.placement) {
       case 'top':
-        return targetLeftRelativeToDocument + target.offsetWidth / 2 - element.offsetWidth / 2;
+        return targetLeftRelativeToDocument + target.offsetWidth / 2 - this.elementWidth / 2;
       case 'bottom':
-        return targetLeftRelativeToDocument + target.offsetWidth / 2 - element.offsetWidth / 2;
+        return targetLeftRelativeToDocument + target.offsetWidth / 2 - this.elementWidth / 2;
       case 'right':
         return targetLeftRelativeToDocument + target.offsetWidth + this.elementOptions.targetOffset;
       case 'left':
-        return targetLeftRelativeToDocument - element.offsetWidth - this.elementOptions.targetOffset;
+        return targetLeftRelativeToDocument - this.elementWidth - this.elementOptions.targetOffset;
       default:
         return 0;
     }
   }
 
-  private computedElementTopPosition(element: HTMLElement, target: HTMLElement): number {
+  private computedElementTopPosition(target: HTMLElement): number {
     const targetBoundingClientRect = target.getBoundingClientRect();
     const targetTopRelativeToDocument = targetBoundingClientRect.top + document.documentElement.scrollTop;
 
     switch (this.elementOptions.placement) {
       case 'top':
-        return targetTopRelativeToDocument - element.offsetHeight - this.elementOptions.targetOffset;
+        return targetTopRelativeToDocument - this.elementHeight - this.elementOptions.targetOffset;
       case 'bottom':
         return targetTopRelativeToDocument + target.offsetHeight + this.elementOptions.targetOffset;
       case 'right':
-        return targetTopRelativeToDocument + target.offsetHeight / 2 - element.offsetHeight / 2;
+        return targetTopRelativeToDocument + target.offsetHeight / 2 - this.elementHeight / 2;
       case 'left':
-        return targetTopRelativeToDocument + target.offsetHeight / 2 - element.offsetHeight / 2;
+        return targetTopRelativeToDocument + target.offsetHeight / 2 - this.elementHeight / 2;
       default:
         return 0;
     }
@@ -156,10 +160,10 @@ export default class DynamicObjectPlacement {
       element.style.setProperty('--upf-modifier-tooltip-left', `${currentTopValue + correctionValue}px`);
     }
 
-    if (elementBoundingClientRect.left + element.offsetWidth - this.elementOptions.viewportOffset > window.innerWidth) {
+    if (elementBoundingClientRect.left + this.elementWidth - this.elementOptions.viewportOffset > window.innerWidth) {
       const currentTopValue = parseInt(element.style.getPropertyValue('--upf-modifier-tooltip-left').replace('px', ''));
       const correctionValue =
-        elementBoundingClientRect.left + element.offsetWidth + this.elementOptions.viewportOffset - window.innerWidth;
+        elementBoundingClientRect.left + this.elementWidth + this.elementOptions.viewportOffset - window.innerWidth;
       element.style.setProperty('--upf-modifier-tooltip-left', `${currentTopValue - correctionValue}px`);
     }
   }
@@ -178,7 +182,7 @@ export default class DynamicObjectPlacement {
       case 'right':
         return 0 - this.arrowOptions.width - rotationAdjustment;
       case 'left':
-        return element.offsetWidth + rotationAdjustment;
+        return this.elementWidth + rotationAdjustment;
       default:
         return 0;
     }
@@ -191,7 +195,7 @@ export default class DynamicObjectPlacement {
 
     switch (this.elementOptions.placement) {
       case 'top':
-        return element.offsetHeight;
+        return this.elementHeight;
       case 'bottom':
         return 0 - this.arrowOptions.height;
       case 'right':

--- a/app/styles/layouts/_header.less
+++ b/app/styles/layouts/_header.less
@@ -10,7 +10,8 @@
     width: 100%;
     padding: @spacing-xxx-sm @spacing-xxx-sm;
 
-    a, a:hover {
+    a,
+    a:hover {
       /*.reset-link;*/
     }
 
@@ -27,7 +28,8 @@
     font-size: 1.2em;
     text-align: center;
 
-    a, i {
+    a,
+    i {
       color: @color-text-contrast;
       text-decoration: none !important;
     }
@@ -43,8 +45,8 @@
   padding: 0;
   top: 0;
   width: 5em;
-  z-index: 9999999;
-  box-shadow: 10px 0 10px -10px rgba(0,0,0,0.1);
+  z-index: 9998;
+  box-shadow: 10px 0 10px -10px rgba(0, 0, 0, 0.1);
 
   .logo-container {
     margin-top: 0;
@@ -96,7 +98,9 @@
 
     // Only change the color of the icons in the sidebar when it's active
     // route.
-    a.active, a.active i, a.active .upf-icon {
+    a.active,
+    a.active i,
+    a.active .upf-icon {
       color: @upf-primary-white;
       border-bottom: none;
       background-color: @upf-primary-bright-purple;
@@ -125,7 +129,8 @@
   display: inline-flex;
   position: absolute;
 
-  .app-header__left-side, .app-header__right-side {
+  .app-header__left-side,
+  .app-header__right-side {
     display: flex;
     align-items: center;
 


### PR DESCRIPTION
### What does this PR do?

- Not launch a delay rendering if one is in progress
- Move logic event destroy in dedicated function
- In `dope.ts`, store height & width element to avoid distortion on the right and bottom of the view port

Related to: https://github.com/upfluence/backlog/issues/2273

### What are the observable changes?
Tooltip disappears.

### Good PR checklist
- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled
