### PR TITLE
Add the ability to preview image in uploader

### DIFF
--- a/addon/components/o-s-s/upload-area.hbs
+++ b/addon/components/o-s-s/upload-area.hbs
@@ -56,7 +56,8 @@
           @rules={{@rules}} @scope={{this.scope}} @privacy={{this.filePrivacy}}
           @onEdition={{fn this.onFileEdition index}}
           @onDeletion={{fn this.onFileDeletion index}}
-          @onUploadSuccess={{fn this.onUploadSuccess index}} />
+          @onUploadSuccess={{fn this.onUploadSuccess index}}
+          @displayPreview={{@displayPreview}} />
       {{/each}}
     </div>
   {{/if}}

--- a/addon/components/o-s-s/upload-area.stories.js
+++ b/addon/components/o-s-s/upload-area.stories.js
@@ -103,6 +103,15 @@ export default {
       },
       control: { type: 'boolean' }
     },
+    displayPreview: {
+      description: 'Wether or not the image should be displayed in the badge after a successful upload.',
+      table: {
+        type: {
+          summary: 'boolean'
+        },
+        defaultValue: { summary: false }
+      }
+    },
     onUploadSuccess: {
       description:
         'Action called when the file is upload with success. This action has two definitions:<br>' +

--- a/addon/components/o-s-s/upload-area.ts
+++ b/addon/components/o-s-s/upload-area.ts
@@ -22,6 +22,7 @@ interface OSSUploadAreaArgs {
   artifact?: FileArtifact;
   size?: 'lg' | 'md';
   multiple?: boolean;
+  displayPreview?: boolean;
 
   onUploadSuccess(artifact: FileArtifact): void;
   onFileDeletion?(): void;

--- a/addon/components/o-s-s/upload-item.hbs
+++ b/addon/components/o-s-s/upload-item.hbs
@@ -1,5 +1,9 @@
 <div class="oss-upload-item {{if this.error 'oss-upload-item--errored'}}">
-  <OSS::Badge @icon={{this.icon}} />
+  {{#if this.shouldDisplayPreview}}
+    <OSS::Badge @image={{this.fileUrl}} />
+  {{else}}
+    <OSS::Badge @icon={{this.icon}} />
+  {{/if}}
 
   <div class="fx-row fx-1 fx-malign-space-between fx-xalign-center allow-text-overflow-on-children">
     <div class="fx-col fx-gap-px-3 allow-text-overflow-on-children">

--- a/addon/components/o-s-s/upload-item.stories.js
+++ b/addon/components/o-s-s/upload-item.stories.js
@@ -62,6 +62,15 @@ export default {
       },
       control: { type: 'text' }
     },
+    displayPreview: {
+      description: 'Wether or not the image should be displayed in the badge after a successful upload.',
+      table: {
+        type: {
+          summary: 'boolean'
+        },
+        defaultValue: { summary: false }
+      }
+    },
     onEdition: {
       description: 'Action triggers when the user click on the edition button',
       table: {

--- a/addon/components/o-s-s/upload-item.ts
+++ b/addon/components/o-s-s/upload-item.ts
@@ -17,6 +17,7 @@ interface OSSUploadItemArgs {
   rules: FileValidator[];
   privacy: FilePrivacy;
   scope: string;
+  displayPreview?: boolean;
   onEdition(): void;
   onDeletion(): void;
   onUploadSuccess(artifact: FileArtifact): void;
@@ -76,6 +77,14 @@ export default class OSSUploadItem extends Component<OSSUploadItemArgs> {
     return `
         background-image: conic-gradient(var(--color-primary-500) ${angle}deg, transparent ${angle + 0.5}deg 100%),
                           conic-gradient(var(--color-border-default) 360deg 100%);`;
+  }
+
+  get displayPreview(): boolean {
+    return this.args.displayPreview || false;
+  }
+
+  get shouldDisplayPreview(): boolean {
+    return this.displayPreview && Boolean(this.fileUrl) && this._extractFileTypeCategory() === 'image';
   }
 
   @action

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -423,7 +423,8 @@
                      @subtitle="JPG, PNG, PDF (Max 800x400px - 2MB)" @onUploadSuccess={{this.onUploadSuccess}} />
 
     <OSS::UploadArea @uploader={{this.mockUploader}} @rules={{array (hash type="filesize" value="8MB")}}
-                     @subtitle="JPG, PNG, PDF (Max 800x400px - 2MB)" @onUploadSuccess={{this.onUploadSuccess}} />
+                     @subtitle="JPG, PNG, PDF (Max 800x400px - 2MB)" @onUploadSuccess={{this.onUploadSuccess}}
+                     @displayPreview={{true}} />
   </div>
 
   <div class="fx-col fx-gap-px-12">


### PR DESCRIPTION
### What does this PR do?
Adds the ability to preview image in uploader, will replace the badge content (icon) with the uploaded image.

Related to: #https://github.com/upfluence/backlog/issues/2284

### Good PR checklist
- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [ ] Added/updated tests
- [x] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled