### PR TITLE
Fix text-ellipsis on upload-item

### DIFF
--- a/addon/components/o-s-s/upload-area.hbs
+++ b/addon/components/o-s-s/upload-area.hbs
@@ -1,4 +1,4 @@
-<div class="oss-upload-area-container fx-1 allow-text-overflow-on-children">
+<div class="oss-upload-area-container fx-1">
   {{#if this.displayUploadArea}}
     <div class={{this.computedClass}}
          {{on "dragover" this._allowDropEvent}}

--- a/addon/components/o-s-s/upload-item.hbs
+++ b/addon/components/o-s-s/upload-item.hbs
@@ -5,8 +5,8 @@
     <OSS::Badge @icon={{this.icon}} />
   {{/if}}
 
-  <div class="fx-row fx-1 fx-malign-space-between fx-xalign-center allow-text-overflow-on-children">
-    <div class="fx-col fx-gap-px-3 allow-text-overflow-on-children">
+  <div class="fx-row fx-1 fx-malign-space-between fx-xalign-center">
+    <div class="fx-col fx-1 fx-gap-px-3">
       <span class="font-color-gray-900 text-ellipsis padding-right-px-12" data-control-name="upload-item-filename">
         {{this.filename}}
       </span>

--- a/app/styles/core-v2/_typography.less
+++ b/app/styles/core-v2/_typography.less
@@ -14,7 +14,7 @@
   --font-text-line-height: 1.6;
   --font-heading-line-height: 1.6;
 
-  --font-family-stack: Inter, "Helvetica Neue", Helvetica, sans-serif;
+  --font-family-stack: Inter, 'Helvetica Neue', Helvetica, sans-serif;
 }
 
 .font-size-xs {
@@ -37,5 +37,6 @@
   font-size: var(--font-size-lg);
 }
 
-.font-weight-semibold { font-weight: 600 }
-.font-weight-bold { font-weight: 700 }
+.font-weight-semibold {
+  font-weight: 600;
+}


### PR DESCRIPTION
### What does this PR do?
Add `fx-1` to fix text-ellipsis on upload-item.
Remove unnecessary class `allow-text-overflow-on-children`

Related to: https://github.com/upfluence/backlog/issues/2218

### What are the observable changes?
![Peek 2023-01-09 17-45](https://user-images.githubusercontent.com/43567222/211363592-6a23a9e1-1540-427c-9fa5-b49a41869bfe.gif)

### Good PR checklist
- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled
