### PR TITLE
components/oss/array-input: add support for extra keyboard triggers

### DIFF
--- a/addon/components/o-s-s/array-input.stories.js
+++ b/addon/components/o-s-s/array-input.stories.js
@@ -25,6 +25,16 @@ export default {
       },
       control: { type: 'text' }
     },
+    keyboardTriggers: {
+      description: 'An array of keyboard event codes that can be used to trigger an entry validation in addition to Enter',
+      table: {
+        type: {
+          summary: 'string[]'
+        },
+        defaultValue: { summary: '[]' }
+      },
+      control: { type: 'array' }
+    },
     onChange: {
       description:
         'A callback that sends the new array to the parent component when the input is changed (adding or removing items)',

--- a/addon/components/o-s-s/array-input.stories.js
+++ b/addon/components/o-s-s/array-input.stories.js
@@ -26,7 +26,8 @@ export default {
       control: { type: 'text' }
     },
     keyboardTriggers: {
-      description: 'An array of keyboard event codes that can be used to trigger an entry validation in addition to Enter',
+      description:
+        'An array of keyboard event codes that can be used to trigger an entry validation in addition to Enter',
       table: {
         type: {
           summary: 'string[]'

--- a/addon/components/o-s-s/array-input.stories.js
+++ b/addon/components/o-s-s/array-input.stories.js
@@ -27,7 +27,7 @@ export default {
     },
     keyboardTriggers: {
       description:
-        'An array of keyboard event codes that can be used to trigger an entry validation in addition to Enter',
+        'An array of keyboard event keys that can be used to trigger an entry validation in addition to Enter',
       table: {
         type: {
           summary: 'string[]'

--- a/addon/components/o-s-s/array-input.ts
+++ b/addon/components/o-s-s/array-input.ts
@@ -10,6 +10,8 @@ interface OSSArrayInputArgs {
   placeholder?: string;
 }
 
+const DEFAULT_KEYBOARD_TRIGGERS = ['Enter'];
+
 export default class OSSArrayInput extends Component<OSSArrayInputArgs> {
   @tracked currentValue = '';
   @tracked items: string[] = [];
@@ -22,7 +24,7 @@ export default class OSSArrayInput extends Component<OSSArrayInputArgs> {
   }
 
   get keyboardTriggers(): string[] {
-    return ['Enter'].concat(this.args.keyboardTriggers || []);
+    return DEFAULT_KEYBOARD_TRIGGERS.concat(this.args.keyboardTriggers || []);
   }
 
   private _triggerComponentRedraw(): void {

--- a/addon/components/o-s-s/array-input.ts
+++ b/addon/components/o-s-s/array-input.ts
@@ -66,7 +66,7 @@ export default class OSSArrayInput extends Component<OSSArrayInputArgs> {
 
   @action
   keyListener(keyboardEvent: KeyboardEvent): void {
-    if (this.keyboardTriggers.includes(keyboardEvent.code) && this.currentValue.length > 0) {
+    if (this.keyboardTriggers.includes(keyboardEvent.key) && this.currentValue.length > 0) {
       keyboardEvent.preventDefault();
       this._validateEntry();
     } else if (this.currentValue.length === 0 && this.items.length > 0 && keyboardEvent.code === 'Backspace') {

--- a/addon/components/o-s-s/array-input.ts
+++ b/addon/components/o-s-s/array-input.ts
@@ -4,6 +4,7 @@ import { tracked } from '@glimmer/tracking';
 
 interface OSSArrayInputArgs {
   values?: string[];
+  keyboardTriggers?: string[];
   validator?: (value: string) => boolean;
   onChange?: (values: string[]) => void;
   placeholder?: string;
@@ -18,6 +19,10 @@ export default class OSSArrayInput extends Component<OSSArrayInputArgs> {
     if (this.args.values) {
       this.items = this.args.values;
     }
+  }
+
+  get keyboardTriggers(): string[] {
+    return ['Enter'].concat(this.args.keyboardTriggers || []);
   }
 
   private _triggerComponentRedraw(): void {
@@ -59,7 +64,8 @@ export default class OSSArrayInput extends Component<OSSArrayInputArgs> {
 
   @action
   keyListener(keyboardEvent: KeyboardEvent): void {
-    if (keyboardEvent.code === 'Enter' && this.currentValue.length > 0) {
+    if (this.keyboardTriggers.includes(keyboardEvent.code) && this.currentValue.length > 0) {
+      keyboardEvent.preventDefault();
       this._validateEntry();
     } else if (this.currentValue.length === 0 && this.items.length > 0 && keyboardEvent.code === 'Backspace') {
       this._editPreviousEntry();

--- a/tests/integration/components/o-s-s/array-input-test.js
+++ b/tests/integration/components/o-s-s/array-input-test.js
@@ -116,6 +116,19 @@ module('Integration | Component | OSS::ArrayInput', function (hooks) {
     });
   });
 
+  module('Keyboard validation', function () {
+    test('entries are validated when one of the extra keyboard trigger is hit', async function (assert) {
+      await render(hbs`<OSS::ArrayInput @keyboardTriggers={{array "Space"}} />`);
+
+      await fillIn('.array-input-container input', 'foobar');
+      let input = find('.array-input-container input');
+      await triggerKeyEvent(input, 'keydown', 'Space', { code: 'Space' });
+
+      assert.dom('.upf-chip').exists();
+      assert.dom('.upf-chip').hasText('foobar');
+    });
+  });
+
   test('Clicking on the remove icon suppresses the target entry', async function (assert) {
     this.loadedValues = ['value1', 'value2'];
     await render(hbs`<OSS::ArrayInput @values={{this.loadedValues}} />`);

--- a/tests/integration/components/o-s-s/array-input-test.js
+++ b/tests/integration/components/o-s-s/array-input-test.js
@@ -118,11 +118,11 @@ module('Integration | Component | OSS::ArrayInput', function (hooks) {
 
   module('Keyboard validation', function () {
     test('entries are validated when one of the extra keyboard trigger is hit', async function (assert) {
-      await render(hbs`<OSS::ArrayInput @keyboardTriggers={{array "Space"}} />`);
+      await render(hbs`<OSS::ArrayInput @keyboardTriggers={{array " "}} />`);
 
       await fillIn('.array-input-container input', 'foobar');
       let input = find('.array-input-container input');
-      await triggerKeyEvent(input, 'keydown', 'Space', { code: 'Space' });
+      await triggerKeyEvent(input, 'keydown', ' ');
 
       assert.dom('.upf-chip').exists();
       assert.dom('.upf-chip').hasText('foobar');


### PR DESCRIPTION
### What does this PR do?

Allow the `OSS::ArrayInput` component to receive extra keyboard event codes that can be used to validate an entry beside the default Enter one.


### What are the observable changes?
<!-- This question could be adequate with multiple use cases, for example: -->

<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->

### Good PR checklist
- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [x] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled
