### PR TITLE
OSS::Tag: add support for extended palette skins and @plain mode

### DIFF
--- a/addon/components/o-s-s/tag.stories.js
+++ b/addon/components/o-s-s/tag.stories.js
@@ -46,6 +46,16 @@ export default {
       control: {
         type: 'boolean'
       }
+    },
+    plain: {
+      description: 'Whether to use the plain style or not',
+      table: {
+        type: { summary: 'boolean' },
+        defaultValue: { summary: 'false' }
+      },
+      control: {
+        type: 'boolean'
+      }
     }
   }
 };

--- a/addon/components/o-s-s/tag.ts
+++ b/addon/components/o-s-s/tag.ts
@@ -1,7 +1,17 @@
 import Component from '@glimmer/component';
 import { assert } from '@ember/debug';
 
-export type SkinType = 'primary' | 'success' | 'warning' | 'danger' | 'secondary';
+export type SkinType =
+  | 'primary'
+  | 'success'
+  | 'warning'
+  | 'danger'
+  | 'secondary'
+  | 'xtd-orange'
+  | 'xtd-cyan'
+  | 'xtd-yellow'
+  | 'xtd-blue'
+  | 'xtd-violet';
 
 type SkinDefType = {
   [key in SkinType]: string;
@@ -13,7 +23,12 @@ export const SkinDefinition: SkinDefType = {
   success: 'success',
   warning: 'alert',
   danger: 'critical',
-  secondary: 'neutral'
+  secondary: 'neutral',
+  'xtd-orange': 'xtd-orange',
+  'xtd-cyan': 'xtd-cyan',
+  'xtd-yellow': 'xtd-yellow',
+  'xtd-blue': 'xtd-blue',
+  'xtd-violet': 'xtd-violet'
 };
 
 interface OSSTagArgs {
@@ -21,6 +36,7 @@ interface OSSTagArgs {
   skin?: string;
   icon?: string;
   hasEllipsis?: boolean;
+  plain?: boolean;
 }
 
 export default class OSSTag extends Component<OSSTagArgs> {
@@ -43,6 +59,10 @@ export default class OSSTag extends Component<OSSTagArgs> {
 
     if (this.skin) {
       classes.push(`upf-tag--${this.skin}`);
+    }
+
+    if (this.args.plain) {
+      classes.push('upf-tag--plain');
     }
 
     return classes.join(' ');

--- a/app/styles/base/_tags.less
+++ b/app/styles/base/_tags.less
@@ -45,4 +45,54 @@
     background-color: var(--color-error-50);
     color: var(--color-error-500);
   }
+
+  &--xtd-orange {
+    background-color: var(--color-orange-50);
+    color: var(--color-orange-500);
+
+    &.upf-tag--plain {
+      background-color: var(--color-orange-500);
+      color: var(--color-white);
+    }
+  }
+
+  &--xtd-cyan {
+    background-color: var(--color-cyan-50);
+    color: var(--color-cyan-500);
+
+    &.upf-tag--plain {
+      background-color: var(--color-cyan-500);
+      color: var(--color-white);
+    }
+  }
+
+  &--xtd-yellow {
+    background-color: var(--color-yellow-50);
+    color: var(--color-yellow-500);
+
+    &.upf-tag--plain {
+      background-color: var(--color-yellow-500);
+      color: var(--color-white);
+    }
+  }
+
+  &--xtd-blue {
+    background-color: var(--color-blue-50);
+    color: var(--color-blue-500);
+
+    &.upf-tag--plain {
+      background-color: var(--color-blue-500);
+      color: var(--color-white);
+    }
+  }
+
+  &--xtd-violet {
+    background-color: var(--color-violet-50);
+    color: var(--color-violet-500);
+
+    &.upf-tag--plain {
+      background-color: var(--color-violet-500);
+      color: var(--color-white);
+    }
+  }
 }

--- a/tests/integration/components/o-s-s/tag-test.ts
+++ b/tests/integration/components/o-s-s/tag-test.ts
@@ -37,6 +37,13 @@ module('Integration | Component | o-s-s/tag', function (hooks) {
     assert.dom('.upf-tag i').hasClass('fa-thumbs-up');
   });
 
+  module('@plain', () => {
+    test('the right class is applied on the tag', async function (assert) {
+      await render(hbs`<OSS::Tag @icon="far fa-thumbs-up" @plain={{true}} />`);
+      assert.dom('.upf-tag').hasClass('upf-tag--plain');
+    });
+  });
+
   module('@hasEllipsis', () => {
     test('When the param is true then the ellipsis is shown', async function (assert) {
       await render(hbs`<OSS::Tag @label='Test with a huge label sentence' @hasEllipsis='true' />`);


### PR DESCRIPTION
### What does this PR do?

OSS::Tag: add support for extended palette skins and @plain mode

### What are the observable changes?
<!-- This question could be adequate with multiple use cases, for example: -->

<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->

### Good PR checklist
- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [x] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled
