### PR TITLE
Add illustration named block to OSS::ModalDialog component

### DIFF
--- a/addon/components/o-s-s/modal-dialog.hbs
+++ b/addon/components/o-s-s/modal-dialog.hbs
@@ -9,6 +9,11 @@
       <i class="fa fa-close padding-xx-sm" {{on "click" this.closeModal}} role="button"
          data-control-name="close-modal-button"></i>
     </header>
+
+    {{#if (has-block "illustration")}}
+      {{yield to="illustration"}}
+    {{/if}}
+
     <div class="oss-modal-dialog--content fx-1">
       {{#if (has-block "content")}}
         {{yield to="content"}}

--- a/addon/components/o-s-s/modal-dialog.stories.js
+++ b/addon/components/o-s-s/modal-dialog.stories.js
@@ -82,5 +82,26 @@ const BasicUsageTemplate = (args) => ({
   context: args
 });
 
+const WithIllustrationTemplate = (args) => ({
+  template: hbs`
+      <OSS::ModalDialog @title={{this.title}} @close={{this.close}} @subtitle={{this.subtitle}} @size={{this.size}} 
+                        @close={{this.close}}>
+        <:illustration>
+        This will contain an illustration.
+        </:illustration>
+        <:content>
+          Content goes here
+        </:content>
+        <:footer>
+          Footer goes here
+        </:footer>
+      </OSS::ModalDialog>
+  `,
+  context: args
+});
+
 export const Usage = BasicUsageTemplate.bind({});
+export const WithIlllustration = WithIllustrationTemplate.bind({});
+
 Usage.args = defaultArgs;
+WithIlllustration.args = defaultArgs;

--- a/addon/components/o-s-s/modal-dialog.stories.js
+++ b/addon/components/o-s-s/modal-dialog.stories.js
@@ -87,7 +87,7 @@ const WithIllustrationTemplate = (args) => ({
       <OSS::ModalDialog @title={{this.title}} @close={{this.close}} @subtitle={{this.subtitle}} @size={{this.size}} 
                         @close={{this.close}}>
         <:illustration>
-        This will contain an illustration.
+          This will contain an illustration.
         </:illustration>
         <:content>
           Content goes here

--- a/tests/integration/components/o-s-s/modal-dialog-test.ts
+++ b/tests/integration/components/o-s-s/modal-dialog-test.ts
@@ -69,6 +69,19 @@ module('Integration | Component | o-s-s/modal-dialog', function (hooks) {
     assert.dom('.oss-modal-dialog .subtitle').hasText('Subtitle');
   });
 
+  test('The illustration named-block is properly displayed', async function (assert) {
+    await render(
+      hbs`
+      <OSS::ModalDialog @title="Example modal" @subtitle="subtitle" @close={{this.closeModal}} @size="md">
+        <:illustration>
+          <p class="illustration-container">Illustration</p>
+        </:illustration>
+      </OSS::ModalDialog>`
+    );
+
+    assert.dom('.illustration-container').exists();
+  });
+
   test('The content named-block is properly displayed', async function (assert) {
     await render(
       hbs`


### PR DESCRIPTION
### What does this PR do?

Add illustration named block to OSS::ModalDialog component


### What are the observable changes?

![Screenshot 2023-05-03 at 16 12 29](https://user-images.githubusercontent.com/4022350/235946378-e0e17708-5192-48cd-88dc-1ee2da6c516f.jpg)

<!-- This question could be adequate with multiple use cases, for example: -->

<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->

### Good PR checklist
- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled
