### PR TITLE
Fix: no triggering onSelection when value does not change

### DIFF
--- a/addon/components/o-s-s/toggle-buttons.ts
+++ b/addon/components/o-s-s/toggle-buttons.ts
@@ -40,6 +40,8 @@ export default class OSSToggleButtons extends Component<OSSToggleButtonsArgs> {
 
   @action
   onSelectToggle(selectedToggle: string): void {
-    this.args.onSelection(selectedToggle);
+    if (this.args.selectedToggle !== selectedToggle) {
+      this.args.onSelection(selectedToggle);
+    }
   }
 }

--- a/tests/integration/components/o-s-s/toggle-buttons-test.ts
+++ b/tests/integration/components/o-s-s/toggle-buttons-test.ts
@@ -111,6 +111,17 @@ module('Integration | Component | o-s-s/toggle-buttons', function (hooks) {
       assert.dom('.oss-toggle-buttons-btn--selected').hasText('Second');
     });
 
+    test('the @onSelection method is not triggered if the item is already selected', async function (assert) {
+      this.onSelectionStub = sinon.stub();
+
+      await render(
+        hbs`<OSS::ToggleButtons @onSelection={{this.onSelectionStub}} @toggles={{this.toggles}} @selectedToggle={{this.selectedToggle}}/>`
+      );
+
+      await click('.oss-toggle-buttons-btn:first-child');
+      assert.ok(this.onSelectionStub.notCalled);
+    });
+
     test('the @onSelection method is triggered with the selected value', async function (assert) {
       this.onSelection = sinon.spy();
 
@@ -118,8 +129,6 @@ module('Integration | Component | o-s-s/toggle-buttons', function (hooks) {
         hbs`<OSS::ToggleButtons @onSelection={{this.onSelection}} @toggles={{this.toggles}} @selectedToggle={{this.selectedToggle}}/>`
       );
 
-      await click('.oss-toggle-buttons-btn:first-child');
-      assert.ok(this.onSelection.calledWith('first'));
       await click('.oss-toggle-buttons-btn:last-child');
       assert.ok(this.onSelection.calledWith('second'));
     });


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the context of this pull request and its purpose. -->

Related to: [#2732](https://github.com/upfluence/backlog/issues/2732)

### What are the observable changes?
Doesn't trigger onSelection if selected has not changed

### Good PR checklist
- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [ ] Added/updated documentation
- [x] Migrated touched components to Glimmer Components
- [x] Properly labeled
