### PR TITLE
Added new component ContentPanel

### DIFF
--- a/addon/components/o-s-s/content-panel.hbs
+++ b/addon/components/o-s-s/content-panel.hbs
@@ -1,0 +1,3 @@
+<div class="oss-content-panel fx-row fx-1" ...attributes>
+  {{yield}}
+</div>

--- a/addon/components/o-s-s/content-panel.hbs
+++ b/addon/components/o-s-s/content-panel.hbs
@@ -1,3 +1,3 @@
-<div class="oss-content-panel fx-row fx-1" ...attributes>
+<div class="oss-content-panel" ...attributes>
   {{yield}}
 </div>

--- a/addon/components/o-s-s/content-panel.stories.js
+++ b/addon/components/o-s-s/content-panel.stories.js
@@ -1,0 +1,33 @@
+import hbs from 'htmlbars-inline-precompile';
+
+export default {
+  title: 'Components/OSS::ContentPanel',
+  component: 'code-panel',
+  argTypes: {},
+  parameters: {
+    docs: {
+      description: {
+        component: 'Used to display content in pages with default styling.'
+      }
+    }
+  }
+};
+
+const defaultArgs = {};
+
+const BasicUsageTemplate = (args) => ({
+  template: hbs`
+    <div class="font-color-black">
+      <OSS::ContentPanel >
+        <div class="fx-col fx-1">
+          <span>Content</span>
+          <span>Goes here</span>
+        </div>
+      </OSS::ContentPanel>
+    </div>
+  `,
+  context: args
+});
+
+export const BasicUsage = BasicUsageTemplate.bind({});
+BasicUsage.args = defaultArgs;

--- a/addon/components/o-s-s/content-panel.stories.js
+++ b/addon/components/o-s-s/content-panel.stories.js
@@ -18,11 +18,9 @@ const defaultArgs = {};
 const BasicUsageTemplate = (args) => ({
   template: hbs`
     <div class="font-color-black">
-      <OSS::ContentPanel >
-        <div class="fx-col fx-1">
-          <span>Content</span>
-          <span>Goes here</span>
-        </div>
+      <OSS::ContentPanel class="fx-col fx-1">
+        <span>Content</span>
+        <span>Goes here</span>
       </OSS::ContentPanel>
     </div>
   `,

--- a/addon/components/o-s-s/content-panel.ts
+++ b/addon/components/o-s-s/content-panel.ts
@@ -1,0 +1,5 @@
+import Component from '@glimmer/component';
+
+interface OSSContentPanelArgs {}
+
+export default class OSSContentPanel extends Component<OSSContentPanelArgs> {}

--- a/app/components/o-s-s/content-panel.js
+++ b/app/components/o-s-s/content-panel.js
@@ -1,0 +1,1 @@
+export { default } from '@upfluence/oss-components/components/o-s-s/content-panel';

--- a/app/styles/organisms/content-panel.less
+++ b/app/styles/organisms/content-panel.less
@@ -1,0 +1,8 @@
+.oss-content-panel {
+  background-color: var(--color-white);
+
+  border-radius: var(--border-radius-md);
+  border: 1px solid var(--color-gray-200);
+
+  padding: var(--spacing-px-36);
+}

--- a/app/styles/organisms/content-panel.less
+++ b/app/styles/organisms/content-panel.less
@@ -2,7 +2,7 @@
   background-color: var(--color-white);
 
   border-radius: var(--border-radius-md);
-  border: 1px solid var(--color-gray-200);
+  border: 1px solid var(--color-border-default);
 
   padding: var(--spacing-px-36);
 }

--- a/app/styles/oss-components.less
+++ b/app/styles/oss-components.less
@@ -40,3 +40,4 @@
 @import 'organisms/table';
 @import 'organisms/modal-dialog';
 @import 'organisms/split-modal';
+@import 'organisms/content-panel';

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -502,15 +502,13 @@
   </div>
 </div>
 <div class="fx-row fx-xalign-start fx-gap-px-10 margin-md">
-  <OSS::ContentPanel>
-    <div class="fx-col fx-1">
-      <span class="text-style-semibold">Title</span>
-      <span class="font-color-gray-500">Subtitle</span>
-      <hr class="width-pc-100" />
-      <span>Content</span>
-    </div>
+  <OSS::ContentPanel class="fx-col fx-1">
+    <span class="text-style-semibold">Title</span>
+    <span class="font-color-gray-500">Subtitle</span>
+    <hr class="width-pc-100" />
+    <span>Content</span>
   </OSS::ContentPanel>
-  <OSS::ContentPanel class="fx-gap-px-10">
+  <OSS::ContentPanel class="fx-row fx-1 fx-gap-px-10">
     <OSS::UrlInput @value={{this.shopifyDomain}} @prefix="https://" @placeholder="shopname" @suffix=".myshopify.com"
                    @errorMessage="Not a valid shopify domain" @validationRegex={{this.subdomainRegex}}
                    @onChange={{this.onUrlInputChange}} />

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -501,3 +501,20 @@
                      @onUploadSuccess={{this.onUploadSuccess}} />
   </div>
 </div>
+<div class="fx-row fx-xalign-start fx-gap-px-10 margin-md">
+  <OSS::ContentPanel>
+    <div class="fx-col fx-1">
+      <span class="text-style-semibold">Title</span>
+      <span class="font-color-gray-500">Subtitle</span>
+      <hr class="width-pc-100" />
+      <span>Content</span>
+    </div>
+  </OSS::ContentPanel>
+  <OSS::ContentPanel class="fx-gap-px-10">
+    <OSS::UrlInput @value={{this.shopifyDomain}} @prefix="https://" @placeholder="shopname" @suffix=".myshopify.com"
+                   @errorMessage="Not a valid shopify domain" @validationRegex={{this.subdomainRegex}}
+                   @onChange={{this.onUrlInputChange}} />
+    <OSS::UrlInput @prefix="https://" @placeholder="No regex specified" @onChange={{this.onUrlInputChange}}
+                   @value={{this.shopifyDomain}} />
+  </OSS::ContentPanel>
+</div>

--- a/tests/integration/components/o-s-s/content-panel-test.ts
+++ b/tests/integration/components/o-s-s/content-panel-test.ts
@@ -1,0 +1,25 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Component | o-s-s/content-panel', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function (assert) {
+    await render(hbs`<OSS::ContentPanel/>`);
+
+    assert.dom('.oss-content-panel').exists();
+  });
+
+  test('The content named-block is properly displayed', async function (assert) {
+    await render(
+      hbs`
+      <OSS::ContentPanel>
+        <p>This is the content</p>
+      </OSS::ContentPanel>`
+    );
+
+    assert.dom('.oss-content-panel').hasText('This is the content');
+  });
+});


### PR DESCRIPTION
### What does this PR do?
Add a new dummy component OSS::ContentPanel which has predefined borders & padding that will display the yielded content.

 Related to: [#ENG-268](https://linear.app/upfluence/issue/ENG-268/[groundwork]-new-osscontentpanel-component)

### What are the observable changes?
![Capture d’écran 2023-06-08 à 15 37 22](https://github.com/upfluence/oss-components/assets/111493996/a458bec7-e312-46bf-bf67-634cb18d9e13)

![Capture d’écran 2023-06-08 à 15 37 09](https://github.com/upfluence/oss-components/assets/111493996/ad8d42d9-c30f-4dce-9d81-15eb73b0447a)

### Good PR checklist
- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [x] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled
