### PR TITLE
New component textArea

### DIFF
--- a/addon/components/o-s-s/text-area.hbs
+++ b/addon/components/o-s-s/text-area.hbs
@@ -1,0 +1,9 @@
+<div class="fx-1">
+  <div class="oss-textarea-container {{if @errorMessage ' oss-textarea-container--errored'}}">
+    <Textarea {{on "change" (fn this._onChange @value)}} @value={{@value}} placeholder={{@placeholder}}
+              disabled={{@disabled}} class="oss-textarea {{this.computedClass}}" rows={{this.rows}} ...attributes />
+  </div>
+  {{#if @errorMessage}}
+    <span class="text-color-error margin-top-xxx-sm">{{@errorMessage}}</span>
+  {{/if}}
+</div>

--- a/addon/components/o-s-s/text-area.hbs
+++ b/addon/components/o-s-s/text-area.hbs
@@ -1,9 +1,9 @@
-<div class="fx-1">
+<div class="fx-1" ...attributes>
   <div class="oss-textarea-container {{if @errorMessage ' oss-textarea-container--errored'}}">
     <Textarea {{on "change" (fn this._onChange @value)}} @value={{@value}} placeholder={{@placeholder}}
-              disabled={{@disabled}} class="oss-textarea {{this.computedClass}}" rows={{this.rows}} ...attributes />
+              disabled={{@disabled}} class="oss-textarea {{this.computedClass}}" rows={{this.rows}} />
   </div>
   {{#if @errorMessage}}
-    <span class="text-color-error margin-top-xxx-sm">{{@errorMessage}}</span>
+    <span class="font-color-error-500 margin-top-px-6">{{@errorMessage}}</span>
   {{/if}}
 </div>

--- a/addon/components/o-s-s/text-area.stories.js
+++ b/addon/components/o-s-s/text-area.stories.js
@@ -6,7 +6,7 @@ export default {
   component: 'text-area',
   argTypes: {
     value: {
-      description: 'Value of the input',
+      description: 'Value of the textarea',
       table: {
         type: {
           summary: 'string'
@@ -16,7 +16,7 @@ export default {
       control: { type: 'text' }
     },
     disabled: {
-      description: 'Disable the default input (when not passing an input named block)',
+      description: 'Disable the default textarea (when not passing an textarea named block)',
       table: {
         type: {
           summary: 'boolean'
@@ -26,7 +26,7 @@ export default {
       control: { type: 'boolean' }
     },
     placeholder: {
-      description: 'Placeholder of the input',
+      description: 'Placeholder of the textarea',
       table: {
         type: {
           summary: 'string'
@@ -36,7 +36,7 @@ export default {
       control: { type: 'text' }
     },
     errorMessage: {
-      description: 'An error message that will be displayed below the input-group.',
+      description: 'An error message that will be displayed below the textarea-group.',
       table: {
         type: {
           summary: 'string'
@@ -46,7 +46,7 @@ export default {
       control: { type: 'text' }
     },
     onChange: {
-      description: 'Method called every time the input is updated',
+      description: 'Method called every time the textarea is updated',
       table: {
         category: 'Actions',
         type: {

--- a/addon/components/o-s-s/text-area.stories.js
+++ b/addon/components/o-s-s/text-area.stories.js
@@ -1,0 +1,84 @@
+import hbs from 'htmlbars-inline-precompile';
+import { action } from '@storybook/addon-actions';
+
+export default {
+  title: 'Components/OSS::TextArea',
+  component: 'text-area',
+  argTypes: {
+    value: {
+      description: 'Value of the input',
+      table: {
+        type: {
+          summary: 'string'
+        },
+        defaultValue: { summary: 'undefined' }
+      },
+      control: { type: 'text' }
+    },
+    disabled: {
+      description: 'Disable the default input (when not passing an input named block)',
+      table: {
+        type: {
+          summary: 'boolean'
+        },
+        defaultValue: { summary: false }
+      },
+      control: { type: 'boolean' }
+    },
+    placeholder: {
+      description: 'Placeholder of the input',
+      table: {
+        type: {
+          summary: 'string'
+        },
+        defaultValue: { summary: 'undefined' }
+      },
+      control: { type: 'text' }
+    },
+    errorMessage: {
+      description: 'An error message that will be displayed below the input-group.',
+      table: {
+        type: {
+          summary: 'string'
+        },
+        defaultValue: { summary: 'undefined' }
+      },
+      control: { type: 'text' }
+    },
+    onChange: {
+      description: 'Method called every time the input is updated',
+      table: {
+        category: 'Actions',
+        type: {
+          summary: 'onChange(value: string): void'
+        }
+      }
+    }
+  },
+  parameters: {
+    docs: {
+      description: {
+        component: 'The OSS version of the textarea component. Configurable & skinable.'
+      }
+    }
+  }
+};
+
+const defaultArgs = {
+  value: 'John',
+  disabled: false,
+  placeholder: 'this is the placeholder',
+  errorMessage: undefined,
+  onChange: action('onChange')
+};
+
+const DefaultUsageTemplate = (args) => ({
+  template: hbs`
+      <OSS::TextArea @value={{this.value}} @disabled={{this.disabled}} @placeholder={{this.placeholder}}
+                           @errorMessage={{this.errorMessage}} @onChange={{this.onChange}} />
+  `,
+  context: args
+});
+
+export const BasicUsage = DefaultUsageTemplate.bind({});
+BasicUsage.args = defaultArgs;

--- a/addon/components/o-s-s/text-area.stories.js
+++ b/addon/components/o-s-s/text-area.stories.js
@@ -1,6 +1,8 @@
 import hbs from 'htmlbars-inline-precompile';
 import { action } from '@storybook/addon-actions';
 
+const ResizeTypes = ['horizontal', 'vertical', 'none', null];
+
 export default {
   title: 'Components/OSS::TextArea',
   component: 'text-area',
@@ -15,8 +17,29 @@ export default {
       },
       control: { type: 'text' }
     },
+    rows: {
+      description: 'Number of rows dispayed in the textarea',
+      table: {
+        type: {
+          summary: 'number'
+        },
+        defaultValue: { summary: 2 }
+      },
+      control: { type: 'number' }
+    },
+    resize: {
+      description: 'Define direction in which textarea can be resized (By default the resize is set to Both)',
+      table: {
+        type: {
+          summary: ResizeTypes.join('|')
+        },
+        defaultValue: { summary: 'both' }
+      },
+      options: ResizeTypes,
+      control: { type: 'select' }
+    },
     disabled: {
-      description: 'Disable the default textarea (when not passing an textarea named block)',
+      description: 'Disable the default textarea',
       table: {
         type: {
           summary: 'boolean'
@@ -58,7 +81,7 @@ export default {
   parameters: {
     docs: {
       description: {
-        component: 'The OSS version of the textarea component. Configurable & skinable.'
+        component: 'The OSS version of the textarea component.'
       }
     }
   }
@@ -66,6 +89,8 @@ export default {
 
 const defaultArgs = {
   value: 'John',
+  rows: 2,
+  resize: null,
   disabled: false,
   placeholder: 'this is the placeholder',
   errorMessage: undefined,
@@ -75,7 +100,8 @@ const defaultArgs = {
 const DefaultUsageTemplate = (args) => ({
   template: hbs`
       <OSS::TextArea @value={{this.value}} @disabled={{this.disabled}} @placeholder={{this.placeholder}}
-                           @errorMessage={{this.errorMessage}} @onChange={{this.onChange}} />
+                     @errorMessage={{this.errorMessage}} @onChange={{this.onChange}} @rows={{this.rows}}
+                     @resize={{this.resize}} />
   `,
   context: args
 });

--- a/addon/components/o-s-s/text-area.ts
+++ b/addon/components/o-s-s/text-area.ts
@@ -4,7 +4,7 @@ import Component from '@glimmer/component';
 
 interface OSSTextAreaArgs {
   rows?: number;
-  resize?: 'vertical' | 'horizontal' | 'both' | 'none';
+  resize?: 'vertical' | 'horizontal' | 'none';
   value?: string;
   disabled?: boolean;
   errorMessage?: string;
@@ -19,7 +19,7 @@ export default class OSSTextArea extends Component<OSSTextAreaArgs> {
     if (this.args.resize) {
       assert(
         '[component][OSS::TextArea] The @resize parameter should be a value of resize',
-        ['vertical', 'horizontal', 'both', 'none'].includes(this.args.resize)
+        ['vertical', 'horizontal', 'none'].includes(this.args.resize)
       );
     }
   }

--- a/addon/components/o-s-s/text-area.ts
+++ b/addon/components/o-s-s/text-area.ts
@@ -25,7 +25,7 @@ export default class OSSTextArea extends Component<OSSTextAreaArgs> {
   }
 
   get rows(): number {
-    return this.args.rows || 1;
+    return this.args.rows || 2;
   }
 
   get computedClass(): string {
@@ -39,8 +39,6 @@ export default class OSSTextArea extends Component<OSSTextAreaArgs> {
 
   @action
   _onChange(value: string): void {
-    if (this.args.onChange) {
-      this.args.onChange(value);
-    }
+    this.args.onChange?.(value);
   }
 }

--- a/addon/components/o-s-s/text-area.ts
+++ b/addon/components/o-s-s/text-area.ts
@@ -1,0 +1,46 @@
+import { assert } from '@ember/debug';
+import { action } from '@ember/object';
+import Component from '@glimmer/component';
+
+interface OSSTextAreaArgs {
+  rows?: number;
+  resize?: 'vertical' | 'horizontal' | 'both' | 'none';
+  value?: string;
+  disabled?: boolean;
+  errorMessage?: string;
+  placeholder?: string;
+  onChange?(value: string): void;
+}
+
+export default class OSSTextArea extends Component<OSSTextAreaArgs> {
+  constructor(owner: unknown, args: OSSTextAreaArgs) {
+    super(owner, args);
+
+    if (this.args.resize) {
+      assert(
+        '[component][OSS::TextArea] The @resize parameter should be a value of resize',
+        ['vertical', 'horizontal', 'both', 'none'].includes(this.args.resize)
+      );
+    }
+  }
+
+  get rows(): number {
+    return this.args.rows || 1;
+  }
+
+  get computedClass(): string {
+    const classes: string[] = [];
+    if (this.args.resize === 'vertical') classes.push('oss-textarea--resize-v');
+    else if (this.args.resize === 'horizontal') classes.push('oss-textarea--resize-h');
+    else if (this.args.resize === 'none') classes.push('oss-textarea--resize-none');
+
+    return classes.join(' ');
+  }
+
+  @action
+  _onChange(value: string): void {
+    if (this.args.onChange) {
+      this.args.onChange(value);
+    }
+  }
+}

--- a/app/components/o-s-s/text-area.js
+++ b/app/components/o-s-s/text-area.js
@@ -1,0 +1,1 @@
+export { default } from '@upfluence/oss-components/components/o-s-s/text-area';

--- a/app/styles/atoms/input-container.less
+++ b/app/styles/atoms/input-container.less
@@ -16,6 +16,11 @@
     width: 100%;
   }
 
+  textarea.upf-input {
+    max-width: 100%;
+    height: var(--height-pc-100);
+  }
+
   .yielded-input input {
     &:extend(.upf-input);
     width: 100%;

--- a/app/styles/molecules/textarea.less
+++ b/app/styles/molecules/textarea.less
@@ -1,0 +1,40 @@
+.oss-textarea-container {
+  position: relative;
+
+  &--errored {
+    textarea,
+    textarea:focus {
+      .border;
+      .border-color-error;
+      .border-radius-default;
+    }
+  }
+
+  .oss-textarea {
+    width: 100%;
+    min-height: var(--spacing-px-36);
+    height: auto;
+  }
+}
+
+.oss-textarea  {
+  .upf-input;
+
+  padding: var(--spacing-px-6) var(--spacing-px-12);
+
+  &--resize-v {
+    resize: vertical;
+  }
+
+  &--resize-h {
+    resize: horizontal;
+  }
+
+  &--resize-none {
+    resize: none;
+  }
+
+  &::-webkit-scrollbar-corner {
+    background: inherit;
+  }
+}

--- a/app/styles/oss-components.less
+++ b/app/styles/oss-components.less
@@ -36,6 +36,7 @@
 @import 'molecules/button-dropdown';
 @import 'molecules/upload-area';
 @import 'molecules/number-input';
+@import 'molecules/textarea';
 @import 'molecules/toggle-buttons';
 @import 'organisms/table';
 @import 'organisms/modal-dialog';

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -1,4 +1,10 @@
 <div class="fx-row fx-xalign-start fx-gap-px-10 margin-md">
+  <OSS::TextArea @value={{this.numberValue}} @onChange={{this.handleNumberInput}}
+                 @errorMessage="This is an error message" @rows={{8}} @resize="vertical" />
+  <OSS::TextArea @value={{this.numberValue}} @onChange={{this.handleNumberInput}} @rows={{1}} />
+</div>
+
+<div class="fx-row fx-xalign-start fx-gap-px-10 margin-md">
   <OSS::Button @label="Open split modal" {{on "click" this.openSplitModal}} />
   {{#if this.showSplitModal}}
     <OSS::SplitModal @close={{this.closeSplitModal}}>

--- a/tests/integration/components/o-s-s/text-area-test.ts
+++ b/tests/integration/components/o-s-s/text-area-test.ts
@@ -4,11 +4,6 @@ import { render, typeIn, setupOnerror } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import sinon from 'sinon';
 
-function getRealHeight(element: Element): number {
-  const height = element.getBoundingClientRect()?.height * 2;
-  return Math.round(height * 100) / 100;
-}
-
 module('Integration | Component | o-s-s/text-area', function (hooks) {
   setupRenderingTest(hooks);
 
@@ -60,19 +55,20 @@ module('Integration | Component | o-s-s/text-area', function (hooks) {
     test('Default height', async function (assert) {
       await render(hbs`<OSS::TextArea />`);
 
-      assert.equal(getRealHeight(document.querySelector(this.textareaSelector)), 36);
+      assert.equal(document.querySelector(this.textareaSelector).offsetHeight, 36);
     });
 
     test('Row change height', async function (assert) {
-      const lineHeight = 19;
       this.rows = 2;
       await render(hbs`<OSS::TextArea @rows={{this.rows}}/>`);
 
-      assert.equal(getRealHeight(document.querySelector(this.textareaSelector)), lineHeight * 2 + 14);
+      const twoRowHeight = document.querySelector(this.textareaSelector).offsetHeight;
+      assert.ok(twoRowHeight > 36);
 
-      this.set('rows', 8);
-      await render(hbs`<OSS::TextArea @rows={{this.rows}}/>`);
-      assert.equal(getRealHeight(document.querySelector(this.textareaSelector)), lineHeight * 8 + 14);
+      await this.set('rows', 8);
+      const heightRowHeight = document.querySelector(this.textareaSelector).offsetHeight;
+
+      assert.ok(heightRowHeight > twoRowHeight);
     });
   });
 

--- a/tests/integration/components/o-s-s/text-area-test.ts
+++ b/tests/integration/components/o-s-s/text-area-test.ts
@@ -89,7 +89,7 @@ module('Integration | Component | o-s-s/text-area', function (hooks) {
 
     test('passing data-control-name works', async function (assert) {
       await render(hbs`<OSS::TextArea data-control-name="description-input" />`);
-      let inputWrapper: Element | null = document.querySelector(this.textareaSelector);
+      let inputWrapper: Element | null = document.querySelector('.fx-1');
       assert.equal(inputWrapper?.getAttribute('data-control-name'), 'description-input');
     });
   });

--- a/tests/integration/components/o-s-s/text-area-test.ts
+++ b/tests/integration/components/o-s-s/text-area-test.ts
@@ -1,0 +1,114 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render, typeIn, setupOnerror } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+import sinon from 'sinon';
+
+function getRealHeight(element: Element): number {
+  const height = element.getBoundingClientRect()?.height * 2;
+  return Math.round(height * 100) / 100;
+}
+
+module('Integration | Component | o-s-s/text-area', function (hooks) {
+  setupRenderingTest(hooks);
+
+  hooks.beforeEach(function () {
+    this.value = 'Data';
+
+    this.textareaSelector = '.oss-textarea-container  .oss-textarea';
+  });
+
+  test('it renders', async function (assert) {
+    await render(hbs`<OSS::TextArea @label='test' />`);
+    assert.dom('.oss-textarea-container').exists();
+  });
+
+  module('@resize', function () {
+    test('Default has no class resize', async function (assert) {
+      await render(hbs`<OSS::TextArea />`);
+      assert.dom(this.textareaSelector).hasNoClass('oss-textarea--resize-v');
+      assert.dom(this.textareaSelector).hasNoClass('oss-textarea--resize-h');
+      assert.dom(this.textareaSelector).hasNoClass('oss-textarea--resize-none');
+    });
+
+    test('When resize is vertical should have class resize-v', async function (assert) {
+      this.resize = 'vertical';
+      await render(hbs`<OSS::TextArea @resize={{this.resize}}/>`);
+      assert.dom(this.textareaSelector).hasClass('oss-textarea--resize-v');
+      assert.dom(this.textareaSelector).hasNoClass('oss-textarea--resize-h');
+      assert.dom(this.textareaSelector).hasNoClass('oss-textarea--resize-none');
+    });
+
+    test('When resize is horizontal should have class resize-h', async function (assert) {
+      this.resize = 'horizontal';
+      await render(hbs`<OSS::TextArea @resize={{this.resize}}/>`);
+      assert.dom(this.textareaSelector).hasNoClass('oss-textarea--resize-v');
+      assert.dom(this.textareaSelector).hasClass('oss-textarea--resize-h');
+      assert.dom(this.textareaSelector).hasNoClass('oss-textarea--resize-none');
+    });
+
+    test('When resize is none should have class resize-none', async function (assert) {
+      this.resize = 'none';
+      await render(hbs`<OSS::TextArea @resize={{this.resize}}/>`);
+      assert.dom(this.textareaSelector).hasNoClass('oss-textarea--resize-v');
+      assert.dom(this.textareaSelector).hasNoClass('oss-textarea--resize-h');
+      assert.dom(this.textareaSelector).hasClass('oss-textarea--resize-none');
+    });
+  });
+
+  module('@rows', function () {
+    test('Default height', async function (assert) {
+      await render(hbs`<OSS::TextArea />`);
+
+      assert.equal(getRealHeight(document.querySelector(this.textareaSelector)), 36);
+    });
+
+    test('Row change height', async function (assert) {
+      const lineHeight = 19;
+      this.rows = 2;
+      await render(hbs`<OSS::TextArea @rows={{this.rows}}/>`);
+
+      assert.equal(getRealHeight(document.querySelector(this.textareaSelector)), lineHeight * 2 + 14);
+
+      this.set('rows', 8);
+      await render(hbs`<OSS::TextArea @rows={{this.rows}}/>`);
+      assert.equal(getRealHeight(document.querySelector(this.textareaSelector)), lineHeight * 8 + 14);
+    });
+  });
+
+  test('When the field is updated, the @onChange method is called', async function (assert) {
+    this.onChange = sinon.spy();
+
+    await render(hbs`<OSS::TextArea @value={{this.value}} @onChange={{this.onChange}}/>`);
+    await typeIn(this.textareaSelector, 'base');
+
+    assert.ok(this.onChange.calledOnceWithExactly('Database'));
+  });
+
+  module('Extra attributes', () => {
+    test('passing an extra class is applied to the component', async function (assert) {
+      await render(hbs`<OSS::TextArea class="my-extra-class" />`);
+      assert.dom('.my-extra-class').exists();
+    });
+
+    test('passing data-control-name works', async function (assert) {
+      await render(hbs`<OSS::TextArea data-control-name="description-input" />`);
+      let inputWrapper: Element | null = document.querySelector(this.textareaSelector);
+      assert.equal(inputWrapper?.getAttribute('data-control-name'), 'description-input');
+    });
+  });
+
+  module('error management', () => {
+    test('it throws an error if @resize is not a correct value', async function (assert) {
+      setupOnerror((err: any) => {
+        assert.equal(
+          err.message,
+          'Assertion Failed: [component][OSS::TextArea] The @resize parameter should be a value of resize'
+        );
+      });
+
+      this.resize = 'NotACorrectValue';
+      await render(hbs`<OSS::TextArea @resize={{this.resize}} />`);
+    });
+  });
+});

--- a/tests/integration/components/o-s-s/text-area-test.ts
+++ b/tests/integration/components/o-s-s/text-area-test.ts
@@ -55,7 +55,7 @@ module('Integration | Component | o-s-s/text-area', function (hooks) {
     test('Default height', async function (assert) {
       await render(hbs`<OSS::TextArea />`);
 
-      assert.equal(document.querySelector(this.textareaSelector).offsetHeight, 36);
+      assert.equal(document.querySelector(this.textareaSelector).offsetHeight, 52);
     });
 
     test('Row change height', async function (assert) {


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the context of this pull request and its purpose. -->

Related to: [ENG-269](https://linear.app/upfluence/issue/ENG-269/[groundwork]-new-osstextarea-component)

### What are the observable changes?
<img width="839" alt="Capture d’écran 2023-06-13 à 09 23 27" src="https://github.com/upfluence/oss-components/assets/111493996/be47a6a9-e871-4511-9d1c-388498ada684">
<img width="839" alt="Capture d’écran 2023-06-13 à 09 23 37" src="https://github.com/upfluence/oss-components/assets/111493996/545da9df-82fd-453a-a82a-b934f7f285a2">


### Good PR checklist
- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [x] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled
