### PR TITLE
Change default placeholder value for OSS::PasswordInput 

### DIFF
--- a/addon/components/o-s-s/password-input.stories.js
+++ b/addon/components/o-s-s/password-input.stories.js
@@ -21,7 +21,7 @@ export default {
         type: {
           summary: 'string'
         },
-        defaultValue: { summary: '*************' }
+        defaultValue: { summary: '••••••••••••' }
       },
       control: { type: 'text' }
     },

--- a/addon/components/o-s-s/password-input.ts
+++ b/addon/components/o-s-s/password-input.ts
@@ -4,7 +4,7 @@ import { tracked } from '@glimmer/tracking';
 import Component from '@glimmer/component';
 import { assert } from '@ember/debug';
 
-const DEFAULT_PLACEHOLDER = '*************';
+const DEFAULT_PLACEHOLDER = '••••••••••••';
 
 interface OSSPasswordInputArgs {
   value: string | null;


### PR DESCRIPTION
### What does this PR do?

Change default placeholder value for `OSS::PasswordInput`.

Related to: nothing (design update)

### What are the observable changes?
![Screenshot from 2023-06-13 11-51-55](https://github.com/upfluence/oss-components/assets/43567222/1ef01d56-807f-4b94-b836-37ab7c48e268)

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [ ] Only addresses one issue
- [x] Properly assigned
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled
