### PR TITLE
Add: defaultAction & lockedAction in sidebar item

### DIFF
--- a/addon/components/o-s-s/layout/sidebar.hbs
+++ b/addon/components/o-s-s/layout/sidebar.hbs
@@ -1,6 +1,6 @@
 <div class="oss-sidebar--containers fx-col" ...attributes>
   <div class="logo-container">
-    <div onClick={{this.onHomeAction}} role="button">
+    <div {{on "click" this.onHomeAction}} role="button">
       <img src={{@logo}} alt="brand" />
     </div>
   </div>

--- a/addon/components/o-s-s/layout/sidebar/item.hbs
+++ b/addon/components/o-s-s/layout/sidebar/item.hbs
@@ -1,4 +1,5 @@
-<div class="oss-sidebar-item" disabled={{if this.locked "disabled"}} ...attributes>
+<div class="oss-sidebar-item" disabled={{if this.locked "disabled"}} onClick={{this.onClick}}
+     role="button" ...attributes>
   {{#if this.locked}}
     <div class="oss-sidebar-item--locked">
       <i class="fal fa-lock"></i>

--- a/addon/components/o-s-s/layout/sidebar/item.hbs
+++ b/addon/components/o-s-s/layout/sidebar/item.hbs
@@ -1,5 +1,5 @@
-<div class="oss-sidebar-item" disabled={{if this.locked "disabled"}} onClick={{this.onClick}}
-     role="button" ...attributes>
+<div class="oss-sidebar-item" disabled={{if this.locked "disabled"}} {{on "click" this.onClick}} role="button"
+     ...attributes>
   {{#if this.locked}}
     <div class="oss-sidebar-item--locked">
       <i class="fal fa-lock"></i>

--- a/addon/components/o-s-s/layout/sidebar/item.stories.js
+++ b/addon/components/o-s-s/layout/sidebar/item.stories.js
@@ -1,4 +1,5 @@
 import hbs from 'htmlbars-inline-precompile';
+import { action } from '@storybook/addon-actions';
 
 export default {
   title: 'Components/OSS::Layout::Sidebar::Item',
@@ -33,6 +34,24 @@ export default {
       control: {
         type: 'boolean'
       }
+    },
+    defaultAction: {
+      description: 'Function to be called on click per default',
+      table: {
+        category: 'Actions',
+        type: {
+          summary: 'defaultAction(): void'
+        }
+      }
+    },
+    lockedAction: {
+      description: 'Function to be called on click when item is locked',
+      table: {
+        category: 'Actions',
+        type: {
+          summary: 'lockedAction(): void'
+        }
+      }
     }
   },
   parameters: {
@@ -48,13 +67,18 @@ export default {
 const defaultArgs = {
   icon: 'far fa-search',
   hasNotifications: false,
-  locked: false
+  locked: false,
+  defaultAction: action('defaultAction'),
+  lockedAction: action('lockedAction')
 };
 
 const Template = (args) => ({
   template: hbs`
     <div style="background: var(--sidebar-bg-color)">
-      <OSS::Layout::Sidebar::Item @icon={{this.icon}} @locked={{this.locked}} @hasNotifications={{this.hasNotifications}}/>
+      <OSS::Layout::Sidebar::Item @icon={{this.icon}} @locked={{this.locked}} 
+                                  @hasNotifications={{this.hasNotifications}}
+                                  @defaultAction={{this.defaultAction}}
+                                  @lockedAction={{this.lockedAction}}/>
     </div>
   `,
   context: args

--- a/addon/components/o-s-s/layout/sidebar/item.ts
+++ b/addon/components/o-s-s/layout/sidebar/item.ts
@@ -1,9 +1,12 @@
 import Component from '@glimmer/component';
+import { action } from '@ember/object';
 
 interface OSSLayoutSidebarItemArgs {
   icon: string;
   locked?: boolean;
   hasNotifications?: boolean;
+  defaultAction?(): void;
+  lockedAction?(): void;
 }
 
 export default class OSSLayoutSidebarItem extends Component<OSSLayoutSidebarItemArgs> {
@@ -13,5 +16,13 @@ export default class OSSLayoutSidebarItem extends Component<OSSLayoutSidebarItem
 
   get hasNotifications(): boolean {
     return this.args.hasNotifications || false;
+  }
+
+  @action
+  onClick(): void {
+    if (this.locked) {
+      return this.args.lockedAction?.();
+    }
+    return this.args.defaultAction?.();
   }
 }

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -1,15 +1,17 @@
 <div class="fx-row">
   <OSS::Layout::Sidebar @logo="/assets/images/upfluence-white-logo.svg" @homeAction={{fn this.redirectTo "/"}}>
     <:content>
-      <OSS::Layout::Sidebar::Item @icon="fas fa-search" class="active" onClick={{fn this.redirectTo "search"}} />
-      <OSS::Layout::Sidebar::Item @icon="fal fa-list" onClick={{fn this.redirectTo "list"}} />
-      <OSS::Layout::Sidebar::Item @icon="fal fa-envelope" onClick={{fn this.redirectTo "envelope"}} />
-      <OSS::Layout::Sidebar::Item @icon="fal fa-bullhorn" onClick={{fn this.redirectTo "bullhorn"}} />
-      <OSS::Layout::Sidebar::Item @icon="fal fa-credit-card" @locked={{true}} />
-      <OSS::Layout::Sidebar::Item @icon="fal fa-project-diagram" onClick={{fn this.redirectTo "diagram"}} />
-      <OSS::Layout::Sidebar::Item @icon="fal fa-chart-pie" onClick={{fn this.redirectTo "pie"}} />
-      <OSS::Layout::Sidebar::Item @icon="fal fa-bullseye-pointer" @hasNotifications={{true}}
-                                  onClick={{fn this.redirectTo "pointer"}} />
+      <OSS::Layout::Sidebar::Item @icon="far fa-search" class="active" @defaultAction={{fn this.redirectTo "search"}} />
+      <OSS::Layout::Sidebar::Item @icon="far fa-list" @defaultAction={{fn this.redirectTo "list"}} />
+      <OSS::Layout::Sidebar::Item @icon="far fa-envelope" @defaultAction={{fn this.redirectTo "envelope"}} />
+      <OSS::Layout::Sidebar::Item @icon="far fa-bullhorn" @defaultAction={{fn this.redirectTo "bullhorn"}} />
+      <OSS::Layout::Sidebar::Item @icon="far fa-credit-card" @locked={{true}}
+                                  @defaultAction={{fn this.redirectTo "credit-card"}}
+                                  @lockedAction={{fn this.redirectTo "locked credit-card"}} />
+      <OSS::Layout::Sidebar::Item @icon="far fa-project-diagram" @defaultAction={{fn this.redirectTo "diagram"}} />
+      <OSS::Layout::Sidebar::Item @icon="far fa-chart-pie" @defaultAction={{fn this.redirectTo "pie"}} />
+      <OSS::Layout::Sidebar::Item @icon="far fa-bullseye-pointer" @hasNotifications={{true}}
+                                  @defaultAction={{fn this.redirectTo "pointer"}} />
     </:content>
     <:footer>
       <OSS::Layout::Sidebar::Item @icon="fal fa-info-circle" />
@@ -17,7 +19,7 @@
                    @initials="Ts" />
     </:footer>
   </OSS::Layout::Sidebar>
-  <div style="padding-left: var(--sidebar-width); width:100%;">
+  <div style="width:100%; height:100vh; overflow: auto;">
     <div class="fx-row fx-xalign-start fx-gap-px-10 margin-md">
       <OSS::TextArea @value={{this.numberValue}} @onChange={{this.handleNumberInput}}
                      @errorMessage="This is an error message" @rows={{8}} @resize="vertical" />

--- a/tests/integration/components/o-s-s/layout/sidebar/item-test.ts
+++ b/tests/integration/components/o-s-s/layout/sidebar/item-test.ts
@@ -1,7 +1,8 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, find } from '@ember/test-helpers';
+import { render, find, click } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
+import sinon from 'sinon';
 
 module('Integration | Component | oss/layout/sidebar/item', function (hooks) {
   setupRenderingTest(hooks);
@@ -37,6 +38,33 @@ module('Integration | Component | oss/layout/sidebar/item', function (hooks) {
     test('When hasNotification is true', async function (assert) {
       await render(hbs`<OSS::Layout::Sidebar::Item  @hasNotifications={{true}}/>`);
       assert.dom('.oss-sidebar-item--notification').exists();
+    });
+  });
+
+  module('Actions', function (hooks) {
+    hooks.beforeEach(function () {
+      this.defaultAction = sinon.spy();
+      this.lockedAction = sinon.spy();
+    });
+
+    test('OnClick defaultAction is triggered', async function (assert) {
+      await render(
+        hbs`<OSS::Layout::Sidebar::Item @defaultAction={{this.defaultAction}} @lockedAction={{this.lockedAction}}/>`
+      );
+      await click('.oss-sidebar-item');
+
+      assert.ok(this.defaultAction.calledOnce);
+      assert.ok(this.lockedAction.notCalled);
+    });
+
+    test('When locked is true lockedAction is triggered', async function (assert) {
+      await render(
+        hbs`<OSS::Layout::Sidebar::Item  @locked={{true}} @defaultAction={{this.defaultAction}} @lockedAction={{this.lockedAction}}/>`
+      );
+      await click('.oss-sidebar-item');
+
+      assert.ok(this.defaultAction.notCalled);
+      assert.ok(this.lockedAction.calledOnce);
     });
   });
 


### PR DESCRIPTION
### What does this PR do?
Handle different action when item is locked or not 

Related to: [#ENG-442](https://linear.app/upfluence/issue/ENG-442/implement-osslayoutssidebar-component)

### What are the observable changes?
<!-- This question could be adequate with multiple use cases, for example: -->

<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->

### Good PR checklist
- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [x] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled
