### PR TITLE
Add OSS:Icon & tests

### DIFF
--- a/addon/components/o-s-s/icon.hbs
+++ b/addon/components/o-s-s/icon.hbs
@@ -1,0 +1,1 @@
+<i class={{this.computedClass}} ...attributes></i>

--- a/addon/components/o-s-s/icon.stories.js
+++ b/addon/components/o-s-s/icon.stories.js
@@ -17,8 +17,8 @@ export default {
       control: { type: 'text' },
       type: { required: true }
     },
-    type: {
-      description: 'The style type of the fontawesome icon',
+    style: {
+      description: 'The style of the fontawesome icon',
       table: {
         type: {
           summary: StyleTypes.join('|')
@@ -41,13 +41,13 @@ export default {
 
 const defaultArgs = {
   icon: 'fa-laptop-code',
-  type: 'regular'
+  style: 'regular'
 };
 
 const Template = (args) => ({
   template: hbs`
     <div style="font-size: 60px;">
-      <OSS::Icon @icon={{this.icon}} @type={{this.type}} />
+      <OSS::Icon @icon={{this.icon}} @style={{this.style}} />
     </div>
   `,
   context: args

--- a/addon/components/o-s-s/icon.stories.js
+++ b/addon/components/o-s-s/icon.stories.js
@@ -1,0 +1,57 @@
+import hbs from 'htmlbars-inline-precompile';
+
+const StyleTypes = ['solid', 'regular', 'light', 'duotone', 'brand'];
+
+export default {
+  title: 'Components/OSS::Icon',
+  component: 'icon',
+  argTypes: {
+    icon: {
+      description: 'The fontawesome icon value',
+      table: {
+        type: {
+          summary: 'string'
+        },
+        defaultValue: { summary: 'undefined' }
+      },
+      control: { type: 'text' },
+      type: { required: true }
+    },
+    type: {
+      description: 'The style type of the fontawesome icon',
+      table: {
+        type: {
+          summary: StyleTypes.join('|')
+        },
+        defaultValue: { summary: 'regular' }
+      },
+      options: StyleTypes,
+      control: { type: 'select' }
+    }
+  },
+  parameters: {
+    docs: {
+      description: {
+        component: 'An fontawesome icon at 5.15.4 version'
+      },
+      iframeHeight: 200
+    }
+  }
+};
+
+const defaultArgs = {
+  icon: 'fa-laptop-code',
+  type: 'regular'
+};
+
+const Template = (args) => ({
+  template: hbs`
+    <div style="font-size: 60px;">
+      <OSS::Icon @icon={{this.icon}} @type={{this.type}} />
+    </div>
+  `,
+  context: args
+});
+
+export const BasicUsage = Template.bind({});
+BasicUsage.args = defaultArgs;

--- a/addon/components/o-s-s/icon.ts
+++ b/addon/components/o-s-s/icon.ts
@@ -1,0 +1,31 @@
+import Component from '@glimmer/component';
+import { assert } from '@ember/debug';
+
+export type IconType = 'solid' | 'regular' | 'light' | 'duotone' | 'brand';
+
+interface OSSIconArgs {
+  icon: string;
+  type?: IconType;
+}
+
+export const TYPE_CLASSES = {
+  solid: 'fas',
+  regular: 'far',
+  light: 'fal',
+  duotone: 'fad',
+  brand: 'fab'
+};
+
+export default class OSSIcon extends Component<OSSIconArgs> {
+  constructor(owner: unknown, args: OSSIconArgs) {
+    super(owner, args);
+    assert('[component][OSS::Icon] The @icon parameter is mandatory', typeof args.icon !== 'undefined');
+  }
+
+  get computedClass(): string {
+    const classes: string[] = [];
+    classes.push(TYPE_CLASSES[this.args.type ?? 'regular']);
+    classes.push(this.args.icon);
+    return classes.join(' ');
+  }
+}

--- a/addon/components/o-s-s/icon.ts
+++ b/addon/components/o-s-s/icon.ts
@@ -1,14 +1,14 @@
 import Component from '@glimmer/component';
 import { assert } from '@ember/debug';
 
-export type IconType = 'solid' | 'regular' | 'light' | 'duotone' | 'brand';
+export type IconStyle = 'solid' | 'regular' | 'light' | 'duotone' | 'brand';
 
 interface OSSIconArgs {
   icon: string;
-  type?: IconType;
+  style?: IconStyle;
 }
 
-export const TYPE_CLASSES = {
+export const STYLE_CLASSES = {
   solid: 'fas',
   regular: 'far',
   light: 'fal',
@@ -24,7 +24,7 @@ export default class OSSIcon extends Component<OSSIconArgs> {
 
   get computedClass(): string {
     const classes: string[] = [];
-    classes.push(TYPE_CLASSES[this.args.type ?? 'regular']);
+    classes.push(STYLE_CLASSES[this.args.style ?? 'regular']);
     classes.push(this.args.icon);
     return classes.join(' ');
   }

--- a/app/components/o-s-s/icon.js
+++ b/app/components/o-s-s/icon.js
@@ -1,0 +1,1 @@
+export { default } from '@upfluence/oss-components/components/o-s-s/icon';

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -22,11 +22,11 @@
   <div style="width:100%; height:100vh; overflow: auto;">
     <div class="fx-row fx-xalign-start fx-gap-px-10 margin-md">
       <OSS::Icon @icon="fa-laptop-code" />
-      <OSS::Icon @icon="fa-laptop-code" @type="solid" />
-      <OSS::Icon @icon="fa-laptop-code" @type="regular" />
-      <OSS::Icon @icon="fa-laptop-code" @type="light" />
-      <OSS::Icon @icon="fa-laptop-code" @type="duotone" />
-      <OSS::Icon @icon="fa-facebook-square" @type="brand" />
+      <OSS::Icon @icon="fa-laptop-code" @style="solid" />
+      <OSS::Icon @icon="fa-laptop-code" @style="regular" />
+      <OSS::Icon @icon="fa-laptop-code" @style="light" />
+      <OSS::Icon @icon="fa-laptop-code" @style="duotone" />
+      <OSS::Icon @icon="fa-facebook-square" @style="brand" />
     </div>
     <div class="fx-row fx-xalign-start fx-gap-px-10 margin-md">
       <OSS::TextArea @value={{this.numberValue}} @onChange={{this.handleNumberInput}}

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -21,6 +21,14 @@
   </OSS::Layout::Sidebar>
   <div style="width:100%; height:100vh; overflow: auto;">
     <div class="fx-row fx-xalign-start fx-gap-px-10 margin-md">
+      <OSS::Icon @icon="fa-laptop-code" />
+      <OSS::Icon @icon="fa-laptop-code" @type="solid" />
+      <OSS::Icon @icon="fa-laptop-code" @type="regular" />
+      <OSS::Icon @icon="fa-laptop-code" @type="light" />
+      <OSS::Icon @icon="fa-laptop-code" @type="duotone" />
+      <OSS::Icon @icon="fa-facebook-square" @type="brand" />
+    </div>
+    <div class="fx-row fx-xalign-start fx-gap-px-10 margin-md">
       <OSS::TextArea @value={{this.numberValue}} @onChange={{this.handleNumberInput}}
                      @errorMessage="This is an error message" @rows={{8}} @resize="vertical" />
       <OSS::TextArea @value={{this.numberValue}} @onChange={{this.handleNumberInput}} @rows={{1}} />
@@ -99,7 +107,7 @@
       <OSS::PowerSelect @items={{this.superHeroes}} @selectedItems={{this.superHeroes}}
                         @onChange={{this.onPowerSelectChange}} @onSearch={{this.onPowerSelectSearch}}>
         <:selected-item as |selectedProduct|>
-          <OSS::Chip @label={{selectedProduct}} @onRemove={{fn this.onPowerSelectChange }} @maxDisplayWidth={{100}} />
+          <OSS::Chip @label={{selectedProduct}} @onRemove={{this.onPowerSelectChange }} @maxDisplayWidth={{100}} />
         </:selected-item>
         <:option-item as |item|>
           {{item}}
@@ -109,7 +117,7 @@
       <OSS::PowerSelect @items={{this.superHeroes}} @selectedItems={{null}} @onChange={{this.onPowerSelectChange}}
                         @onSearch={{this.onPowerSelectSearch}}>
         <:selected-item as |selectedProduct|>
-          <OSS::Chip @label={{selectedProduct}} @onRemove={{fn this.onPowerSelectChange }} @maxDisplayWidth={{100}} />
+          <OSS::Chip @label={{selectedProduct}} @onRemove={{this.onPowerSelectChange }} @maxDisplayWidth={{100}} />
         </:selected-item>
         <:option-item as |item|>
           {{item}}

--- a/tests/integration/components/o-s-s/icon-test.ts
+++ b/tests/integration/components/o-s-s/icon-test.ts
@@ -3,7 +3,7 @@ import { setupRenderingTest } from 'ember-qunit';
 import { render, setupOnerror } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
-const TYPE_CLASSES = {
+const STYLE_CLASSES = {
   solid: 'fas',
   regular: 'far',
   light: 'fal',
@@ -24,15 +24,15 @@ module('Integration | Component | o-s-s/icon', function (hooks) {
     assert.dom('i').hasClass('fa-code-merge');
   });
 
-  test(`it renders the correct default type class`, async function (assert) {
+  test(`it renders the correct default style class`, async function (assert) {
     await render(hbs`<OSS::Icon @icon="fa-code-merge" />`);
     assert.dom('i').hasClass('far');
   });
 
-  for (const [key, value] of Object.entries(TYPE_CLASSES)) {
-    test(`it renders the correct type ${key} class`, async function (assert) {
-      this.type = key;
-      await render(hbs`<OSS::Icon @icon="fa-code-merge" @type={{this.type}} />`);
+  for (const [key, value] of Object.entries(STYLE_CLASSES)) {
+    test(`it renders the correct style ${key} class`, async function (assert) {
+      this.style = key;
+      await render(hbs`<OSS::Icon @icon="fa-code-merge" @style={{this.style}} />`);
       assert.dom('i').hasClass(value);
     });
   }

--- a/tests/integration/components/o-s-s/icon-test.ts
+++ b/tests/integration/components/o-s-s/icon-test.ts
@@ -1,0 +1,47 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render, setupOnerror } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+const TYPE_CLASSES = {
+  solid: 'fas',
+  regular: 'far',
+  light: 'fal',
+  duotone: 'fad',
+  brand: 'fab'
+};
+
+module('Integration | Component | o-s-s/icon', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function (assert) {
+    await render(hbs`<OSS::Icon @icon="fa-laptop-code" />`);
+    assert.dom('i').exists();
+  });
+
+  test('it renders the correct icon class', async function (assert) {
+    await render(hbs`<OSS::Icon @icon="fa-code-merge" />`);
+    assert.dom('i').hasClass('fa-code-merge');
+  });
+
+  test(`it renders the correct default type class`, async function (assert) {
+    await render(hbs`<OSS::Icon @icon="fa-code-merge" />`);
+    assert.dom('i').hasClass('far');
+  });
+
+  for (const [key, value] of Object.entries(TYPE_CLASSES)) {
+    test(`it renders the correct type ${key} class`, async function (assert) {
+      this.type = key;
+      await render(hbs`<OSS::Icon @icon="fa-code-merge" @type={{this.type}} />`);
+      assert.dom('i').hasClass(value);
+    });
+  }
+
+  test('it throws an error if icon argument is missing', async function (assert) {
+    setupOnerror((error: Error) => {
+      assert.equal(error.message, 'Assertion Failed: [component][OSS::Icon] The @icon parameter is mandatory');
+    });
+
+    await render(hbs`<OSS::Icon />`);
+  });
+});


### PR DESCRIPTION
### What does this PR do?

Add OSS:Icon & tests

Related to: https://linear.app/upfluence/issue/ENG-508/ossicon-component

### What are the observable changes?
![Screenshot from 2023-07-05 12-16-32](https://github.com/upfluence/oss-components/assets/43567222/6165cf96-d673-458c-ace9-2dd633e8bb13)

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [x] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled
