### PR TITLE
Use OSS::Icon and update OSS::Skeleton

### DIFF
--- a/addon/components/o-s-s/alert.hbs
+++ b/addon/components/o-s-s/alert.hbs
@@ -2,7 +2,7 @@
   <div class="indicator"></div>
   <div class="main-container {{if this.plain 'main-container--plain'}}">
     <span class="icon">
-      <i class={{concat "far " this.iconClass}}></i>
+      <OSS::Icon @icon={{this.iconClass}} />
     </span>
     <div class="text-container">
       {{#if @title}}

--- a/addon/components/o-s-s/badge.hbs
+++ b/addon/components/o-s-s/badge.hbs
@@ -1,6 +1,6 @@
 <div class={{this.computedClass}} ...attributes>
   {{#if @icon}}
-    <i class="{{@icon}}"></i>
+    <OSS::Icon @style={{fa-icon-style @icon}} @icon={{fa-icon-value @icon}} />
   {{else if @image}}
     <img src={{@image}} alt={{t "oss-components.badge.image_alt"}} />
   {{else}}

--- a/addon/components/o-s-s/banner.hbs
+++ b/addon/components/o-s-s/banner.hbs
@@ -3,7 +3,8 @@
   {{#if (has-block "custom-icon")}}
     <div>{{yield to="custom-icon"}}</div>
   {{else if @icon}}
-    <i class="{{@icon}} upf-badge upf-badge--shape-round upf-badge--size-md"></i>
+    <OSS::Icon @style={{fa-icon-style @icon}} @icon={{fa-icon-value @icon}}
+               class="upf-badge upf-badge--shape-round upf-badge--size-md" />
   {{else if @image}}
     <img class="upf-badge upf-badge--size-md upf-badge--shape-round" src={{@image}} alt="banner" />
   {{/if}}

--- a/addon/components/o-s-s/button-dropdown.hbs
+++ b/addon/components/o-s-s/button-dropdown.hbs
@@ -2,7 +2,7 @@
   <div class="oss-button-dropdown__trigger fx-row fx-xalign-center">
     <div class="fx-row fx-xalign-center fx-gap-px-6">
       {{#if @icon}}
-        <i class={{@icon}}></i>
+        <OSS::Icon @style={{fa-icon-style @icon}} @icon={{fa-icon-value @icon}} />
       {{/if}}
 
       {{#if @label}}
@@ -11,7 +11,7 @@
     </div>
 
     <div class="fx-row fx-xalign-center" role="button" {{on "click" this.toggleDropdown}}>
-      <i class="far fa-caret-{{if this.displayDropdown 'up' 'down'}}"></i>
+      <OSS::Icon @icon="fa-caret-{{if this.displayDropdown 'up' 'down'}}" />
     </div>
   </div>
 

--- a/addon/components/o-s-s/button-dropdown.stories.js
+++ b/addon/components/o-s-s/button-dropdown.stories.js
@@ -45,7 +45,7 @@ const Template = (args) => ({
     <OSS::ButtonDropdown @icon={{this.icon}} @label={{this.label}}>
       <:items>
         <div class="oss-button-dropdown__item">
-          <i class="fas fa-share"></i> Share
+          <OSS::Icon @style="solid" @icon="fa-share" /> Share
         </div>
       </:items>
     </OSS::ButtonDropdown>

--- a/addon/components/o-s-s/button.hbs
+++ b/addon/components/o-s-s/button.hbs
@@ -3,10 +3,10 @@
   {{#if this.intervalState}}
     {{t "oss-components.button.cancel_message" time=this.counterTimeLeftSecond}}
   {{else if this.loadingState}}
-    <i class="fas fa-circle-notch fa-spin"></i>
+    <OSS::Icon @style="solid" @icon="fa-circle-notch fa-spin" />
   {{else}}
     {{#if @icon}}
-      <i class={{@icon}}></i>
+      <OSS::Icon @style={{fa-icon-style @icon}} @icon={{fa-icon-value @icon}} />
     {{/if}}
 
     {{#if @label}}

--- a/addon/components/o-s-s/chip.hbs
+++ b/addon/components/o-s-s/chip.hbs
@@ -4,5 +4,5 @@
         {{enable-tooltip title=(if @maxDisplayWidth @label '') placement='top'}}>
     {{@label}}
   </span>
-  <i class="far fa-times-circle" role={{unless @disabled 'button'}} {{on "click" this.onCrossClick}} />
+  <OSS::Icon @icon="fa-times-circle" role={{unless @disabled 'button'}} {{on "click" this.onCrossClick}} />
 </div>

--- a/addon/components/o-s-s/country-selector.hbs
+++ b/addon/components/o-s-s/country-selector.hbs
@@ -9,9 +9,9 @@
       <span class="{{unless this.selectedCountry 'text-color-default-light'}}">{{this.inputLabel}}</span>
     </div>
     {{#if this.dropdownVisibility}}
-      <i class="far fa-chevron-up"></i>
+      <OSS::Icon @icon="fa-chevron-up" />
     {{else}}
-      <i class="far fa-chevron-down"></i>
+      <OSS::Icon @icon="fa-chevron-down" />
     {{/if}}
   </div>
   {{#if this.dropdownVisibility}}
@@ -27,7 +27,7 @@
           <span class="text-color-default-light margin-left-xx-sm">{{item.name}}</span>
           {{#if (eq this.selectedCountry item)}}
             <div class="fx-1"></div>
-            <i class="far fa-check text-color-bright-purple padding-right-px-6"></i>
+            <OSS::Icon @icon="fa-check" class="font-color-primary-500 padding-right-px-6" />
           {{/if}}
         </div>
       </:option>

--- a/addon/components/o-s-s/currency-input.hbs
+++ b/addon/components/o-s-s/currency-input.hbs
@@ -13,9 +13,9 @@
 
       {{#if this.allowCurrencyUpdate}}
         {{#if this.currencySelectorShown}}
-          <i class="far fa-chevron-up margin-left-xxx-sm"></i>
+          <OSS::Icon @icon="fa-chevron-up" class="margin-left-px-6" />
         {{else}}
-          <i class="far fa-chevron-down margin-left-xxx-sm"></i>
+          <OSS::Icon @icon="fa-chevron-down" class="margin-left-px-6" />
         {{/if}}
       {{/if}}
     </div>
@@ -27,7 +27,7 @@
   </div>
   {{#if @errorMessage}}
     <div class="font-color-error-500 margin-top-px-6 fx-row fx-gap-px-6 fx-xalign-center">
-      <i class="far fa-exclamation-triangle"></i> {{@errorMessage}}
+      <OSS::Icon @icon="fa-exclamation-triangle" /> {{@errorMessage}}
     </div>
   {{/if}}
   {{#if this.currencySelectorShown}}
@@ -40,7 +40,7 @@
           <span class="symbol text-color-default-light margin-left-xx-sm">{{currency.symbol}}</span>
           <span class="text-color-default-light margin-left-xx-sm fx-1">{{currency.code}}</span>
           {{#if (eq this.selectedCurrency currency)}}
-            <i class="far fa-check text-color-bright-purple padding-right-px-6"></i>
+            <OSS::Icon @icon="fa-check" class="font-color-primary-500 padding-right-px-6" />
           {{/if}}
         </div>
       </:option>

--- a/addon/components/o-s-s/infinite-select.hbs
+++ b/addon/components/o-s-s/infinite-select.hbs
@@ -11,11 +11,7 @@
                {{if (eq this.items.length 0) 'upf-infinite-select__items-container--empty'}}"
                {{on-bottom-reached this.onBottomReached}} {{scroll-shadow}}>
       {{#if (and @loading (not @loadingMore))}}
-        <div class="upf-skeleton-content fx-col fx-malign-start padding-xx-sm">
-          {{#each this.loadingRows as |width|}}
-            <div class="upf-skeleton-effect margin-bottom-xx-sm" style="width: 100%; height: 8px;"></div>
-          {{/each}}
-        </div>
+        <OSS::Skeleton @width="100%" @height="18" @multiple={{5}} @direction="col" />
       {{else}}
         {{#each this.items as |item|}}
           <li class="upf-infinite-select__item" role="button" {{on "click" (fn this.didSelectItem item)}}>
@@ -45,11 +41,7 @@
         {{/each}}
 
         {{#if @loadingMore}}
-          <div class="upf-skeleton-content fx-col fx-malign-start padding-xx-sm">
-            {{#each this.loadingMoreRows as |width|}}
-              <div class="upf-skeleton-effect margin-bottom-xx-sm" style="width: 100%; height: 8px;"></div>
-            {{/each}}
-          </div>
+          <OSS::Skeleton @width="100%" @height="18" @multiple={{3}} @direction="col" />
         {{/if}}
       {{/if}}
     </ul>

--- a/addon/components/o-s-s/infinite-select.ts
+++ b/addon/components/o-s-s/infinite-select.ts
@@ -25,9 +25,6 @@ type InfinityItem = {
 const DEFAULT_ITEM_LABEL = 'name';
 
 export default class OSSInfiniteSelect extends Component<InfiniteSelectArgs> {
-  loadingRows = new Array(5);
-  loadingMoreRows = new Array(3);
-
   @tracked _searchKeyword: string = '';
 
   constructor(owner: unknown, args: InfiniteSelectArgs) {

--- a/addon/components/o-s-s/input-container.stories.js
+++ b/addon/components/o-s-s/input-container.stories.js
@@ -85,9 +85,9 @@ const AdvancedWithNamedBlocksTemplate = (args) => ({
       <OSS::InputContainer>
         <:prefix>
           {{#if (gt this.lastname.length 0)}}
-            <i class="fa fa-check text-color-success"></i>
+            <OSS::Icon @icon="fa-check" class="font-color-success-500" />
           {{else}}
-            <i class="fa fa-times text-color-error"></i>
+            <OSS::Icon @icon="fa-times" class="font-color-error-500" />
           {{/if}}
         </:prefix>
         <:input>
@@ -95,9 +95,9 @@ const AdvancedWithNamedBlocksTemplate = (args) => ({
         </:input>
         <:suffix>
           {{#if (gt this.lastname.length 0)}}
-            <i class="fa fa-check text-color-success"></i>
+            <OSS::Icon @icon="fa-check" class="font-color-success-500" />
           {{else}}
-            <i class="fa fa-times text-color-error"></i>
+            <OSS::Icon @icon="fa-times" class="font-color-error-500" />
           {{/if}}
         </:suffix>
       </OSS::InputContainer>

--- a/addon/components/o-s-s/layout/sidebar/item.hbs
+++ b/addon/components/o-s-s/layout/sidebar/item.hbs
@@ -2,11 +2,11 @@
      ...attributes>
   {{#if this.locked}}
     <div class="oss-sidebar-item--locked">
-      <i class="fal fa-lock"></i>
+      <OSS::Icon @style="solid" @icon="fa-lock" />
     </div>
   {{/if}}
   <div class="oss-sidebar-item--icon">
-    <i class={{@icon}}></i>
+    <OSS::Icon @style={{fa-icon-style @icon}} @icon={{fa-icon-value @icon}} />
   </div>
   {{#if this.hasNotifications}}
     <span class="oss-sidebar-item--notification" />

--- a/addon/components/o-s-s/link.hbs
+++ b/addon/components/o-s-s/link.hbs
@@ -1,6 +1,6 @@
 <div class="upf-link" role="button" {{on "click" this.goTo}} ...attributes>
   {{#if @icon}}
-    <i class={{@icon}}></i>
+    <OSS::Icon @style={{fa-icon-style @icon}} @icon={{fa-icon-value @icon}} />
   {{/if}}
 
   {{#if @label}}

--- a/addon/components/o-s-s/modal-dialog.hbs
+++ b/addon/components/o-s-s/modal-dialog.hbs
@@ -6,8 +6,8 @@
         <span class="title">{{@title}}</span>
         <span class="subtitle">{{@subtitle}}</span>
       </div>
-      <i class="fa fa-close padding-xx-sm" {{on "click" this.closeModal}} role="button"
-         data-control-name="close-modal-button"></i>
+      <OSS::Icon @style="solid" @icon="fa-times" class="padding-px-12" {{on "click" this.closeModal}} role="button"
+                 data-control-name="close-modal-button" />
     </header>
 
     {{#if (has-block "illustration")}}

--- a/addon/components/o-s-s/nav-tab.hbs
+++ b/addon/components/o-s-s/nav-tab.hbs
@@ -4,16 +4,16 @@
             {{on "click" (fn this.onSelectTab tab)}} disabled={{tab.disabled}}>
       <div class="fx-row tab-content fx-xalign-center fx-gap-px-9">
         {{#if tab.icon}}
-          <i class={{tab.icon}} />
+          <OSS::Icon @style={{fa-icon-style tab.icon}} @icon={{fa-icon-value tab.icon}} />
         {{/if}}
         {{#if tab.label}}
           <span class="text-size-6">{{tab.label}}</span>
         {{/if}}
         {{#if tab.infoCircle}}
-          <i class="far fa-info-circle" />
+          <OSS::Icon @icon="fa-info-circle" />
         {{/if}}
         {{#if tab.notificationDot}}
-          <i class="fas fa-circle font-color-accent text-size-1" />
+          <OSS::Icon @style="solid" @icon="fa-circle" class="font-color-accent text-size-1" />
         {{/if}}
       </div>
       <div class="border-display" />

--- a/addon/components/o-s-s/phone-number-input.hbs
+++ b/addon/components/o-s-s/phone-number-input.hbs
@@ -3,9 +3,9 @@
     <div class="country-selector fx-row" role="button" {{on "click" this.toggleCountrySelector}}>
       <div class="fflag fflag-{{this.selectedCountry.id}} ff-sm ff-rounded"></div>
       {{#if this.countrySelectorShown}}
-        <i class="fal fa-chevron-up margin-left-xxx-sm"></i>
+        <OSS::Icon @icon="fa-chevron-up" class="margin-left-px-6" />
       {{else}}
-        <i class="fal fa-chevron-down margin-left-xxx-sm"></i>
+        <OSS::Icon @icon="fa-chevron-down" class="margin-left-px-6" />
       {{/if}}
     </div>
     <span class="phone-prefix">{{@prefix}}</span>
@@ -30,7 +30,7 @@
           <span class="text-color-default-light margin-left-xx-sm">{{country.name}}</span>
           <span class="text-color-default-light margin-left-xxx-sm fx-1">(+{{get country.countryCallingCodes 0}})</span>
           {{#if (eq this.selectedCountry country)}}
-            <i class="far fa-check text-color-bright-purple"></i>
+            <OSS::Icon @icon="fa-check" class="font-color-primary-500" />
           {{/if}}
         </div>
       </:option>

--- a/addon/components/o-s-s/power-select.hbs
+++ b/addon/components/o-s-s/power-select.hbs
@@ -13,9 +13,9 @@
       </div>
 
       {{#if this.displaySelect}}
-        <i class="far fa-chevron-up margin-left-px-6 margin-right-px-6 margin-top-px-6"></i>
+        <OSS::Icon @icon="fa-chevron-up" class="margin-left-px-6 margin-right-px-6 margin-top-px-6" />
       {{else}}
-        <i class="far fa-chevron-down margin-left-px-6 margin-right-px-6 margin-top-px-6"></i>
+        <OSS::Icon @icon="fa-chevron-down" class="margin-left-px-6 margin-right-px-6 margin-top-px-6" />
       {{/if}}
     </div>
   </div>

--- a/addon/components/o-s-s/select.hbs
+++ b/addon/components/o-s-s/select.hbs
@@ -13,9 +13,9 @@
         <span class="text-color-default-light">{{this.placeholder}}</span>
       {{/if}}
       {{#if this.displaySelect}}
-        <i class="far fa-chevron-up margin-left-px-6"></i>
+        <OSS::Icon @icon="fa-chevron-up" class="margin-left-px-6" />
       {{else}}
-        <i class="far fa-chevron-down margin-left-px-6"></i>
+        <OSS::Icon @icon="fa-chevron-down" class="margin-left-px-6" />
       {{/if}}
     </div>
   </div>
@@ -35,7 +35,7 @@
           {{/if}}
 
           {{#if (eq @value item)}}
-            <i class="far fa-check font-color-primary-500 padding-right-px-6"></i>
+            <OSS::Icon @icon="fa-check" class="font-color-primary-500 padding-right-px-6" />
           {{/if}}
         </div>
       </:option>
@@ -44,13 +44,13 @@
 
   {{#if @errorMessage}}
     <div class="font-color-error-500 margin-top-px-6 fx-row fx-gap-px-6 fx-xalign-center">
-      <i class="far fa-exclamation-triangle"></i> {{@errorMessage}}
+      <OSS::Icon @icon="fa-exclamation-triangle" /> {{@errorMessage}}
     </div>
   {{/if}}
 
   {{#if @successMessage}}
     <div class="font-color-success-500 margin-top-px-6 fx-row fx-gap-px-6 fx-xalign-center">
-      <i class="far fa-check-circle"></i> {{@successMessage}}
+      <OSS::Icon @icon="fa-check-circle" /> {{@successMessage}}
     </div>
   {{/if}}
 </div>

--- a/addon/components/o-s-s/skeleton.hbs
+++ b/addon/components/o-s-s/skeleton.hbs
@@ -1,5 +1,11 @@
-<div class={{this.computedClass}} style={{this.computedStyle}} ...attributes>
+{{#if @multiple}}
+  <div class="fx-1 {{this.computedClass}}" ...attributes>
+    {{#each this.rows as |row|}}
+      <div class="upf-skeleton-effect" style={{row}}></div>
+    {{/each}}
+  </div>
+{{else}}
   {{#each this.rows as |row|}}
-    <div class={{concat "upf-skeleton-effect " row.class}} style={{row.style}}></div>
+    <div class="upf-skeleton-effect" style={{row}} ...attributes></div>
   {{/each}}
-</div>
+{{/if}}

--- a/addon/components/o-s-s/skeleton.stories.js
+++ b/addon/components/o-s-s/skeleton.stories.js
@@ -1,6 +1,6 @@
 import hbs from 'htmlbars-inline-precompile';
 
-const DirectionTypes = ['row', 'column'];
+const DirectionTypes = ['row', 'col', 'column'];
 
 export default {
   title: 'Components/OSS::Skeleton',
@@ -47,7 +47,7 @@ export default {
       control: { type: 'number' }
     },
     randomize: {
-      description: 'Randomize skeleton effect width',
+      description: 'Randomize skeleton effect width within a 15% range',
       table: {
         type: {
           summary: 'boolean'
@@ -56,7 +56,7 @@ export default {
       },
       control: { type: 'boolean' }
     },
-    type: {
+    direction: {
       description: 'Direction of the skeleton',
       table: {
         type: {
@@ -90,7 +90,7 @@ const Template = (args) => ({
   template: hbs`
     <div class="bg-color-white padding-px-6">
       <OSS::Skeleton @height={{this.height}} @width={{this.width}} @multiple={{this.multiple}} @gap={{this.gap}} 
-                     @type={{this.type}}
+                     @direction={{this.direction}}
                      @randomize={{this.randomize}}/>
     </div>
   `,

--- a/addon/components/o-s-s/social-post-badge.hbs
+++ b/addon/components/o-s-s/social-post-badge.hbs
@@ -2,6 +2,6 @@
      {{on "click" this.onPostTypeClick}}
      ...attributes>
   <div class="icon-container">
-    <i class={{this.iconDefinition}}></i>
+    <OSS::Icon @style={{fa-icon-style this.iconDefinition}} @icon={{fa-icon-value this.iconDefinition}} />
   </div>
 </div>

--- a/addon/components/o-s-s/split-modal.hbs
+++ b/addon/components/o-s-s/split-modal.hbs
@@ -12,7 +12,8 @@
       {{/if}}
     </div>
     <div class="split-modal__preview">
-      <i class="far fa-times close-modal-icon" role="button" {{on "click" this.closeModal}}></i>
+      <OSS::Icon @style="solid" @icon="fa-times" class="close-modal-icon" role="button"
+                 {{on "click" this.closeModal}} />
       {{yield to="preview"}}
     </div>
   </div>

--- a/addon/components/o-s-s/star-rating.hbs
+++ b/addon/components/o-s-s/star-rating.hbs
@@ -1,8 +1,8 @@
 <div class="star-rating fx-row">
   {{#each this.activeStars}}
-    <i class="fas fa-star {{this.activeColorClass}}"></i>
+    <OSS::Icon @style="solid" @icon="fa-star" class={{this.activeColorClass}} />
   {{/each}}
   {{#each this.passiveStars}}
-    <i class="fas fa-star {{this.passiveColorClass}}"></i>
+    <OSS::Icon @style="solid" @icon="fa-star" class={{this.passiveColorClass}} />
   {{/each}}
 </div>

--- a/addon/components/o-s-s/tag.hbs
+++ b/addon/components/o-s-s/tag.hbs
@@ -1,6 +1,6 @@
 <div class={{this.computedClass}} ...attributes>
   {{#if @icon}}
-    <i class={{@icon}}></i>
+    <OSS::Icon @style={{fa-icon-style @icon}} @icon={{fa-icon-value @icon}} />
   {{/if}}
 
   {{#if @label}}

--- a/addon/components/o-s-s/toggle-buttons.ts
+++ b/addon/components/o-s-s/toggle-buttons.ts
@@ -39,7 +39,8 @@ export default class OSSToggleButtons extends Component<OSSToggleButtonsArgs> {
   }
 
   @action
-  onSelectToggle(selectedToggle: string): void {
+  onSelectToggle(selectedToggle: string, event: PointerEvent): void {
+    event.stopPropagation();
     if (this.args.selectedToggle !== selectedToggle) {
       this.args.onSelection(selectedToggle);
     }

--- a/addon/components/o-s-s/upload-item.hbs
+++ b/addon/components/o-s-s/upload-item.hbs
@@ -33,7 +33,7 @@
         {{#if this.error}}
           <span class="fx-row fx-gap-px-6 font-color-gray-500 fx-xalign-center" role="button"
                 data-control-name="upload-item-try-again-button" {{on "click" this.performUpload}}>
-            <i class="far fa-redo"></i> {{t "oss-components.upload-area.errors.try_again"}}
+            <OSS::Icon @icon="fa-redo" /> {{t "oss-components.upload-area.errors.try_again"}}
           </span>
         {{else}}
           <OSS::Button

--- a/addon/helpers/Helpers.stories.mdx
+++ b/addon/helpers/Helpers.stories.mdx
@@ -59,3 +59,11 @@ With route only
   @label='Button that opens link on target'
   {{on 'click' (redirect-to url='https://github.com/upfluence/oss-components' target="_blank")}} />
 ```
+
+## fa-icon-value
+Get the value from a font-awesome icon string
+e.g. "far fa-hourglass" will return "fa-hourglass"
+
+## fa-icon-style
+Get the style from a font-awesome icon string
+e.g. "far fa-hourglass" will return "regular"

--- a/addon/helpers/fa-icon-style.ts
+++ b/addon/helpers/fa-icon-style.ts
@@ -1,0 +1,13 @@
+import Helper from '@ember/component/helper';
+import { assert } from '@ember/debug';
+import { getIconStyle } from '../utils/icon-details';
+
+export default class extends Helper {
+  compute(args: any[]) {
+    const faIconString = args[0];
+
+    assert('[helper][OSS::fa-icon-style] faIconString argument is mandatory', typeof faIconString === 'string');
+
+    return getIconStyle(faIconString);
+  }
+}

--- a/addon/helpers/fa-icon-value.ts
+++ b/addon/helpers/fa-icon-value.ts
@@ -1,0 +1,13 @@
+import Helper from '@ember/component/helper';
+import { assert } from '@ember/debug';
+import { getIconValue } from '../utils/icon-details';
+
+export default class extends Helper {
+  compute(args: any[]) {
+    const faIconString = args[0];
+
+    assert('[helper][OSS::fa-icon-value] faIconString argument is mandatory', typeof faIconString === 'string');
+
+    return getIconValue(faIconString);
+  }
+}

--- a/addon/utils/icon-details.ts
+++ b/addon/utils/icon-details.ts
@@ -1,0 +1,31 @@
+
+
+export type IconStyle = 'solid' | 'regular' | 'light' | 'duotone' | 'brand';
+
+const FA_ICON_PREFIX = 'fa-';
+const STYLE_MATCHER: { [key: string]: IconStyle } = {
+  fas: 'solid',
+  far: 'regular',
+  fal: 'light',
+  fad: 'duotone',
+  fab: 'brand'
+};
+
+export function getIconStyle(fontAwesomeIcon: string): IconStyle {
+  let iconStyle: IconStyle = STYLE_MATCHER.far;
+
+  Object.keys(STYLE_MATCHER).forEach((style: string) => {
+    if (fontAwesomeIcon.includes(style)) {
+      iconStyle = STYLE_MATCHER[style];
+    }
+  });
+  return iconStyle;
+}
+
+export function getIconValue(fontAwesomeIcon: string): string {
+  let iconValues: string[] = [];
+  fontAwesomeIcon.split(' ').forEach((part: string) => {
+    if (part.includes(FA_ICON_PREFIX)) iconValues.push(part);
+  });
+  return iconValues.join(' ');
+}

--- a/app/helpers/fa-icon-style.js
+++ b/app/helpers/fa-icon-style.js
@@ -1,0 +1,1 @@
+export { default, faIconStyle } from '@upfluence/oss-components/helpers/fa-icon-style';

--- a/app/helpers/fa-icon-value.js
+++ b/app/helpers/fa-icon-value.js
@@ -1,0 +1,1 @@
+export { default, faIconValue } from '@upfluence/oss-components/helpers/fa-icon-value';

--- a/app/styles/organisms/Table.stories.mdx
+++ b/app/styles/organisms/Table.stories.mdx
@@ -19,7 +19,7 @@ entire set. This helps users compare and access the data easily.
   <div class="upf-table-v2">
     <div class="upf-table__header">
       <div class="upf-table__cell">
-        Header 1 <i class="fa fa-info-circle"></i>
+        Header 1 <OSS::Icon @icon="fa-info-circle" />
       </div>
       <div class="upf-table__cell">
         Header 2
@@ -48,7 +48,7 @@ entire set. This helps users compare and access the data easily.
           Content 5
         </div>
         <div class="upf-table__cell upf-table__cell--action">
-          <i class="fa fa-chevron-right"></i>
+          <OSS::Icon @icon="fa-chevron-right"/>
         </div>
       </div>
       <div class="upf-table__row">
@@ -62,7 +62,7 @@ entire set. This helps users compare and access the data easily.
           Content 5
         </div>
         <div class="upf-table__cell upf-table__cell--action">
-          <i class="fa fa-chevron-right"></i>
+          <OSS::Icon @icon="fa-chevron-right" />
         </div>
       </div>
     </div>
@@ -75,7 +75,7 @@ entire set. This helps users compare and access the data easily.
   <div class="upf-table-v2 upf-table-v2--clickable">
     <div class="upf-table__header">
       <div class="upf-table__cell">
-        Header 1 <i class="fa fa-info-circle"></i>
+        Header 1 <OSS::Icon @icon="fa-info-circle" />
       </div>
       <div class="upf-table__cell">
         Header 2
@@ -104,7 +104,7 @@ entire set. This helps users compare and access the data easily.
           Content 5
         </div>
         <div class="upf-table__cell upf-table__cell--action">
-          <i class="fa fa-chevron-right"></i>
+          <OSS::Icon @icon="fa-chevron-right" />
         </div>
       </div>
       <div class="upf-table__row">
@@ -118,7 +118,7 @@ entire set. This helps users compare and access the data easily.
           Content 5
         </div>
         <div class="upf-table__cell upf-table__cell--action">
-          <i class="fa fa-chevron-right"></i>
+          <OSS::Icon @icon="fa-chevron-right" />
         </div>
       </div>
     </div>

--- a/app/templates/components/input-wrapper.hbs
+++ b/app/templates/components/input-wrapper.hbs
@@ -2,12 +2,10 @@
 
 {{#if this.error}}
   <span class="col-xs-12 upf-input-feedback upf-input-feedback--error">
-    <i class="fa fa-exclamation-circle" aria-label={{this.error}}>
-    </i>
+    <OSS::Icon @icon="fa-exclamation-circle" aria-label={{this.error}} />
   </span>
 {{else if this.help}}
   <span class="col-xs-12 upf-input-feedback upf-input-feedback--help">
-    <i class="fa fa-question-circle" aria-label={{this.help}}>
-    </i>
+    <OSS::Icon @icon="fa-question-circle" aria-label={{this.help}} />
   </span>
 {{/if}}

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -20,6 +20,16 @@
     </:footer>
   </OSS::Layout::Sidebar>
   <div style="width:100%; height:100vh; overflow: auto;">
+    <div class="fx-row fx-1 fx-gap-px-10 margin-md">
+      <OSS::Skeleton @width="70%" />
+      <OSS::Skeleton @width={{20}} />
+    </div>
+    <div class="fx-row fx-1 fx-gap-px-10 margin-md">
+      <OSS::Skeleton @direction="column" @width="60%" @gap="12" @multiple="3" @randomize={{true}} />
+    </div>
+    <div class="fx-row fx-1 fx-gap-px-10 margin-md">
+      <OSS::Skeleton @width="10%" @multiple="3" @direction="row" @randomize="true" />
+    </div>
     <div class="fx-row fx-xalign-start fx-gap-px-10 margin-md">
       <OSS::Icon @icon="fa-laptop-code" />
       <OSS::Icon @icon="fa-laptop-code" @style="solid" />
@@ -36,6 +46,14 @@
 
     <div class="fx-row fx-xalign-start fx-gap-px-10 margin-md">
       <OSS::Button @label="Open split modal" {{on "click" this.openSplitModal}} />
+      <OSS::ButtonDropdown @icon="far fa-hourglass" @label="Dropdown button">
+        <:items>
+          <div class="oss-button-dropdown__item">
+            <OSS::Icon @style="solid" @icon="fa-share" /> Share
+          </div>
+        </:items>
+      </OSS::ButtonDropdown>
+      <OSS::Button @label="loading" @loading={{true}} />
       {{#if this.showSplitModal}}
         <OSS::SplitModal @close={{this.closeSplitModal}}>
           <:content>
@@ -263,7 +281,7 @@
       <OSS::Alert @title="Title" @subtitle="Subtitle">
         <:extra-content>
           <div class="fx-row fx-gap-px-12">
-            <OSS::Link @label="Super Label" />
+            <OSS::Link @label="Super Label" @icon="fas fa-hourglass" />
             <OSS::Link @label="Super Label 2" />
           </div>
         </:extra-content>
@@ -299,7 +317,7 @@
           </:content>
           <:footer>
             <div class="fx-1">
-              <i class="fa fa-info"></i><a href="">More info</a>
+              <OSS::Icon @icon="fa-info" /><a href="">More info</a>
             </div>
             <div class="fx-row fx-gap-px-12">
               <OSS::Button @skin="default" @label="Close" {{on "click" this.closeModal}} />
@@ -486,7 +504,7 @@
                 {{#if header.title}}
                   <OSS::Tag @skin="primary" @label="Hello" />
                 {{else}}
-                  <i class="fa fa-chevron-right"></i>
+                  <OSS::Icon @icon="fa-chevron-right" />
                 {{/if}}
               </div>
             {{/each}}
@@ -512,7 +530,7 @@
                 {{#if header.title}}
                   Content {{index}}
                 {{else}}
-                  <i class="fa fa-chevron-right"></i>
+                  <OSS::Icon @icon="fa-chevron-right" />
                 {{/if}}
               </div>
             {{/each}}
@@ -555,11 +573,6 @@
         <OSS::UrlInput @prefix="https://" @placeholder="No regex specified" @onChange={{this.onUrlInputChange}}
                        @value={{this.shopifyDomain}} />
       </OSS::ContentPanel>
-    </div>
-    <div class="fx-row fx-xalign-start fx-gap-px-10 margin-md">
-      <OSS::Skeleton @height="200" @width="400" />
-      <OSS::Skeleton @type="row" @height="300" @width="400" @multiple="12" @randomize={{true}} />
-      <OSS::Skeleton @type="column" @width="600" @gap="12" @multiple="3" @randomize={{false}} />
     </div>
   </div>
 </div>

--- a/tests/integration/components/o-s-s/input-container-test.js
+++ b/tests/integration/components/o-s-s/input-container-test.js
@@ -17,13 +17,13 @@ module('Integration | Component | o-s-s/input-container', function (hooks) {
       await render(hbs`
       <OSS::InputContainer>
         <:prefix>
-          <i class="fas fa-user"></i>
+          <OSS::Icon @style="solid" @icon="fa-user" />
         </:prefix>
         <:input>
           <Input id="custom-input"/>
         </:input>
         <:suffix>
-          <i class="fas fa-times"></i>
+          <OSS::Icon @style="solid" @icon="fa-times" />
         </:suffix>
       </OSS::InputContainer>`);
     }

--- a/tests/integration/components/o-s-s/layout/sidebar/item-test.ts
+++ b/tests/integration/components/o-s-s/layout/sidebar/item-test.ts
@@ -8,7 +8,7 @@ module('Integration | Component | oss/layout/sidebar/item', function (hooks) {
   setupRenderingTest(hooks);
 
   test('it renders', async function (assert) {
-    await render(hbs`<OSS::Layout::Sidebar::Item />`);
+    await render(hbs`<OSS::Layout::Sidebar::Item @icon="far fa-search" />`);
 
     assert.dom('.oss-sidebar-item').exists();
   });
@@ -21,22 +21,22 @@ module('Integration | Component | oss/layout/sidebar/item', function (hooks) {
 
   module('Arguments', () => {
     test('Default value for locked is false', async function (assert) {
-      await render(hbs`<OSS::Layout::Sidebar::Item/>`);
+      await render(hbs`<OSS::Layout::Sidebar::Item @icon="far fa-search"/>`);
       assert.dom('.oss-sidebar-item--locked').doesNotExist();
     });
 
     test('When locked is true', async function (assert) {
-      await render(hbs`<OSS::Layout::Sidebar::Item  @locked={{true}}/>`);
+      await render(hbs`<OSS::Layout::Sidebar::Item @icon="far fa-search" @locked={{true}}/>`);
       assert.dom('.oss-sidebar-item--locked').exists();
     });
 
     test('Default value for hasNotification is false', async function (assert) {
-      await render(hbs`<OSS::Layout::Sidebar::Item/>`);
+      await render(hbs`<OSS::Layout::Sidebar::Item @icon="far fa-search"/>`);
       assert.dom('.oss-sidebar-item--notification').doesNotExist();
     });
 
     test('When hasNotification is true', async function (assert) {
-      await render(hbs`<OSS::Layout::Sidebar::Item  @hasNotifications={{true}}/>`);
+      await render(hbs`<OSS::Layout::Sidebar::Item @icon="far fa-search" @hasNotifications={{true}}/>`);
       assert.dom('.oss-sidebar-item--notification').exists();
     });
   });
@@ -49,7 +49,7 @@ module('Integration | Component | oss/layout/sidebar/item', function (hooks) {
 
     test('OnClick defaultAction is triggered', async function (assert) {
       await render(
-        hbs`<OSS::Layout::Sidebar::Item @defaultAction={{this.defaultAction}} @lockedAction={{this.lockedAction}}/>`
+        hbs`<OSS::Layout::Sidebar::Item @icon="far fa-search" @defaultAction={{this.defaultAction}} @lockedAction={{this.lockedAction}}/>`
       );
       await click('.oss-sidebar-item');
 
@@ -59,7 +59,7 @@ module('Integration | Component | oss/layout/sidebar/item', function (hooks) {
 
     test('When locked is true lockedAction is triggered', async function (assert) {
       await render(
-        hbs`<OSS::Layout::Sidebar::Item  @locked={{true}} @defaultAction={{this.defaultAction}} @lockedAction={{this.lockedAction}}/>`
+        hbs`<OSS::Layout::Sidebar::Item @icon="far fa-search" @locked={{true}} @defaultAction={{this.defaultAction}} @lockedAction={{this.lockedAction}}/>`
       );
       await click('.oss-sidebar-item');
 
@@ -70,12 +70,12 @@ module('Integration | Component | oss/layout/sidebar/item', function (hooks) {
 
   module('Extra attributes', () => {
     test('passing an extra class is applied to the component', async function (assert) {
-      await render(hbs`<OSS::Layout::Sidebar::Item class="my-extra-class" />`);
+      await render(hbs`<OSS::Layout::Sidebar::Item @icon="far fa-search" class="my-extra-class" />`);
       assert.dom('.my-extra-class').exists();
     });
 
     test('passing data-control-name works', async function (assert) {
-      await render(hbs`<OSS::Layout::Sidebar::Item data-control-name="layout-sidebar" />`);
+      await render(hbs`<OSS::Layout::Sidebar::Item @icon="far fa-search" data-control-name="layout-sidebar" />`);
       let inputWrapper: Element | null = find('.oss-sidebar-item');
       assert.equal(inputWrapper?.getAttribute('data-control-name'), 'layout-sidebar');
     });

--- a/tests/integration/components/o-s-s/modal-dialog-test.ts
+++ b/tests/integration/components/o-s-s/modal-dialog-test.ts
@@ -33,7 +33,7 @@ module('Integration | Component | o-s-s/modal-dialog', function (hooks) {
       hbs`<OSS::ModalDialog @title="Example modal" @subtitle="subtitle" @close={{this.closeModal}} @size="md" />`
     );
 
-    await click('.fa-close');
+    await click('.fa-times');
     assert.ok(this.closeModal.calledOnce);
   });
 

--- a/tests/integration/components/o-s-s/skeleton-test.ts
+++ b/tests/integration/components/o-s-s/skeleton-test.ts
@@ -8,14 +8,14 @@ module('Integration | Component | o-s-s/skeleton', function (hooks) {
 
   test('it renders', async function (assert) {
     await render(hbs`<OSS::Skeleton/>`);
-    assert.dom('.upf-skeleton-content').exists();
+    assert.dom('.upf-skeleton-effect').exists();
   });
 
   module('@height parameters', () => {
     test('Default height', async function (assert) {
       await render(hbs`<OSS::Skeleton/>`);
 
-      assert.dom('.upf-skeleton-content').hasStyle({ height: '36px' });
+      assert.dom('.upf-skeleton-effect').hasStyle({ height: '36px' });
     });
 
     test('The style height should correspond to parameter value', async function (assert) {
@@ -23,7 +23,7 @@ module('Integration | Component | o-s-s/skeleton', function (hooks) {
 
       await render(hbs`<OSS::Skeleton @height={{this.height}}/>`);
 
-      assert.dom('.upf-skeleton-content').hasStyle({ height: '400px' });
+      assert.dom('.upf-skeleton-effect').hasStyle({ height: '400px' });
     });
   });
 
@@ -31,7 +31,7 @@ module('Integration | Component | o-s-s/skeleton', function (hooks) {
     test('Default width', async function (assert) {
       await render(hbs`<OSS::Skeleton/>`);
 
-      assert.dom('.upf-skeleton-content').hasStyle({ width: '36px' });
+      assert.dom('.upf-skeleton-effect').hasStyle({ width: '36px' });
     });
 
     test('The style width should correspond to parameter value', async function (assert) {
@@ -39,23 +39,23 @@ module('Integration | Component | o-s-s/skeleton', function (hooks) {
 
       await render(hbs`<OSS::Skeleton @width={{this.width}}/>`);
 
-      assert.dom('.upf-skeleton-content').hasStyle({ width: '400px' });
+      assert.dom('.upf-skeleton-effect').hasStyle({ width: '400px' });
     });
   });
 
   module('@gap parameters', () => {
     test('Default gap', async function (assert) {
-      await render(hbs`<OSS::Skeleton/>`);
+      await render(hbs`<OSS::Skeleton @multiple={{2}} />`);
 
-      assert.dom('.upf-skeleton-content').hasClass('fx-gap-px-9');
+      assert.dom('.fx-1').hasClass('fx-gap-px-9');
     });
 
     test('The has class corresponding to gap', async function (assert) {
       this.gap = 12;
 
-      await render(hbs`<OSS::Skeleton @gap={{this.gap}}/>`);
+      await render(hbs`<OSS::Skeleton @gap={{this.gap}} @multiple={{2}} />`);
 
-      assert.dom('.upf-skeleton-content').hasClass('fx-gap-px-12');
+      assert.dom('.fx-1').hasClass('fx-gap-px-12');
     });
   });
 
@@ -63,7 +63,7 @@ module('Integration | Component | o-s-s/skeleton', function (hooks) {
     test('Default has one skeleton effect', async function (assert) {
       await render(hbs`<OSS::Skeleton/>`);
 
-      let items = findAll('.upf-skeleton-content .upf-skeleton-effect');
+      let items = findAll('.upf-skeleton-effect');
 
       assert.ok(items.length === 1);
     });
@@ -73,7 +73,7 @@ module('Integration | Component | o-s-s/skeleton', function (hooks) {
 
       await render(hbs`<OSS::Skeleton @multiple={{this.multiple}}/>`);
 
-      let items = findAll('.upf-skeleton-content .upf-skeleton-effect');
+      let items = findAll('.upf-skeleton-effect');
 
       assert.ok(items.length === 4);
     });
@@ -88,40 +88,30 @@ module('Integration | Component | o-s-s/skeleton', function (hooks) {
     test('Default randomize is false', async function (assert) {
       await render(hbs`<OSS::Skeleton @width={{this.width}}/>`);
 
-      let item = find('.upf-skeleton-content .upf-skeleton-effect') as HTMLElement;
+      let item = find('.upf-skeleton-effect') as HTMLElement;
 
-      assert.dom('.upf-skeleton-content .upf-skeleton-effect').hasClass('fx-1');
       assert.ok(this.width == item?.offsetWidth);
     });
 
-    test('Randomize width', async function (assert) {
+    test('Randomize width is within a 15% range', async function (assert) {
       await render(hbs`<OSS::Skeleton @multiple={{this.multiple}} @width={{this.width}} @randomize={{true}}/>`);
 
-      let item = find('.upf-skeleton-content .upf-skeleton-effect') as HTMLElement;
+      let item = find('.upf-skeleton-effect') as HTMLElement;
 
-      assert.ok(this.width * 0.8 <= item?.offsetWidth && item?.offsetWidth <= this.width);
-    });
-
-    test('Randomize width and @type is column', async function (assert) {
-      await render(hbs`<OSS::Skeleton @type="column" @width={{this.width}} @randomize={{true}}/>`);
-
-      let item = find('.upf-skeleton-content .upf-skeleton-effect') as HTMLElement;
-
-      assert.dom('.upf-skeleton-content .upf-skeleton-effect').hasNoClass('fx-1');
-      assert.ok(this.width * 0.5 <= item?.offsetWidth && item?.offsetWidth <= this.width * 1.5);
+      assert.ok(item.offsetWidth < 230 && item.offsetWidth > 170);
     });
   });
 
-  test('@type default value is row', async function (assert) {
-    await render(hbs`<OSS::Skeleton/>`);
+  test('@direction default value is row', async function (assert) {
+    await render(hbs`<OSS::Skeleton @multiple="3" />`);
 
-    assert.dom('.upf-skeleton-content').hasClass(`fx-col`);
+    assert.dom('.fx-1').hasClass(`fx-row`);
   });
 
-  test('@type value is column', async function (assert) {
-    await render(hbs`<OSS::Skeleton @type="column"/>`);
+  test('@direction value is column if specified', async function (assert) {
+    await render(hbs`<OSS::Skeleton @direction="column" @multiple="2" />`);
 
-    assert.dom('.upf-skeleton-content').hasClass(`fx-row`);
+    assert.dom('.fx-1').hasClass(`fx-col`);
   });
 
   module('Extra attributes', () => {
@@ -132,20 +122,20 @@ module('Integration | Component | o-s-s/skeleton', function (hooks) {
 
     test('passing data-control-name works', async function (assert) {
       await render(hbs`<OSS::Skeleton data-control-name="layout-sidebar" />`);
-      let inputWrapper: Element | null = find('.upf-skeleton-content');
+      let inputWrapper: Element | null = find('.upf-skeleton-effect');
       assert.equal(inputWrapper?.getAttribute('data-control-name'), 'layout-sidebar');
     });
   });
 
   module('Error management', () => {
-    test('it throws an error if @type is provided and does not match required values', async function (assert) {
+    test('it throws an error if @direct is provided and does not match required values', async function (assert) {
       setupOnerror((err: any) => {
         assert.equal(
           err.message,
-          'Assertion Failed: [component][OSS::Skeleton] The @type argument should be a value of row,column'
+          'Assertion Failed: [component][OSS::Skeleton] The @direction argument should be a value of row,column,col'
         );
       });
-      await render(hbs`<OSS::Skeleton @type="toto"/>`);
+      await render(hbs`<OSS::Skeleton @direction="toto"/>`);
     });
   });
 });


### PR DESCRIPTION
…on, replace skeletons

### What does this PR do?
- replace icons with OSS::Icons
- Add helpers & utils:
-- fa-icon-value, fa-icon-style : documented helpers
-- utils to retrieve these values
- Fix OSS::Skeleton
- Replace skellies where needed

### Good PR checklist
- [x] Title makes sense
- [x] Is against the correct branch
- [ ] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [x] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled