### PR TITLE
Add minReachedTooltip and maxReachedTooltip for number-input

### DIFF
--- a/addon/components/o-s-s/number-input.hbs
+++ b/addon/components/o-s-s/number-input.hbs
@@ -1,9 +1,9 @@
-<div class="number-input fx-row" {{enable-tooltip title=this.reachedTooltip placement="top"}}>
+<div class="number-input fx-row">
   <OSS::Button @square={{true}} @size="md" @icon="far fa-minus" {{on "click" this.decreaseValue}}
-               disabled={{this.isMinDisabled}} />
+               disabled={{this.isMinDisabled}} {{enable-tooltip title=this.minTooltipTitle placement="top"}} />
   {{! template-lint-disable no-triple-curlies}}
   <OSS::InputContainer @value={{this.localValue}} @onChange={{this.checkUserInput}} style={{{this.dynamicWidth}}}
                        {{on "keydown" this.keyParser}} {{on "blur" this.checkUserInput}} />
   <OSS::Button @square={{true}} @size="md" @icon="far fa-plus" {{on "click" this.increaseValue}}
-               disabled={{this.isMaxDisabled}} />
+               disabled={{this.isMaxDisabled}} {{enable-tooltip title=this.maxTooltipTitle placement="top"}} />
 </div>

--- a/addon/components/o-s-s/number-input.hbs
+++ b/addon/components/o-s-s/number-input.hbs
@@ -1,7 +1,9 @@
-<div class="number-input fx-row">
-  <OSS::Button @square={{true}} @size="md" @icon="far fa-minus" {{on "click" this.decreaseValue}} />
+<div class="number-input fx-row" {{enable-tooltip title=this.reachedTooltip placement="top"}}>
+  <OSS::Button @square={{true}} @size="md" @icon="far fa-minus" {{on "click" this.decreaseValue}}
+               disabled={{this.isMinDisabled}} />
   {{! template-lint-disable no-triple-curlies}}
   <OSS::InputContainer @value={{this.localValue}} @onChange={{this.checkUserInput}} style={{{this.dynamicWidth}}}
                        {{on "keydown" this.keyParser}} {{on "blur" this.checkUserInput}} />
-  <OSS::Button @square={{true}} @size="md" @icon="far fa-plus" {{on "click" this.increaseValue}} />
+  <OSS::Button @square={{true}} @size="md" @icon="far fa-plus" {{on "click" this.increaseValue}}
+               disabled={{this.isMaxDisabled}} />
 </div>

--- a/addon/components/o-s-s/number-input.stories.js
+++ b/addon/components/o-s-s/number-input.stories.js
@@ -11,7 +11,7 @@ export default {
         type: {
           summary: 'number'
         },
-        defaultValue: { summary: false }
+        defaultValue: { summary: 'undefined' }
       },
       control: { type: 'number' }
     },
@@ -21,7 +21,7 @@ export default {
         type: {
           summary: 'number'
         },
-        defaultValue: { summary: false }
+        defaultValue: { summary: 'undefined' }
       },
       control: { type: 'number' }
     },
@@ -31,7 +31,7 @@ export default {
         type: {
           summary: 'number'
         },
-        defaultValue: { summary: false }
+        defaultValue: { summary: 'undefined' }
       },
       control: { type: 'number' }
     },
@@ -41,12 +41,38 @@ export default {
         type: {
           summary: 'number'
         },
-        defaultValue: { summary: false }
+        defaultValue: { summary: 'undefined' }
       },
       control: { type: 'number' }
     },
+    minReachedTooltip: {
+      description: '[OPTIONAL] The tooltip to render when the minimum is reached',
+      table: {
+        type: {
+          summary: 'string'
+        },
+        defaultValue: { summary: 'undefined' }
+      },
+      control: { type: 'text' }
+    },
+    maxReachedTooltip: {
+      description: '[OPTIONAL] The tooltip to render when the maximum is reached',
+      table: {
+        type: {
+          summary: 'string'
+        },
+        defaultValue: { summary: 'undefined' }
+      },
+      control: { type: 'text' }
+    },
     onChange: {
-      description: '[OPTIONAL] A callback that sends back the new value of the input'
+      description: '[OPTIONAL] A callback that sends back the new value of the input',
+      table: {
+        category: 'Actions',
+        type: {
+          summary: 'onChange(value): void'
+        }
+      }
     }
   },
   parameters: {
@@ -61,7 +87,8 @@ export default {
 
 const DefaultUsageTemplate = (args) => ({
   template: hbs`
-    <OSS::NumberInput @value={{this.value}} @min={{this.min}} @max={{this.max}} @step={{this.step}} @onChange={{this.onChange}} />
+    <OSS::NumberInput @value={{this.value}} @min={{this.min}} @max={{this.max}} @step={{this.step}} @onChange={{this.onChange}}
+                      @minReachedTooltip={{this.minReachedTooltip}} @maxReachedTooltip={{this.maxReachedTooltip}} />
   `,
   context: args
 });
@@ -71,5 +98,7 @@ BasicUsage.args = {
   min: 0,
   max: 15,
   step: 3,
+  minReachedTooltip: '',
+  maxReachedTooltip: '',
   onChange: action('onChange')
 };

--- a/addon/components/o-s-s/number-input.ts
+++ b/addon/components/o-s-s/number-input.ts
@@ -23,14 +23,6 @@ const CHAR_PIXEL_WIDTH = 7;
 export default class OSSNumberInput extends Component<OSSNumberInputArgs> {
   @tracked localValue: number = this.args.value || DEFAULT_VALUE;
   @tracked reachedTooltip: string | null = null;
-  @tracked isMinDisabled: boolean = false;
-  @tracked isMaxDisabled: boolean = false;
-
-  constructor(owner: unknown, args: OSSNumberInputArgs) {
-    super(owner, args);
-    this.reachedTooltipHandler();
-    this.checkDisabledButton();
-  }
 
   get step(): number {
     return this.args.step || 1;
@@ -38,6 +30,22 @@ export default class OSSNumberInput extends Component<OSSNumberInputArgs> {
 
   get dynamicWidth(): any {
     return `width: ${BASE_INPUT_PIXEL_WIDTH + ('' + this.localValue).length * CHAR_PIXEL_WIDTH}px`;
+  }
+
+  get isMinDisabled(): boolean {
+    return Number(this.localValue) === this.args.min;
+  }
+
+  get isMaxDisabled(): boolean {
+    return Number(this.localValue) === this.args.max;
+  }
+
+  get minTooltipTitle(): string | undefined {
+    return Number(this.localValue) === this.args.min ? this.args.minReachedTooltip : undefined;
+  }
+
+  get maxTooltipTitle(): string | undefined {
+    return Number(this.localValue) === this.args.max ? this.args.maxReachedTooltip : undefined;
   }
 
   @action
@@ -65,8 +73,6 @@ export default class OSSNumberInput extends Component<OSSNumberInputArgs> {
       this.localValue = this.args.max;
     }
     this.notifyChanges();
-    this.reachedTooltipHandler();
-    this.checkDisabledButton();
   }
 
   @action
@@ -88,25 +94,5 @@ export default class OSSNumberInput extends Component<OSSNumberInputArgs> {
   @action
   notifyChanges(): void {
     this.args.onChange?.(Number(this.localValue));
-  }
-
-  private reachedTooltipHandler(): void {
-    if (Number(this.localValue) === this.args.min) {
-      if (!this.args.minReachedTooltip) return;
-      this.reachedTooltip = this.args.minReachedTooltip;
-      return;
-    }
-    if (Number(this.localValue) === this.args.max) {
-      if (!this.args.maxReachedTooltip) return;
-      this.reachedTooltip = this.args.maxReachedTooltip;
-      return;
-    }
-    this.reachedTooltip = null;
-    document.querySelector('.upf-tooltip')?.remove();
-  }
-
-  private checkDisabledButton(): void {
-    this.isMinDisabled = Number(this.localValue) === this.args.min;
-    this.isMaxDisabled = Number(this.localValue) === this.args.max;
   }
 }

--- a/addon/components/o-s-s/number-input.ts
+++ b/addon/components/o-s-s/number-input.ts
@@ -7,6 +7,8 @@ interface OSSNumberInputArgs {
   min?: number;
   max?: number;
   step?: number;
+  minReachedTooltip?: string;
+  maxReachedTooltip?: string;
   onChange?(value: number): void;
 }
 
@@ -20,6 +22,15 @@ const CHAR_PIXEL_WIDTH = 7;
 
 export default class OSSNumberInput extends Component<OSSNumberInputArgs> {
   @tracked localValue: number = this.args.value || DEFAULT_VALUE;
+  @tracked reachedTooltip: string | null = null;
+  @tracked isMinDisabled: boolean = false;
+  @tracked isMaxDisabled: boolean = false;
+
+  constructor(owner: unknown, args: OSSNumberInputArgs) {
+    super(owner, args);
+    this.reachedTooltipHandler();
+    this.checkDisabledButton();
+  }
 
   get step(): number {
     return this.args.step || 1;
@@ -54,6 +65,8 @@ export default class OSSNumberInput extends Component<OSSNumberInputArgs> {
       this.localValue = this.args.max;
     }
     this.notifyChanges();
+    this.reachedTooltipHandler();
+    this.checkDisabledButton();
   }
 
   @action
@@ -75,5 +88,25 @@ export default class OSSNumberInput extends Component<OSSNumberInputArgs> {
   @action
   notifyChanges(): void {
     this.args.onChange?.(Number(this.localValue));
+  }
+
+  private reachedTooltipHandler(): void {
+    if (Number(this.localValue) === this.args.min) {
+      if (!this.args.minReachedTooltip) return;
+      this.reachedTooltip = this.args.minReachedTooltip;
+      return;
+    }
+    if (Number(this.localValue) === this.args.max) {
+      if (!this.args.maxReachedTooltip) return;
+      this.reachedTooltip = this.args.maxReachedTooltip;
+      return;
+    }
+    this.reachedTooltip = null;
+    document.querySelector('.upf-tooltip')?.remove();
+  }
+
+  private checkDisabledButton(): void {
+    this.isMinDisabled = Number(this.localValue) === this.args.min;
+    this.isMaxDisabled = Number(this.localValue) === this.args.max;
   }
 }

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -100,6 +100,7 @@
     <div class="fx-row fx-xalign-start fx-gap-px-10 margin-md">
       <OSS::NumberInput @value={{this.numberValue}} @onChange={{this.handleNumberInput}} />
       <OSS::NumberInput @min={{0}} @max={{15}} @step={{5}} @onChange={{this.handleNumberInput}} />
+      <OSS::NumberInput @min={{0}} @max={{15}} @step={{5}} @minReachedTooltip="Hello" @maxReachedTooltip="you" @onChange={{this.handleNumberInput}} />
     </div>
     <div class="fx-row fx-xalign-start fx-gap-px-10 margin-md">
       <OSS::UrlInput @value={{this.shopifyDomain}} @prefix="https://" @placeholder="shopname" @suffix=".myshopify.com"

--- a/tests/integration/components/o-s-s/number-input-test.ts
+++ b/tests/integration/components/o-s-s/number-input-test.ts
@@ -78,8 +78,12 @@ module('Integration | Component | o-s-s/number-input', function (hooks) {
     test('If @max parameter is set, increasing the value sets the max value', async function (assert) {
       await render(hbs`<OSS::NumberInput @value={{5}} @max={{5}} />`);
       assert.dom('.number-input input').hasValue('5');
-      await click('.upf-square-btn:nth-of-type(2)');
-      assert.dom('.number-input input').hasValue('5');
+      assert.dom('.upf-square-btn:nth-of-type(2)').isDisabled();
+    });
+
+    test('If @max & @maxReachedTooltip parameter are set, it renders the tooltip', async function (assert) {
+      await render(hbs`<OSS::NumberInput @value={{5}} @max={{5}} @maxReachedTooltip="max" />`);
+      await assert.tooltip('.number-input').hasTitle('max');
     });
   });
 
@@ -110,8 +114,12 @@ module('Integration | Component | o-s-s/number-input', function (hooks) {
     test('If @min parameter is set, decreasing the value sets the min value', async function (assert) {
       await render(hbs`<OSS::NumberInput @value={{5}} @min={{5}} />`);
       assert.dom('.number-input input').hasValue('5');
-      await click('.upf-square-btn:nth-of-type(1)');
-      assert.dom('.number-input input').hasValue('5');
+      assert.dom('.upf-square-btn:nth-of-type(1)').isDisabled();
+    });
+
+    test('If @min & @minReachedTooltip parameter are set, it renders the tooltip', async function (assert) {
+      await render(hbs`<OSS::NumberInput @value={{5}} @min={{5}} @minReachedTooltip="min" />`);
+      await assert.tooltip('.number-input').hasTitle('min');
     });
   });
 

--- a/tests/integration/components/o-s-s/number-input-test.ts
+++ b/tests/integration/components/o-s-s/number-input-test.ts
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@ember/test-helpers';
+import { render, waitFor } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import click from '@ember/test-helpers/dom/click';
 import triggerKeyEvent from '@ember/test-helpers/dom/trigger-key-event';
@@ -83,7 +83,9 @@ module('Integration | Component | o-s-s/number-input', function (hooks) {
 
     test('If @max & @maxReachedTooltip parameter are set, it renders the tooltip', async function (assert) {
       await render(hbs`<OSS::NumberInput @value={{5}} @max={{5}} @maxReachedTooltip="max" />`);
-      await assert.tooltip('.number-input').hasTitle('max');
+      document.querySelector('.upf-square-btn:nth-of-type(2)')?.dispatchEvent(new Event('mouseover'));
+      await waitFor('.upf-tooltip');
+      assert.dom('.upf-tooltip .title').hasText('max');
     });
   });
 
@@ -119,7 +121,9 @@ module('Integration | Component | o-s-s/number-input', function (hooks) {
 
     test('If @min & @minReachedTooltip parameter are set, it renders the tooltip', async function (assert) {
       await render(hbs`<OSS::NumberInput @value={{5}} @min={{5}} @minReachedTooltip="min" />`);
-      await assert.tooltip('.number-input').hasTitle('min');
+      document.querySelector('.upf-square-btn:nth-of-type(1)')?.dispatchEvent(new Event('mouseover'));
+      await waitFor('.upf-tooltip');
+      assert.dom('.upf-tooltip .title').hasText('min');
     });
   });
 


### PR DESCRIPTION
### What does this PR do?
Add minReachedTooltip and maxReachedTooltip args 
Disable buttons for min max  

Related to: https://linear.app/upfluence/issue/ENG-636/[seats-management]-add-support-for-billingseatsmanagermodal-component

### What are the observable changes?

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [x] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled
