### PR TITLE
Add onChange method for email-input components

### DIFF
--- a/addon/components/o-s-s/email-input.stories.js
+++ b/addon/components/o-s-s/email-input.stories.js
@@ -51,6 +51,13 @@ export default {
         category: 'Actions',
         type: { summary: 'validates?(isPassing: boolean): void' }
       }
+    },
+    onChange: {
+      description: 'A callback that sends the new value to the parent component when the input is changed',
+      table: {
+        category: 'Actions',
+        type: { summary: 'onChange?(value: string | null): void' }
+      }
     }
   },
   parameters: {

--- a/addon/components/o-s-s/email-input.ts
+++ b/addon/components/o-s-s/email-input.ts
@@ -10,6 +10,7 @@ interface OSSEmailInputArgs {
   errorMessage?: string;
   validateFormat?: boolean;
   validates?(isPassing: boolean): void;
+  onChange?(value: string | null): void;
 }
 
 const DEFAULT_PLACEHOLDER = 'e.g: john.doe@example.com';
@@ -46,6 +47,7 @@ export default class OSSEmailInput extends Component<OSSEmailInputArgs> {
   @action
   validateInput(): void {
     this.regexError = '';
+    this.args.onChange?.(this.args.value);
 
     if (!this._runValidation || !this.args.value) {
       this.args.validates?.(true);

--- a/tests/dummy/app/controllers/application.js
+++ b/tests/dummy/app/controllers/application.js
@@ -76,6 +76,7 @@ export default class ApplicationController extends Controller {
   @tracked radio2 = false;
   @tracked isChecked = true;
   @tracked togglable = false;
+  @tracked emailInputValue = '';
 
   @tracked media = [
     {
@@ -280,6 +281,11 @@ export default class ApplicationController extends Controller {
     console.log('onPhoneNumberChange', prefix, phoneNumber);
     this.phonePrefix = prefix;
     this.phoneNumber = phoneNumber;
+  }
+
+  @action
+  onEmailInputChange(value) {
+    console.log('onEmailInputChange', value);
   }
 
   @action

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -21,9 +21,12 @@
   </OSS::Layout::Sidebar>
 
   <div style="width:100%; height:100vh; overflow: auto;">
-    <OSS::Illustration @src="/@upfluence/oss-components/assets/images/no-records.svg" />
+    <div class="fx-row fx-1 fx-gap-px-10 margin-md">
+      <OSS::EmailInput @value={{this.emailInputValue}} @onChange={{this.onEmailInputChange}} />
+    </div>
 
     <div class="fx-row fx-1 fx-gap-px-10 margin-md">
+      <OSS::Illustration @src="/@upfluence/oss-components/assets/images/no-records.svg" />
       <OSS::TogglableSection @title="This is a title" @subtitle="This is a subtitle" @toggled={{this.togglable}}
                              @icon="far fa-hourglass" @onChange={{this.onToggle}}>
         <:contents>

--- a/tests/integration/components/o-s-s/email-input-test.ts
+++ b/tests/integration/components/o-s-s/email-input-test.ts
@@ -2,6 +2,7 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render, setupOnerror, typeIn } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
+import sinon from 'sinon';
 
 module('Integration | Component | o-s-s/email-input', function (hooks) {
   setupRenderingTest(hooks);
@@ -53,5 +54,13 @@ module('Integration | Component | o-s-s/email-input', function (hooks) {
     });
 
     await render(hbs`<OSS::EmailInput />`);
+  });
+
+  test('it calls the @onChange method', async function (assert) {
+    this.value = '';
+    this.onChange = sinon.stub();
+    await render(hbs`<OSS::EmailInput @value={{this.value}} @onChange={{this.onChange}} />`);
+    await typeIn('input', 'a');
+    assert.true(this.onChange.calledOnceWithExactly('a'));
   });
 });


### PR DESCRIPTION
### What does this PR do?

Add `onChange` method for email-input components

Related to: https://linear.app/upfluence/issue/ENG-781/error-message-not-very-clear-when-trying-to-register-account-with

### What are the observable changes?
<!-- This question could be adequate with multiple use cases, for example: -->

<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [x] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled
