### PR TITLE
enable-tooltip: destroy on click when only triggered on hover

### DIFF
--- a/addon/modifiers/enable-tooltip.ts
+++ b/addon/modifiers/enable-tooltip.ts
@@ -173,6 +173,12 @@ function initEventListener(state: EnableTooltipState, element: HTMLElement): voi
     });
   }
 
+  if (triggerEvents.length === 1 && triggerEvents[0] === 'hover') {
+    element.addEventListener('click', (event) => {
+      destroyWithEvent(state, event);
+    });
+  }
+
   if (triggerEvents.includes('focus')) {
     element.addEventListener('focusin', () => {
       delayedRender(state);


### PR DESCRIPTION
### What does this PR do?

enable-tooltip: destroy on click when only triggered on hover

### What are the observable changes?
<!-- This question could be adequate with multiple use cases, for example: -->

<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->

### Good PR checklist
- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled
