### PR TITLE
ButtonDrodown: Add preventable action to automatically close dropdown…

### DIFF
--- a/addon/components/o-s-s/button-dropdown.hbs
+++ b/addon/components/o-s-s/button-dropdown.hbs
@@ -16,6 +16,7 @@
 
   {{#if this.displayDropdown}}
     <div class="oss-button-dropdown__items"
+         {{on "click" this.toggleDropdown}}
          {{did-insert this.setupChildrenClickHandler}}
          {{will-destroy this.teardownChildrenClickHandler}}
          {{on-click-outside this.onClickOutside useCapture=true}}>

--- a/tests/integration/components/o-s-s/button-dropdown-test.ts
+++ b/tests/integration/components/o-s-s/button-dropdown-test.ts
@@ -124,6 +124,46 @@ module('Integration | Component | o-s-s/button-dropdown', function (hooks) {
     });
   });
 
+  module('When the dropdown is opened', function (hooks) {
+    hooks.beforeEach(function () {
+      this.mainAction = sinon.stub();
+    });
+
+    test('Clicking on an item should close the dropdown', async function (assert) {
+      await render(
+        hbs`<OSS::ButtonDropdown @icon="far fa-users" @label="label" @mainAction={{this.mainAction}}>
+              <:items>
+                <div class="oss-button-dropdown__item">foo</div>
+              </:items>
+            </OSS::ButtonDropdown>`
+      );
+
+      await click('.oss-button-dropdown__trigger .fx-row:last-child');
+      await click('.oss-button-dropdown__items .oss-button-dropdown__item');
+
+      assert.dom('.oss-button-dropdown__items .oss-button-dropdown__item').doesNotExist();
+    });
+
+    test('Clicking on an item with stopPropagation should keep the dropdown opened', async function (assert) {
+      this.stopPropagation = function (e: MouseEvent) {
+        e.stopPropagation();
+      };
+
+      await render(
+        hbs`<OSS::ButtonDropdown @icon="far fa-users" @label="label" @mainAction={{this.mainAction}}>
+              <:items>
+                <div class="oss-button-dropdown__item" {{on "click" this.stopPropagation}}>bar</div>
+              </:items>
+            </OSS::ButtonDropdown>`
+      );
+
+      await click('.oss-button-dropdown__trigger .fx-row:last-child');
+      await click('.oss-button-dropdown__items .oss-button-dropdown__item');
+
+      assert.dom('.oss-button-dropdown__items .oss-button-dropdown__item').exists();
+    });
+  });
+
   module('Error management', function () {
     test('it throws an error if no icon or label args is provided', async function (assert) {
       setupOnerror((err: { message: string }) => {


### PR DESCRIPTION
… when item is clicked

### What does this PR do?
<!-- A brief description of the context of this pull request and its purpose. -->

Related to: #[ENG-964](https://linear.app/upfluence/issue/ENG-964/certain-dropdown-menus-remain-open)

### What are the observable changes?
<!-- This question could be adequate with multiple use cases, for example: -->

<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->

### Good PR checklist
- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled
