### PR TITLE
New OSS::AttributesPanel component

### DIFF
--- a/addon/components/o-s-s/array-input.stories.js
+++ b/addon/components/o-s-s/array-input.stories.js
@@ -50,8 +50,8 @@ export default {
       description:
         'The method that validates the current content of the input. If the result is true, then on enter, the input is added to the values array.',
       table: {
+        category: 'Actions',
         type: {
-          category: 'Actions',
           summary: 'validator?(value: string): boolean'
         }
       }

--- a/addon/components/o-s-s/attributes-panel.hbs
+++ b/addon/components/o-s-s/attributes-panel.hbs
@@ -29,9 +29,10 @@
         <div class="fx-col fx-gap-px-18">
           {{yield to="edition-mode"}}
           <div class="fx-row fx-gap-px-18 fx-malign-end">
-            <OSS::Button @label="Cancel" {{on "click" this.onCancel}} data-control-name="attributes-panel-cancel-button" />
-            <OSS::Button @skin="primary" @label="Save" @loading={{this.isLoading}} {{on "click" this.onSave}}
-                         data-control-name="attributes-panel-save-button" />
+            <OSS::Button @label={{t "oss-components.attributes_panel.cancel"}} {{on "click" this.onCancel}}
+                         data-control-name="attributes-panel-cancel-button" />
+            <OSS::Button @skin="primary" @label={{t "oss-components.attributes_panel.save"}} @loading={{this.isLoading}}
+                         {{on "click" this.onSave}} data-control-name="attributes-panel-save-button" />
           </div>
         </div>
       {{/if}}

--- a/addon/components/o-s-s/attributes-panel.hbs
+++ b/addon/components/o-s-s/attributes-panel.hbs
@@ -1,4 +1,4 @@
-<div class="attributes-panel">
+<div class="attributes-panel" ...attributes>
   <div class="fx-row fx-malign-space-between">
     <div class="fx-row fx-gap-px-12 fx-xalign-center">
       {{#if @icon}}

--- a/addon/components/o-s-s/attributes-panel.hbs
+++ b/addon/components/o-s-s/attributes-panel.hbs
@@ -13,12 +13,13 @@
         {{#if (has-block "contextual-action")}}
           {{yield to="contextual-action"}}
         {{/if}}
-        <OSS::Button @icon="fa-pen" @square={{true}} {{on "click" this.toggleMode}} />
+        <OSS::Button @icon="fa-pen" @square={{true}} {{on "click" this.toggleMode}}
+                     data-control-name="attributes-panel-mode-switch-button" />
       </div>
     {{/if}}
   </div>
 
-  <div class={{this.containerClasses}}>
+  <div class={{concat "attributes-panel__container attributes-panel__container--" this.modeSelected}}>
     {{#if (eq this.modeSelected "view")}}
       {{#if (has-block "view-mode")}}
         {{yield to="view-mode"}}
@@ -28,8 +29,9 @@
         <div class="fx-col fx-gap-px-18">
           {{yield to="edition-mode"}}
           <div class="fx-row fx-gap-px-18 fx-malign-end">
-            <OSS::Button @label="Cancel" {{on "click" this.onCancel}} />
-            <OSS::Button @skin="primary" @label="Save" @loading={{this.isLoading}} {{on "click" this.onSave}} />
+            <OSS::Button @label="Cancel" {{on "click" this.onCancel}} data-control-name="attributes-panel-cancel-button" />
+            <OSS::Button @skin="primary" @label="Save" @loading={{this.isLoading}} {{on "click" this.onSave}}
+                         data-control-name="attributes-panel-save-button" />
           </div>
         </div>
       {{/if}}

--- a/addon/components/o-s-s/attributes-panel.hbs
+++ b/addon/components/o-s-s/attributes-panel.hbs
@@ -1,0 +1,38 @@
+<div class="attributes-panel">
+  <div class="fx-row fx-malign-space-between">
+    <div class="fx-row fx-gap-px-12 fx-xalign-center">
+      {{#if @icon}}
+        <OSS::Icon class="font-color-primary-500" @icon={{@icon}} />
+      {{/if}}
+      <span class="font-size-md font-weight-semibold">
+        {{@title}}
+      </span>
+    </div>
+    {{#if (eq this.modeSelected "view")}}
+      <div class="fx-row fx-gap-px-6">
+        {{#if (has-block "contextual-action")}}
+          {{yield to="contextual-action"}}
+        {{/if}}
+        <OSS::Button @icon="fa-pen" @square={{true}} {{on "click" this.toggleMode}} />
+      </div>
+    {{/if}}
+  </div>
+
+  <div class={{this.containerClasses}}>
+    {{#if (eq this.modeSelected "view")}}
+      {{#if (has-block "view-mode")}}
+        {{yield to="view-mode"}}
+      {{/if}}
+    {{else}}
+      {{#if (has-block "edition-mode")}}
+        <div class="fx-col fx-gap-px-18">
+          {{yield to="edition-mode"}}
+          <div class="fx-row fx-gap-px-18 fx-malign-end">
+            <OSS::Button @label="Cancel" {{on "click" this.onCancel}} />
+            <OSS::Button @skin="primary" @label="Save" @loading={{this.isLoading}} {{on "click" this.onSave}} />
+          </div>
+        </div>
+      {{/if}}
+    {{/if}}
+  </div>
+</div>

--- a/addon/components/o-s-s/attributes-panel.stories.js
+++ b/addon/components/o-s-s/attributes-panel.stories.js
@@ -1,0 +1,116 @@
+import hbs from 'htmlbars-inline-precompile';
+import { action } from '@storybook/addon-actions';
+
+export default {
+  title: 'Components/OSS::AttributesPanel',
+  component: 'attributes-panel',
+  argTypes: {
+    title: {
+      description: 'The title of the panel',
+      table: {
+        type: {
+          summary: 'string'
+        },
+        defaultValue: { summary: 'undefined' }
+      },
+      control: { type: 'text' },
+      type: { required: true }
+    },
+    icon: {
+      description: 'The icon rendered next to the title',
+      table: {
+        type: {
+          summary: 'string'
+        },
+        defaultValue: { summary: 'undefined' }
+      },
+      control: { type: 'text' }
+    },
+    onSave: {
+      description: 'A callback sent when the saved button is pressed',
+      table: {
+        category: 'Actions',
+        type: {
+          summary: 'onSave(): Promise<void>'
+        }
+      },
+      type: { required: true }
+    },
+    onEdit: {
+      description: 'A callback sent when the edition button is pressed',
+      table: {
+        category: 'Actions',
+        type: {
+          summary: 'onEdit?(): void'
+        }
+      }
+    },
+    onCancel: {
+      description: 'A callback sent when the cancel button is pressed',
+      table: {
+        category: 'Actions',
+        type: {
+          summary: 'onCancel?(): void'
+        }
+      }
+    }
+  },
+  parameters: {
+    docs: {
+      description: {
+        component: 'A component composed of the 2 modes, one for the view and another for the edition'
+      }
+    }
+  }
+};
+
+const defaultArgs = {
+  title: 'Title',
+  icon: 'fa-laptop-code',
+  onSave: action('onSave'),
+  onCancel: action('onCancel'),
+  onEdit: action('onEdit')
+};
+
+const DefaultUsageTemplate = (args) => ({
+  template: hbs`
+    <div style="width: 350px; background-color: var(--color-gray-50); padding: var(--spacing-px-24);">
+      <OSS::AttributesPanel @title={{this.title}} @icon={{this.icon}} @onSave={{this.onSave}}
+                            @onCancel={{this.onCancel}} @onEdit={{this.onEdit}}>
+          <:view-mode>
+            View mode
+          </:view-mode>
+          <:edition-mode>
+            Edition mode
+          </:edition-mode>
+        </OSS::AttributesPanel>
+      </div>
+  `,
+  context: args
+});
+
+const WithContextualActionTemplate = (args) => ({
+  template: hbs`
+    <div style="width: 350px; background-color: var(--color-gray-50); padding: var(--spacing-px-24);">
+      <OSS::AttributesPanel @title={{this.title}} @icon={{this.icon}} @onSave={{this.onSave}}
+                            @onCancel={{this.onCancel}} @onEdit={{this.onEdit}}>
+          <:contextual-action>
+            <OSS::Button @icon="fa-plus" @square={{true}} />
+          </:contextual-action>
+          <:view-mode>
+            View mode
+          </:view-mode>
+          <:edition-mode>
+            Edition mode
+          </:edition-mode>
+        </OSS::AttributesPanel>
+      </div>
+  `,
+  context: args
+});
+
+export const BasicUsage = DefaultUsageTemplate.bind({});
+BasicUsage.args = defaultArgs;
+
+export const WithContextualAction = WithContextualActionTemplate.bind({});
+WithContextualAction.args = defaultArgs;

--- a/addon/components/o-s-s/attributes-panel.stories.js
+++ b/addon/components/o-s-s/attributes-panel.stories.js
@@ -37,7 +37,7 @@ export default {
       type: { required: true }
     },
     onEdit: {
-      description: 'A callback sent when the edition button is pressed',
+      description: 'A callback sent when the edit button is pressed',
       table: {
         category: 'Actions',
         type: {
@@ -58,7 +58,8 @@ export default {
   parameters: {
     docs: {
       description: {
-        component: 'A component composed of the 2 modes, one for the view and another for the edition'
+        component:
+          'A component meant to display OSS::Attributes. It has 2 modes: a view panel where information will be read-only and an edit mode where the information will be editable.'
       }
     }
   }

--- a/addon/components/o-s-s/attributes-panel.ts
+++ b/addon/components/o-s-s/attributes-panel.ts
@@ -1,0 +1,50 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+
+type Mode = 'view' | 'edition';
+
+interface OSSAttributesPanelArgs {
+  title: string;
+  icon?: string;
+  onSave(): Promise<void>;
+  onEdit?(mode: Mode): void;
+  onCancel?(): void;
+}
+
+export default class OSSAttributesPanel extends Component<OSSAttributesPanelArgs> {
+  @tracked modeSelected: Mode = 'view';
+  @tracked isLoading: boolean = false;
+
+  get containerClasses(): string {
+    const classes = ['attributes-panel__container'];
+    const modeClass =
+      this.modeSelected === 'view' ? 'attributes-panel__container--view' : 'attributes-panel__container--edition';
+    classes.push(modeClass);
+    return classes.join(' ');
+  }
+
+  @action
+  toggleMode(): void {
+    this.modeSelected = this.modeSelected === 'view' ? 'edition' : 'view';
+    this.args.onEdit?.(this.modeSelected);
+  }
+
+  @action
+  onCancel(): void {
+    this.toggleMode();
+    this.args.onCancel?.();
+  }
+
+  @action
+  onSave(): void {
+    this.isLoading = true;
+    this.args
+      .onSave()
+      .then(() => {
+        this.toggleMode();
+      })
+      .catch(() => {})
+      .finally(() => (this.isLoading = false));
+  }
+}

--- a/addon/components/o-s-s/attributes-panel.ts
+++ b/addon/components/o-s-s/attributes-panel.ts
@@ -1,6 +1,7 @@
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
+import { assert } from '@ember/debug';
 
 type Mode = 'view' | 'edition';
 
@@ -8,7 +9,7 @@ interface OSSAttributesPanelArgs {
   title: string;
   icon?: string;
   onSave(): Promise<void>;
-  onEdit?(mode: Mode): void;
+  onEdit?(): void;
   onCancel?(): void;
 }
 
@@ -16,18 +17,17 @@ export default class OSSAttributesPanel extends Component<OSSAttributesPanelArgs
   @tracked modeSelected: Mode = 'view';
   @tracked isLoading: boolean = false;
 
-  get containerClasses(): string {
-    const classes = ['attributes-panel__container'];
-    const modeClass =
-      this.modeSelected === 'view' ? 'attributes-panel__container--view' : 'attributes-panel__container--edition';
-    classes.push(modeClass);
-    return classes.join(' ');
+  constructor(owner: unknown, args: OSSAttributesPanelArgs) {
+    super(owner, args);
+
+    assert('[component][OSS::AttributesPanel] The @title parameter is mandatory', typeof args.title === 'string');
+    assert('[component][OSS::AttributesPanel] The @onSave parameter is mandatory', typeof args.onSave === 'function');
   }
 
   @action
   toggleMode(): void {
     this.modeSelected = this.modeSelected === 'view' ? 'edition' : 'view';
-    this.args.onEdit?.(this.modeSelected);
+    this.args.onEdit?.();
   }
 
   @action

--- a/app/components/o-s-s/attributes-panel.js
+++ b/app/components/o-s-s/attributes-panel.js
@@ -1,0 +1,1 @@
+export { default } from '@upfluence/oss-components/components/o-s-s/attributes-panel';

--- a/app/styles/organisms/attributes-panel.less
+++ b/app/styles/organisms/attributes-panel.less
@@ -1,0 +1,18 @@
+.attributes-panel {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  gap: var(--spacing-px-12);
+
+  &__container {
+    border: 1px solid var(--color-border-default);
+    border-radius: var(--border-radius-md);
+    background-color: var(--color-white);
+    padding: var(--spacing-px-18);
+    transition: all 0.25s ease-in-out;
+
+    &--edition {
+      box-shadow: 0 0 0 2px var(--color-primary-100), var(--box-shadow-xs);
+    }
+  }
+}

--- a/app/styles/oss-components.less
+++ b/app/styles/oss-components.less
@@ -49,3 +49,4 @@
 @import 'organisms/sidebar';
 @import 'organisms/access-panel';
 @import 'organisms/panel';
+@import 'organisms/attributes-panel';

--- a/tests/dummy/app/controllers/application.js
+++ b/tests/dummy/app/controllers/application.js
@@ -352,6 +352,25 @@ export default class ApplicationController extends Controller {
   onCheck(value) {
     this.isChecked = value;
   }
+
+  @action
+  onAttributePanelSave() {
+    return new Promise((resolve) => {
+      setTimeout(() => {
+        resolve();
+      }, 300);
+    });
+  }
+
+  @action
+  onAttributePanelCancel() {
+    console.log('Attributes panel cancel');
+  }
+
+  @action
+  onAttributePanelEdit(mode) {
+    console.log(`Attributes panel edition ${mode}`);
+  }
 }
 
 const testScript = `import { module, test } from 'qunit';

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -20,10 +20,24 @@
     </:footer>
   </OSS::Layout::Sidebar>
 
-  <div style="width:100%; height:100vh; overflow: auto;">
+  <div style="width:100%; height:100vh; overflow: auto; background-color: var(--color-gray-50)">
     <div class="fx-1 fx-col fx-gap-px-9">
       <OSS::Attribute::Country @countryCode="US" />
       <OSS::Attribute::Country @countryCode="" />
+    </div>
+    <div class="fx-row fx-1 fx-gap-px-10 margin-md">
+      <OSS::AttributesPanel @title="Title" @icon="fa-laptop-code" @onSave={{this.onAttributePanelSave}}
+                            @onCancel={{this.onAttributePanelCancel}} @onEdit={{this.onAttributePanelEdit}}>
+        <:contextual-action>
+          <OSS::Button @icon="fa-plus" @square={{true}} />
+        </:contextual-action>
+        <:view-mode>
+          View mode
+        </:view-mode>
+        <:edition-mode>
+          Edition mode
+        </:edition-mode>
+      </OSS::AttributesPanel>
     </div>
     <div class="fx-row fx-1 fx-gap-px-10 margin-md">
       <OSS::EmailInput @value={{this.emailInputValue}} @onChange={{this.onEmailInputChange}} />

--- a/tests/integration/components/o-s-s/attributes-panel-test.ts
+++ b/tests/integration/components/o-s-s/attributes-panel-test.ts
@@ -1,0 +1,175 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render, click, setupOnerror } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+import sinon from 'sinon';
+
+module('Integration | Component | o-s-s/attributes-panel', function (hooks) {
+  setupRenderingTest(hooks);
+
+  hooks.beforeEach(function () {
+    this.icon = 'fa-laptop-code';
+    this.title = 'Title';
+    this.onSave = sinon.stub();
+    this.onCancel = sinon.stub();
+    this.onEdit = sinon.stub();
+  });
+
+  test('it renders', async function (assert) {
+    await render(hbs`<OSS::AttributesPanel @icon={{this.icon}} @title={{this.title}} @onSave={{this.onSave}} />`);
+    assert.dom('.attributes-panel').exists();
+  });
+
+  test('it renders the icon', async function (assert) {
+    await render(hbs`<OSS::AttributesPanel @icon={{this.icon}} @title={{this.title}} @onSave={{this.onSave}} />`);
+    assert.dom('.attributes-panel .fa-laptop-code').exists();
+  });
+
+  test('it renders the title', async function (assert) {
+    await render(hbs`<OSS::AttributesPanel @icon={{this.icon}} @title={{this.title}} @onSave={{this.onSave}} />`);
+    assert.dom('.attributes-panel span').hasText('Title');
+  });
+
+  test('it renders the contextual-action named block', async function (assert) {
+    await render(hbs`
+      <OSS::AttributesPanel @icon={{this.icon}} @title={{this.title}} @onSave={{this.onSave}}>
+        <:contextual-action>
+          <OSS::Button @icon="fa-plus" @square={{true}} />
+        </:contextual-action>
+      </OSS::AttributesPanel>
+    `);
+    assert.dom('.attributes-panel .fa-plus').exists();
+  });
+
+  module('for view mode', (hooks) => {
+    hooks.beforeEach(async function () {
+      await render(hbs`
+        <OSS::AttributesPanel @icon={{this.icon}} @title={{this.title}} @onSave={{this.onSave}} @onEdit={{this.onEdit}}>
+          <:view-mode>
+            <div class="custom-view-mode">View mode</div>
+          </:view-mode>
+        </OSS::AttributesPanel>
+      `);
+    });
+
+    test('it renders the view-mode named block', function (assert) {
+      assert.dom('.attributes-panel__container.attributes-panel__container--view').exists();
+      assert.dom('.custom-view-mode').hasText('View mode');
+    });
+
+    test('it renders edition button', function (assert) {
+      assert.dom('[data-control-name="attributes-panel-mode-switch-button"]').exists();
+    });
+
+    module('when clicking on edit button', (hooks) => {
+      hooks.beforeEach(async function () {
+        await click('[data-control-name="attributes-panel-mode-switch-button"]');
+      });
+
+      test('it changes to edition mode container', function (assert) {
+        assert.dom('.attributes-panel__container.attributes-panel__container--view').doesNotExist();
+        assert.dom('.attributes-panel__container.attributes-panel__container--edition').exists();
+      });
+
+      test('it calls the @onEdit', function (assert) {
+        assert.true(this.onEdit.calledOnceWithExactly());
+      });
+    });
+  });
+
+  module('for edition mode', (hooks) => {
+    hooks.beforeEach(async function () {
+      await render(hbs`
+        <OSS::AttributesPanel @icon={{this.icon}} @title={{this.title}} @onSave={{this.onSave}} @onEdit={{this.onEdit}}
+                              @onCancel={{this.onCancel}}>
+          <:contextual-action><div class="custom-contextual-action"></div></:contextual-action>
+          <:edition-mode>
+            <div class="custom-edition-mode">Edition mode</div>
+          </:edition-mode>
+        </OSS::AttributesPanel>
+      `);
+      await click('[data-control-name="attributes-panel-mode-switch-button"]');
+    });
+
+    test('it renders the view-mode named block', function (assert) {
+      assert.dom('.attributes-panel__container.attributes-panel__container--edition').exists();
+      assert.dom('.custom-edition-mode').hasText('Edition mode');
+    });
+
+    test("it doesn't renders edition button", function (assert) {
+      assert.dom('[data-control-name="attributes-panel-mode-switch-button"]').doesNotExist();
+    });
+
+    test("it doesn't renders contextual-action named block", function (assert) {
+      assert.dom('.custom-contextual-action').doesNotExist();
+    });
+
+    test('it renders the save and cancel button', function (assert) {
+      assert.dom('[data-control-name="attributes-panel-cancel-button"]').exists();
+      assert.dom('[data-control-name="attributes-panel-save-button"]').exists();
+    });
+
+    module('when clicking on cancel button', (hooks) => {
+      hooks.beforeEach(async function () {
+        await click('[data-control-name="attributes-panel-cancel-button"]');
+      });
+
+      test('it switches to view mode', function (assert) {
+        assert.dom('.attributes-panel__container.attributes-panel__container--view').exists();
+        assert.dom('.attributes-panel__container.attributes-panel__container--edition').doesNotExist();
+      });
+
+      test('it calls the @onCancel', function (assert) {
+        assert.true(this.onCancel.calledOnceWithExactly());
+      });
+    });
+
+    module('when clicking on save button', () => {
+      test('it switches to view mode', async function (assert) {
+        this.onSave.resolves();
+        await click('[data-control-name="attributes-panel-save-button"]');
+        assert.dom('.attributes-panel__container.attributes-panel__container--view').exists();
+        assert.dom('.attributes-panel__container.attributes-panel__container--edition').doesNotExist();
+      });
+
+      test("it doesn't switch to the view mode", async function (assert) {
+        this.onSave.rejects();
+        await click('[data-control-name="attributes-panel-save-button"]');
+        assert.dom('.attributes-panel__container.attributes-panel__container--view').doesNotExist();
+        assert.dom('.attributes-panel__container.attributes-panel__container--edition').exists();
+      });
+
+      test('it render a loading state', async function (assert) {
+        this.onSave.returns(new Promise(() => {}));
+        await click('[data-control-name="attributes-panel-save-button"]');
+        assert.dom('[data-control-name="attributes-panel-save-button"] .fa-circle-notch').exists();
+      });
+
+      test('it calls the @onSave', async function (assert) {
+        this.onSave.resolves();
+        await click('[data-control-name="attributes-panel-save-button"]');
+        assert.true(this.onSave.calledOnceWithExactly());
+      });
+    });
+  });
+
+  test('it throws an error if @title is missing', async function (assert) {
+    setupOnerror((error: Error) => {
+      assert.equal(
+        error.message,
+        'Assertion Failed: [component][OSS::AttributesPanel] The @title parameter is mandatory'
+      );
+    });
+    await render(hbs`<OSS::AttributesPanel @onSave={{this.onSave}} />`);
+  });
+
+  test('it throws an error if @onSave is missing', async function (assert) {
+    setupOnerror((error: Error) => {
+      assert.equal(
+        error.message,
+        'Assertion Failed: [component][OSS::AttributesPanel] The @onSave parameter is mandatory'
+      );
+    });
+    await render(hbs`<OSS::AttributesPanel @title={{this.title}} />`);
+  });
+});

--- a/tests/integration/components/o-s-s/attributes-panel-test.ts
+++ b/tests/integration/components/o-s-s/attributes-panel-test.ts
@@ -41,8 +41,36 @@ module('Integration | Component | o-s-s/attributes-panel', function (hooks) {
     assert.dom('.attributes-panel .fa-plus').exists();
   });
 
-  module('for view mode', (hooks) => {
-    hooks.beforeEach(async function () {
+  module('for view mode', () => {
+    test('it renders the view-mode named block', async function (assert) {
+      await renderComponent();
+      assert.dom('.attributes-panel__container.attributes-panel__container--view').exists();
+      assert.dom('.custom-view-mode').hasText('View mode');
+    });
+
+    test('it renders edition button', async function (assert) {
+      await renderComponent();
+      assert.dom('[data-control-name="attributes-panel-mode-switch-button"]').exists();
+    });
+
+    module('when clicking on edit button', () => {
+      test('it changes to edition mode container', async function (assert) {
+        await renderComponent();
+        await click('[data-control-name="attributes-panel-mode-switch-button"]');
+
+        assert.dom('.attributes-panel__container.attributes-panel__container--view').doesNotExist();
+        assert.dom('.attributes-panel__container.attributes-panel__container--edition').exists();
+      });
+
+      test('it calls the @onEdit', async function (assert) {
+        await renderComponent();
+        await click('[data-control-name="attributes-panel-mode-switch-button"]');
+
+        assert.true(this.onEdit.calledOnceWithExactly());
+      });
+    });
+
+    async function renderComponent() {
       await render(hbs`
         <OSS::AttributesPanel @icon={{this.icon}} @title={{this.title}} @onSave={{this.onSave}} @onEdit={{this.onEdit}}>
           <:view-mode>
@@ -50,35 +78,86 @@ module('Integration | Component | o-s-s/attributes-panel', function (hooks) {
           </:view-mode>
         </OSS::AttributesPanel>
       `);
+    }
+  });
+
+  module('for edition mode', () => {
+    test('it renders the view-mode named block', async function (assert) {
+      await renderComponentAndClickOnEdit();
+      assert.dom('.attributes-panel__container.attributes-panel__container--edition').exists();
+      assert.dom('.custom-edition-mode').hasText('Edition mode');
     });
 
-    test('it renders the view-mode named block', function (assert) {
-      assert.dom('.attributes-panel__container.attributes-panel__container--view').exists();
-      assert.dom('.custom-view-mode').hasText('View mode');
+    test("it doesn't renders edition button", async function (assert) {
+      await renderComponentAndClickOnEdit();
+      assert.dom('[data-control-name="attributes-panel-mode-switch-button"]').doesNotExist();
     });
 
-    test('it renders edition button', function (assert) {
-      assert.dom('[data-control-name="attributes-panel-mode-switch-button"]').exists();
+    test("it doesn't renders contextual-action named block", async function (assert) {
+      await renderComponentAndClickOnEdit();
+      assert.dom('.custom-contextual-action').doesNotExist();
     });
 
-    module('when clicking on edit button', (hooks) => {
-      hooks.beforeEach(async function () {
-        await click('[data-control-name="attributes-panel-mode-switch-button"]');
+    test('it renders the save and cancel button', async function (assert) {
+      await renderComponentAndClickOnEdit();
+      assert.dom('[data-control-name="attributes-panel-cancel-button"]').exists();
+      assert.dom('[data-control-name="attributes-panel-save-button"]').exists();
+    });
+
+    module('when clicking on cancel button', () => {
+      test('it switches to view mode', async function (assert) {
+        await renderComponentAndClickOnEdit();
+
+        await click('[data-control-name="attributes-panel-cancel-button"]');
+        assert.dom('.attributes-panel__container.attributes-panel__container--view').exists();
+        assert.dom('.attributes-panel__container.attributes-panel__container--edition').doesNotExist();
       });
 
-      test('it changes to edition mode container', function (assert) {
+      test('it calls the @onCancel', async function (assert) {
+        await renderComponentAndClickOnEdit();
+
+        await click('[data-control-name="attributes-panel-cancel-button"]');
+        assert.true(this.onCancel.calledOnceWithExactly());
+      });
+    });
+
+    module('when clicking on save button', () => {
+      test('it switches to view mode', async function (assert) {
+        this.onSave.resolves();
+        await renderComponentAndClickOnEdit();
+
+        await click('[data-control-name="attributes-panel-save-button"]');
+        assert.dom('.attributes-panel__container.attributes-panel__container--view').exists();
+        assert.dom('.attributes-panel__container.attributes-panel__container--edition').doesNotExist();
+      });
+
+      test("it doesn't switch to the view mode", async function (assert) {
+        this.onSave.rejects();
+        await renderComponentAndClickOnEdit();
+
+        await click('[data-control-name="attributes-panel-save-button"]');
         assert.dom('.attributes-panel__container.attributes-panel__container--view').doesNotExist();
         assert.dom('.attributes-panel__container.attributes-panel__container--edition').exists();
       });
 
-      test('it calls the @onEdit', function (assert) {
-        assert.true(this.onEdit.calledOnceWithExactly());
+      test('it render a loading state', async function (assert) {
+        this.onSave.returns(new Promise(() => {}));
+        await renderComponentAndClickOnEdit();
+
+        await click('[data-control-name="attributes-panel-save-button"]');
+        assert.dom('[data-control-name="attributes-panel-save-button"] .fa-circle-notch').exists();
+      });
+
+      test('it calls the @onSave', async function (assert) {
+        this.onSave.resolves();
+        await renderComponentAndClickOnEdit();
+
+        await click('[data-control-name="attributes-panel-save-button"]');
+        assert.true(this.onSave.calledOnceWithExactly());
       });
     });
-  });
 
-  module('for edition mode', (hooks) => {
-    hooks.beforeEach(async function () {
+    async function renderComponentAndClickOnEdit() {
       await render(hbs`
         <OSS::AttributesPanel @icon={{this.icon}} @title={{this.title}} @onSave={{this.onSave}} @onEdit={{this.onEdit}}
                               @onCancel={{this.onCancel}}>
@@ -89,68 +168,7 @@ module('Integration | Component | o-s-s/attributes-panel', function (hooks) {
         </OSS::AttributesPanel>
       `);
       await click('[data-control-name="attributes-panel-mode-switch-button"]');
-    });
-
-    test('it renders the view-mode named block', function (assert) {
-      assert.dom('.attributes-panel__container.attributes-panel__container--edition').exists();
-      assert.dom('.custom-edition-mode').hasText('Edition mode');
-    });
-
-    test("it doesn't renders edition button", function (assert) {
-      assert.dom('[data-control-name="attributes-panel-mode-switch-button"]').doesNotExist();
-    });
-
-    test("it doesn't renders contextual-action named block", function (assert) {
-      assert.dom('.custom-contextual-action').doesNotExist();
-    });
-
-    test('it renders the save and cancel button', function (assert) {
-      assert.dom('[data-control-name="attributes-panel-cancel-button"]').exists();
-      assert.dom('[data-control-name="attributes-panel-save-button"]').exists();
-    });
-
-    module('when clicking on cancel button', (hooks) => {
-      hooks.beforeEach(async function () {
-        await click('[data-control-name="attributes-panel-cancel-button"]');
-      });
-
-      test('it switches to view mode', function (assert) {
-        assert.dom('.attributes-panel__container.attributes-panel__container--view').exists();
-        assert.dom('.attributes-panel__container.attributes-panel__container--edition').doesNotExist();
-      });
-
-      test('it calls the @onCancel', function (assert) {
-        assert.true(this.onCancel.calledOnceWithExactly());
-      });
-    });
-
-    module('when clicking on save button', () => {
-      test('it switches to view mode', async function (assert) {
-        this.onSave.resolves();
-        await click('[data-control-name="attributes-panel-save-button"]');
-        assert.dom('.attributes-panel__container.attributes-panel__container--view').exists();
-        assert.dom('.attributes-panel__container.attributes-panel__container--edition').doesNotExist();
-      });
-
-      test("it doesn't switch to the view mode", async function (assert) {
-        this.onSave.rejects();
-        await click('[data-control-name="attributes-panel-save-button"]');
-        assert.dom('.attributes-panel__container.attributes-panel__container--view').doesNotExist();
-        assert.dom('.attributes-panel__container.attributes-panel__container--edition').exists();
-      });
-
-      test('it render a loading state', async function (assert) {
-        this.onSave.returns(new Promise(() => {}));
-        await click('[data-control-name="attributes-panel-save-button"]');
-        assert.dom('[data-control-name="attributes-panel-save-button"] .fa-circle-notch').exists();
-      });
-
-      test('it calls the @onSave', async function (assert) {
-        this.onSave.resolves();
-        await click('[data-control-name="attributes-panel-save-button"]');
-        assert.true(this.onSave.calledOnceWithExactly());
-      });
-    });
+    }
   });
 
   test('it throws an error if @title is missing', async function (assert) {

--- a/tests/integration/components/o-s-s/infinite-select-test.js
+++ b/tests/integration/components/o-s-s/infinite-select-test.js
@@ -4,7 +4,7 @@ import { click, typeIn, render, scrollTo, setupOnerror, triggerKeyEvent } from '
 import hbs from 'htmlbars-inline-precompile';
 import sinon from 'sinon';
 
-function _isFocused(element: HTMLElement): Boolean {
+function _isFocused(element) {
   return element === document.activeElement;
 }
 

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -58,5 +58,8 @@ oss-components:
       subtitle: Failed to copy to your clipboard. Please try again.
   access-panel:
     search_placeholder: Search...
+  attributes_panel:
+    save: Save
+    cancel: Cancel
   attribute:
     country: Country


### PR DESCRIPTION
### What does this PR do?

Add new OSS::AttributesPanel component
Add tests & documentation

Related to: https://linear.app/upfluence/issue/ENG-1555/[oss-components]-new-ossattributespanel-component

### What are the observable changes?

![Peek 2023-10-26 17-40](https://github.com/upfluence/oss-components/assets/43567222/15b84c0c-6606-484c-9484-9704871eba4f)

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [x] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled
