### PR TITLE
OSS::Attribute::Text update

### DIFF
--- a/addon/components/o-s-s/attribute/country.ts
+++ b/addon/components/o-s-s/attribute/country.ts
@@ -1,11 +1,14 @@
 import Component from '@glimmer/component';
 import { CountryData, countries } from '@upfluence/oss-components/utils/country-codes';
+import { tracked } from '@glimmer/tracking';
 
 interface OSSAttributeCountryArgs {
   countryCode?: string;
 }
 
 export default class OSSAttributeCountry extends Component<OSSAttributeCountryArgs> {
+  @tracked displayCopyBtn: boolean = false;
+
   private countryDictionnary: CountryData[] = countries;
 
   get countryName(): string {

--- a/addon/components/o-s-s/attribute/text.hbs
+++ b/addon/components/o-s-s/attribute/text.hbs
@@ -10,7 +10,7 @@
     {{/if}}
   </div>
   <span class="oss-attribute__value">{{this.value}}</span>
-  {{#if this.isCopyable}}
+  {{#if (and this.displayCopyBtn this.isCopyable)}}
     <div class="oss-attribute__copy">
       <OSS::Copy @value={{this.value}} @inline={{true}} />
     </div>

--- a/addon/components/o-s-s/attribute/text.stories.js
+++ b/addon/components/o-s-s/attribute/text.stories.js
@@ -42,7 +42,7 @@ export default {
         type: {
           summary: 'boolean'
         },
-        defaultValue: { summary: false }
+        defaultValue: { summary: true }
       },
       control: { type: 'boolean' }
     }
@@ -59,7 +59,8 @@ export default {
 
 const defaultArgs = {
   label: 'Label',
-  value: 'Your copied value'
+  value: 'Your copied value',
+  copyable: true
 };
 
 const BasicUsageTemplate = (args) => ({

--- a/addon/components/o-s-s/attribute/text.ts
+++ b/addon/components/o-s-s/attribute/text.ts
@@ -11,8 +11,8 @@ interface OSSAttributeTextArgs {
 }
 
 export default class OSSAttributeText extends Component<OSSAttributeTextArgs> {
-  @tracked displayCopyBtn = false;
-  @tracked copyable = this.args.copyable ?? true;
+  @tracked displayCopyBtn: boolean = false;
+  @tracked copyable: boolean = this.args.copyable ?? true;
 
   constructor(owner: unknown, args: OSSAttributeTextArgs) {
     super(owner, args);
@@ -24,6 +24,6 @@ export default class OSSAttributeText extends Component<OSSAttributeTextArgs> {
   }
 
   get isCopyable(): boolean {
-    return Boolean(this.copyable) && !isBlank(this.args.value);
+    return this.copyable && !isBlank(this.args.value);
   }
 }

--- a/app/components/o-s-s/attribute/text.js
+++ b/app/components/o-s-s/attribute/text.js
@@ -1,1 +1,1 @@
-export { default } from '@upfluence/oss-components/components/o-s-s/attribute-text';
+export { default } from '@upfluence/oss-components/components/o-s-s/attribute/text';

--- a/tests/integration/components/o-s-s/attribute/text-test.ts
+++ b/tests/integration/components/o-s-s/attribute/text-test.ts
@@ -4,7 +4,7 @@ import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import triggerEvent from '@ember/test-helpers/dom/trigger-event';
 
-module('Integration | Component | o-s-s/attribute-text', function (hooks) {
+module('Integration | Component | o-s-s/attribute/text', function (hooks) {
   setupRenderingTest(hooks);
 
   module('Default behavior', function () {
@@ -45,6 +45,11 @@ module('Integration | Component | o-s-s/attribute-text', function (hooks) {
       hooks.beforeEach(function () {
         this.textForCopy = 'copied value';
         this.displayCopyBtn = true;
+      });
+
+      test('the copy icon is not visible before hovering', async function (assert) {
+        await render(hbs`<OSS::Attribute::Text @label="Hello" @value={{this.textForCopy}} />`);
+        assert.dom('.oss-attribute__copy').doesNotExist();
       });
 
       test('the text is copyable by default', async function (assert) {


### PR DESCRIPTION
### What does this PR do?

OSS::Attribute::Text update:
- move the file according to his name
- before hovering the inline copy should be NOT visible
- default value for `copyable` arg set to true
- tests

Related to: https://linear.app/upfluence/issue/ENG-1564/[ember-influencer]-new-attributespanelshippingaddress-component-and

### What are the observable changes?

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [x] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled