### PR TITLE
Disabled the save button in edition mode for attributes-panel

### DIFF
--- a/addon/components/o-s-s/attributes-panel.hbs
+++ b/addon/components/o-s-s/attributes-panel.hbs
@@ -32,7 +32,7 @@
             <OSS::Button @label={{t "oss-components.attributes_panel.cancel"}} {{on "click" this.onCancel}}
                          data-control-name="attributes-panel-cancel-button" />
             <OSS::Button @skin="primary" @label={{t "oss-components.attributes_panel.save"}} @loading={{this.isLoading}}
-                         {{on "click" this.onSave}} data-control-name="attributes-panel-save-button" />
+                         disabled={{@isSaveDisabled}} {{on "click" this.onSave}} data-control-name="attributes-panel-save-button" />
           </div>
         </div>
       {{/if}}

--- a/addon/components/o-s-s/attributes-panel.stories.js
+++ b/addon/components/o-s-s/attributes-panel.stories.js
@@ -26,6 +26,16 @@ export default {
       },
       control: { type: 'text' }
     },
+    isSaveDisabled: {
+      description: 'If the save button is disabled or not',
+      table: {
+        type: {
+          summary: 'boolean'
+        },
+        defaultValue: { summary: 'undefined' }
+      },
+      control: { type: 'boolean' }
+    },
     onSave: {
       description: 'A callback sent when the saved button is pressed',
       table: {
@@ -68,6 +78,7 @@ export default {
 const defaultArgs = {
   title: 'Title',
   icon: 'fa-laptop-code',
+  isSaveDisabled: false,
   onSave: action('onSave'),
   onCancel: action('onCancel'),
   onEdit: action('onEdit')
@@ -77,7 +88,7 @@ const DefaultUsageTemplate = (args) => ({
   template: hbs`
     <div style="width: 350px; background-color: var(--color-gray-50); padding: var(--spacing-px-24);">
       <OSS::AttributesPanel @title={{this.title}} @icon={{this.icon}} @onSave={{this.onSave}}
-                            @onCancel={{this.onCancel}} @onEdit={{this.onEdit}}>
+                            @onCancel={{this.onCancel}} @onEdit={{this.onEdit}} @isSaveDisabled={{this.isSaveDisabled}} >
           <:view-mode>
             View mode
           </:view-mode>
@@ -94,7 +105,7 @@ const WithContextualActionTemplate = (args) => ({
   template: hbs`
     <div style="width: 350px; background-color: var(--color-gray-50); padding: var(--spacing-px-24);">
       <OSS::AttributesPanel @title={{this.title}} @icon={{this.icon}} @onSave={{this.onSave}}
-                            @onCancel={{this.onCancel}} @onEdit={{this.onEdit}}>
+                            @onCancel={{this.onCancel}} @onEdit={{this.onEdit}} @isSaveDisabled={{this.isSaveDisabled}}>
           <:contextual-action>
             <OSS::Button @icon="fa-plus" @square={{true}} />
           </:contextual-action>

--- a/addon/components/o-s-s/attributes-panel.ts
+++ b/addon/components/o-s-s/attributes-panel.ts
@@ -8,6 +8,7 @@ type Mode = 'view' | 'edition';
 interface OSSAttributesPanelArgs {
   title: string;
   icon?: string;
+  isSaveDisabled?: boolean;
   onSave(): Promise<void>;
   onEdit?(): void;
   onCancel?(): void;

--- a/tests/integration/components/o-s-s/attributes-panel-test.ts
+++ b/tests/integration/components/o-s-s/attributes-panel-test.ts
@@ -10,6 +10,7 @@ module('Integration | Component | o-s-s/attributes-panel', function (hooks) {
   hooks.beforeEach(function () {
     this.icon = 'fa-laptop-code';
     this.title = 'Title';
+    this.isSaveDisabled = undefined;
     this.onSave = sinon.stub();
     this.onCancel = sinon.stub();
     this.onEdit = sinon.stub();
@@ -157,10 +158,29 @@ module('Integration | Component | o-s-s/attributes-panel', function (hooks) {
       });
     });
 
+    module('when @isSaveDisabled', () => {
+      test('is undefined, the save button is not disabled', async function (assert) {
+        await renderComponentAndClickOnEdit();
+        assert.dom('[data-control-name="attributes-panel-save-button"]').isNotDisabled();
+      });
+
+      test('is true, the save button is disabled', async function (assert) {
+        this.isSaveDisabled = true;
+        await renderComponentAndClickOnEdit();
+        assert.dom('[data-control-name="attributes-panel-save-button"]').isDisabled();
+      });
+
+      test('is false, the save button is not disabled', async function (assert) {
+        this.isSaveDisabled = false;
+        await renderComponentAndClickOnEdit();
+        assert.dom('[data-control-name="attributes-panel-save-button"]').isNotDisabled();
+      });
+    });
+
     async function renderComponentAndClickOnEdit() {
       await render(hbs`
         <OSS::AttributesPanel @icon={{this.icon}} @title={{this.title}} @onSave={{this.onSave}} @onEdit={{this.onEdit}}
-                              @onCancel={{this.onCancel}}>
+                              @onCancel={{this.onCancel}} @isSaveDisabled={{this.isSaveDisabled}}>
           <:contextual-action><div class="custom-contextual-action"></div></:contextual-action>
           <:edition-mode>
             <div class="custom-edition-mode">Edition mode</div>


### PR DESCRIPTION
### What does this PR do?
Disabled the save button in edition mode for attributes-panel

Related to: https://linear.app/upfluence/issue/ENG-1753/save-button-is-enabled-when-shipping-address-section-is-empty

### What are the observable changes?
![Peek 2023-11-03 17-17](https://github.com/upfluence/oss-components/assets/43567222/0eee7623-464e-46e4-9b43-585f20dbff6c)

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [x] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled
