### PR TITLE
Adds Attribute::Base component with tests

### DIFF
--- a/addon/components/o-s-s/attribute/base.hbs
+++ b/addon/components/o-s-s/attribute/base.hbs
@@ -1,0 +1,20 @@
+<div class="oss-attribute"
+     {{on "mouseenter" (fn (mut this.displayCopyBtn) true)}}
+     {{on "mouseleave" (fn (mut this.displayCopyBtn) false)}}
+     ...attributes>
+  {{#if (has-block "label")}}
+    <div class="oss-attribute__label">{{yield to="label"}}</div>
+  {{/if}}
+  {{#if (has-block "value")}}
+    <div class="oss-attribute__value">{{yield to="value"}}</div>
+  {{else}}
+    <span class="oss-attribute__value">
+      {{@value}}
+    </span>
+  {{/if}}
+  {{#if (and this.displayCopyBtn this.isCopyable)}}
+    <div class="oss-attribute__copy">
+      <OSS::Copy @value={{@value}} @inline={{true}} />
+    </div>
+  {{/if}}
+</div>

--- a/addon/components/o-s-s/attribute/base.ts
+++ b/addon/components/o-s-s/attribute/base.ts
@@ -1,0 +1,13 @@
+import { isBlank } from '@ember/utils';
+import Component from '@glimmer/component';
+
+interface OSSAttributeBaseArgs {
+  value: string;
+  copyable?: boolean;
+}
+
+export default class OSSAttributeBase extends Component<OSSAttributeBaseArgs> {
+  get isCopyable(): boolean {
+    return (this.args.copyable ?? true) && !isBlank(this.args.value) && this.args.value !== '-';
+  }
+}

--- a/addon/components/o-s-s/attribute/country.hbs
+++ b/addon/components/o-s-s/attribute/country.hbs
@@ -1,17 +1,8 @@
-<div class="oss-attribute"
-     {{on "mouseenter" (fn (mut this.displayCopyBtn) true)}}
-     {{on "mouseleave" (fn (mut this.displayCopyBtn) false)}}
-     data-control-name="attribute-country" ...attributes>
-  <div class="oss-attribute__label">
+<OSS::Attribute::Base @value={{this.countryName}} data-control-name="attribute-country" ...attributes>
+  <:label>
     <span>{{t "oss-components.attribute.country"}}</span>
     {{#if (not-eq this.countryName "-")}}
       <div class="fflag fflag-{{@countryCode}} ff-round ff-sm"></div>
     {{/if}}
-  </div>
-  <span class="oss-attribute__value">
-    {{this.countryName}}
-  </span>
-  {{#if (and this.displayCopyBtn (not-eq this.countryName "-"))}}
-    <OSS::Copy @value={{this.countryName}} @inline="true" />
-  {{/if}}
-</div>
+  </:label>
+</OSS::Attribute::Base>

--- a/addon/components/o-s-s/attribute/text.hbs
+++ b/addon/components/o-s-s/attribute/text.hbs
@@ -1,18 +1,9 @@
-<div class="oss-attribute"
-     {{on "mouseenter" (fn (mut this.displayCopyBtn) true)}}
-     {{on "mouseleave" (fn (mut this.displayCopyBtn) false)}}
-     data-control-name="attribute-text">
-  <div class="oss-attribute__label">
-    <span>{{this.args.label}}</span>
-    {{#if this.args.tooltip}}
+<OSS::Attribute::Base @value={{this.value}} @copyable={{@copyable}} data-control-name="attribute-text" ...attributes>
+  <:label>
+    <span>{{@label}}</span>
+    {{#if @tooltip}}
       <OSS::Icon @icon="far fa-info-circle" class="oss-attribute__info" @inline={{true}}
-                 {{enable-tooltip title=this.args.tooltip placement="top"}} />
+                 {{enable-tooltip title=@tooltip placement="top"}} />
     {{/if}}
-  </div>
-  <span class="oss-attribute__value">{{this.value}}</span>
-  {{#if (and this.displayCopyBtn this.isCopyable)}}
-    <div class="oss-attribute__copy">
-      <OSS::Copy @value={{this.value}} @inline={{true}} />
-    </div>
-  {{/if}}
-</div>
+  </:label>
+</OSS::Attribute::Base>

--- a/addon/components/o-s-s/attribute/text.ts
+++ b/addon/components/o-s-s/attribute/text.ts
@@ -12,7 +12,7 @@ interface OSSAttributeTextArgs {
 export default class OSSAttributeText extends Component<OSSAttributeTextArgs> {
   constructor(owner: unknown, args: OSSAttributeTextArgs) {
     super(owner, args);
-    assert(`[component][OSS::Attribute::Text] label is required `, this.args.label);
+    assert('[component][OSS::Attribute::Text] label is required', this.args.label);
   }
 
   get value(): string {

--- a/addon/components/o-s-s/attribute/text.ts
+++ b/addon/components/o-s-s/attribute/text.ts
@@ -1,7 +1,6 @@
 import { assert } from '@ember/debug';
 import { isBlank } from '@ember/utils';
 import Component from '@glimmer/component';
-import { tracked } from '@glimmer/tracking';
 
 interface OSSAttributeTextArgs {
   label: string;
@@ -11,9 +10,6 @@ interface OSSAttributeTextArgs {
 }
 
 export default class OSSAttributeText extends Component<OSSAttributeTextArgs> {
-  @tracked displayCopyBtn: boolean = false;
-  @tracked copyable: boolean = this.args.copyable ?? true;
-
   constructor(owner: unknown, args: OSSAttributeTextArgs) {
     super(owner, args);
     assert(`[component][OSS::Attribute::Text] label is required `, this.args.label);
@@ -21,9 +17,5 @@ export default class OSSAttributeText extends Component<OSSAttributeTextArgs> {
 
   get value(): string {
     return isBlank(this.args.value) ? '-' : this.args.value!;
-  }
-
-  get isCopyable(): boolean {
-    return this.copyable && !isBlank(this.args.value);
   }
 }

--- a/app/components/o-s-s/attribute/base.js
+++ b/app/components/o-s-s/attribute/base.js
@@ -1,0 +1,1 @@
+export { default } from '@upfluence/oss-components/components/o-s-s/attribute/base';

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -21,10 +21,6 @@
   </OSS::Layout::Sidebar>
 
   <div style="width:100%; height:100vh; overflow: auto; background-color: var(--color-gray-50)">
-    <div class="fx-1 fx-col fx-gap-px-9">
-      <OSS::Attribute::Country @countryCode="US" />
-      <OSS::Attribute::Country @countryCode="" />
-    </div>
     <div class="fx-row fx-1 fx-gap-px-10 margin-md">
       <OSS::AttributesPanel @title="Title" @icon="fa-laptop-code" @onSave={{this.onAttributePanelSave}}
                             @onCancel={{this.onAttributePanelCancel}} @onEdit={{this.onAttributePanelEdit}}>
@@ -45,6 +41,10 @@
     <div class="fx-row fx-1 fx-gap-px-10 margin-md">
       <OSS::Copy @value="I am the value copied" @inline={{true}} />
       <OSS::Copy @value="I am the value copied" />
+    </div>
+    <div class="fx-row fx-1 fx-gap-px-10 margin-md">
+      <OSS::Attribute::Country @countryCode="US" />
+      <OSS::Attribute::Country @countryCode="" />
     </div>
     <div class="fx-row fx-1 fx-gap-px-10 margin-md">
       <OSS::Attribute::Text @label="Label with tooltip copyable" @value="Hello World"

--- a/tests/integration/components/o-s-s/attribute/base-test.ts
+++ b/tests/integration/components/o-s-s/attribute/base-test.ts
@@ -1,0 +1,80 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+import triggerEvent from '@ember/test-helpers/dom/trigger-event';
+
+module('Integration | Component | o-s-s/attribute/base', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('It renders', async function (assert) {
+    await render(hbs`<OSS::Attribute::Base />`);
+
+    assert.dom('.oss-attribute').exists();
+  });
+
+  test('The splattributes argument is set on the component', async function (assert) {
+    await render(hbs`<OSS::Attribute::Base data-control-name="testing-splattributes" />`);
+
+    assert.dom('[data-control-name="testing-splattributes"]').exists();
+  });
+
+  test('It displays the label named-block when passed', async function (assert) {
+    await render(hbs`<OSS::Attribute::Base @value="bananas">
+                      <:label><span>this is the label named-block</span></:label>
+                     </OSS::Attribute::Base>`);
+
+    assert.dom('.oss-attribute .oss-attribute__label').hasText('this is the label named-block');
+  });
+
+  module('Value handling', () => {
+    test('It displays the value when passed', async function (assert) {
+      await render(hbs`<OSS::Attribute::Base @value="bananas" />`);
+
+      assert.dom('.oss-attribute .oss-attribute__value').hasText('bananas');
+    });
+
+    test('It displays the value named-block when passed', async function (assert) {
+      await render(hbs`<OSS::Attribute::Base @value="bananas">
+                       <:value>
+                         <div class="fx-row fx-xalign-center fx-gap-px-6">
+                           {{@value}}
+                           <OSS::Icon @icon="fa-lock" />
+                         </div>
+                       </:value>
+                     </OSS::Attribute::Base>`);
+
+      assert.dom('.oss-attribute .oss-attribute__value .fa-lock').exists();
+    });
+  });
+
+  module('Copy button behaviour', () => {
+    test('The text is copyable by default if a value is passed', async function (assert) {
+      await render(hbs`<OSS::Attribute::Base @label="label" @value="value" />`);
+
+      await triggerEvent('.oss-attribute', 'mouseenter');
+      assert.dom('.oss-attribute__copy').exists();
+    });
+
+    test('The text is not copyable if the value is blank', async function (assert) {
+      await render(hbs`<OSS::Attribute::Base @label="label" @value="   " />`);
+
+      await triggerEvent('.oss-attribute', 'mouseenter');
+      assert.dom('.oss-attribute__copy').doesNotExist();
+    });
+
+    test('The text is not copyable if the value is undefined', async function (assert) {
+      await render(hbs`<OSS::Attribute::Base @label="label" />`);
+
+      await triggerEvent('.oss-attribute', 'mouseenter');
+      assert.dom('.oss-attribute__copy').doesNotExist();
+    });
+
+    test('The text is not copyable if the @copyable parameter is set to false', async function (assert) {
+      await render(hbs`<OSS::Attribute::Base @label="label" @value="value" @copyable={{false}} />`);
+
+      await triggerEvent('.oss-attribute', 'mouseenter');
+      assert.dom('.oss-attribute__copy').doesNotExist();
+    });
+  });
+});

--- a/tests/integration/components/o-s-s/attribute/text-test.ts
+++ b/tests/integration/components/o-s-s/attribute/text-test.ts
@@ -9,7 +9,7 @@ module('Integration | Component | o-s-s/attribute/text', function (hooks) {
 
   module('Default behavior', function () {
     module('Render conditions', function () {
-      test('it renders', async function (assert) {
+      test('It renders', async function (assert) {
         await render(hbs`<OSS::Attribute::Text @label="Hello" @value="World" />`);
         assert.dom('.oss-attribute').exists();
         assert.dom('.oss-attribute__label').hasText('Hello');
@@ -22,13 +22,13 @@ module('Integration | Component | o-s-s/attribute/text', function (hooks) {
         assert.dom('.oss-attribute__value').hasText('-');
       });
 
-      test('it renders with a tooltip when specified', async function (assert) {
+      test('It renders with a tooltip when specified', async function (assert) {
         await render(hbs`<OSS::Attribute::Text @label="Hello" @tooltip="Tooltip" />`);
         assert.dom('.oss-attribute__info').exists();
         await assert.tooltip('.oss-attribute__info').hasTitle('Tooltip');
       });
 
-      test('it renders a dash as value when no value is specified', async function (assert) {
+      test('It renders a dash as value when no value is specified', async function (assert) {
         await render(hbs`<OSS::Attribute::Text @label="Hello" />`);
         assert.dom('.oss-attribute').exists();
         assert.dom('.oss-attribute__value').hasText('-');
@@ -47,12 +47,12 @@ module('Integration | Component | o-s-s/attribute/text', function (hooks) {
         this.displayCopyBtn = true;
       });
 
-      test('the copy icon is not visible before hovering', async function (assert) {
+      test('The copy icon is not visible before hovering', async function (assert) {
         await render(hbs`<OSS::Attribute::Text @label="Hello" @value={{this.textForCopy}} />`);
         assert.dom('.oss-attribute__copy').doesNotExist();
       });
 
-      test('the text is copyable by default', async function (assert) {
+      test('The text is copyable by default', async function (assert) {
         await render(hbs`<OSS::Attribute::Text @label="Hello" @value={{this.textForCopy}} />`);
 
         await triggerEvent('.oss-attribute', 'mouseenter');


### PR DESCRIPTION
### What does this PR do?
Adds Attribute::Base component with tests

Linked to: https://linear.app/upfluence/issue/ENG-1559/[oss-components]-new-ossattributerevealemail-component

### Good PR checklist
- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled