### PR TITLE
Updated: inputContainer's prefix & suffix padding and suffix hitbox

### DIFF
--- a/app/styles/atoms/input-container.less
+++ b/app/styles/atoms/input-container.less
@@ -45,22 +45,28 @@
   .suffix {
     .morpheme;
     right: 0;
-    padding-right: 10px;
-    padding-left: 8px;
+    i,
+    div {
+      padding-right: 12px;
+      padding-left: 12px;
+      height: 100%;
+      display: flex;
+      align-items: center;
+    }
   }
 
   .prefix {
     .morpheme;
     left: 0;
-    padding-right: 8px;
-    padding-left: 10px;
+    padding-right: 12px;
+    padding-left: 12px;
   }
 
   &.has-prefix input {
-    padding-left: 25px;
+    padding-left: 32px;
   }
 
   &.has-suffix input {
-    padding-right: 25px;
+    padding-right: 32px;
   }
 }

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -22,6 +22,21 @@
 
   <div style="width:100%; height:100vh; overflow: auto; background-color: var(--color-gray-50)">
     <div class="fx-row fx-1 fx-gap-px-10 margin-md">
+      <OSS::InputContainer @placeholder="search" @value={{this.shopUrl}}>
+        <:prefix>
+          <OSS::Icon @icon="fa-search" class="font-color-gray-500" />
+        </:prefix>
+        <:suffix>
+          {{#if (gt this.shopUrl.length 0)}}
+            <OSS::Icon @icon="fa-times" class="font-color-gray-500" role="button"
+                       {{on "click" (fn (mut this.shopUrl) '')}} />
+          {{/if}}
+        </:suffix>
+      </OSS::InputContainer>
+      <OSS::InputContainer @placeholder="search" @value={{this.shopUrl}} />
+      <OSS::PasswordInput @value="azeaze" />
+    </div>
+    <div class="fx-row fx-1 fx-gap-px-10 margin-md">
       <OSS::AttributesPanel @title="Title" @icon="fa-laptop-code" @onSave={{this.onAttributePanelSave}}
                             @onCancel={{this.onAttributePanelCancel}} @onEdit={{this.onAttributePanelEdit}}>
         <:contextual-action>


### PR DESCRIPTION
### What does this PR do?

Updated padding for prefix & suffix of OSS::InputContainer.
Also updated the clickable area of the suffix.
![Screenshot 2023-11-07 at 11 05 32](https://github.com/upfluence/oss-components/assets/5032005/97105f30-14ae-46fd-be99-9b6c4c69cf9e)
![Screenshot 2023-11-07 at 11 05 46](https://github.com/upfluence/oss-components/assets/5032005/7d77f189-da60-4270-946b-0efdb57de394)


### Good PR checklist
- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [ ] Properly labeled
