### PR TITLE
Adds OSS::Attribute::PhoneNumber along with documentation and tests

### DIFF
--- a/addon/components/o-s-s/attribute/phone-number.hbs
+++ b/addon/components/o-s-s/attribute/phone-number.hbs
@@ -1,0 +1,8 @@
+<OSS::Attribute::Base @value={{this.formattedPhoneNumber}} data-control-name="attribute-phone-number" ...attributes>
+  <:label>
+    <span>{{t "oss-components.attribute.phone_number"}}</span>
+    {{#if this.countryCodeDictionaryMatch}}
+      <div class="fflag fflag-{{@countryCode}} ff-round ff-sm"></div>
+    {{/if}}
+  </:label>
+</OSS::Attribute::Base>

--- a/addon/components/o-s-s/attribute/phone-number.stories.js
+++ b/addon/components/o-s-s/attribute/phone-number.stories.js
@@ -1,0 +1,54 @@
+import hbs from 'htmlbars-inline-precompile';
+
+export default {
+  title: 'Components/OSS::Attribute::PhoneNumber',
+  component: 'phone-number',
+  argTypes: {
+    countryCode: {
+      description:
+        'The country-code in alpha2 format that will be used to display the country flag if it matches the dictionary.',
+      table: {
+        defaultValue: { summary: 'undefined' }
+      },
+      control: { type: 'text' }
+    },
+    prefix: {
+      description: 'The phone number prefix to be displayed with a space before the number. (e.g. "+33")',
+      table: {
+        defaultValue: { summary: 'undefined' }
+      },
+      control: { type: 'text' }
+    },
+    number: {
+      description: 'The phone number that will be displayed',
+      table: {
+        defaultValue: { summary: 'undefined' }
+      },
+      control: { type: 'text' }
+    }
+  },
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'Member of the Attribute displays. The OSS::Attribute::PhoneNumber displays a phone number and a country flag if the country-code is provided.'
+      }
+    }
+  }
+};
+
+const defaultArgs = {
+  countryCode: 'FR'
+};
+
+const Template = (args) => ({
+  template: hbs`
+    <div style="padding: 12px; background: white">
+      <OSS::Attribute::PhoneNumber @countryCode={{this.countryCode}} />
+    </div>
+  `,
+  context: args
+});
+
+export const Default = Template.bind({});
+Default.args = defaultArgs;

--- a/addon/components/o-s-s/attribute/phone-number.stories.js
+++ b/addon/components/o-s-s/attribute/phone-number.stories.js
@@ -38,13 +38,15 @@ export default {
 };
 
 const defaultArgs = {
-  countryCode: 'FR'
+  countryCode: 'FR',
+  prefix: '+33',
+  number: '6 12 34 56 78'
 };
 
 const Template = (args) => ({
   template: hbs`
     <div style="padding: 12px; background: white">
-      <OSS::Attribute::PhoneNumber @countryCode={{this.countryCode}} />
+      <OSS::Attribute::PhoneNumber @countryCode={{this.countryCode}} @prefix={{this.prefix}} @number={{this.number}} />
     </div>
   `,
   context: args

--- a/addon/components/o-s-s/attribute/phone-number.ts
+++ b/addon/components/o-s-s/attribute/phone-number.ts
@@ -1,0 +1,24 @@
+import Component from '@glimmer/component';
+import { CountryData, countries } from '@upfluence/oss-components/utils/country-codes';
+
+interface OSSAttributePhoneNumberArgs {
+  countryCode?: string;
+  prefix?: string;
+  number?: string;
+}
+
+export default class OSSAttributePhoneNumber extends Component<OSSAttributePhoneNumberArgs> {
+  private countryDictionnary: CountryData[] = countries;
+
+  get formattedPhoneNumber(): string {
+    return this.args.number ? `${this.formattedPrefix}${this.args.number}` : '-';
+  }
+
+  get countryCodeDictionaryMatch(): boolean {
+    return !!this.countryDictionnary.find((country: CountryData) => country.alpha2 === this.args.countryCode);
+  }
+
+  private get formattedPrefix(): string {
+    return this.args.prefix ? `${this.args.prefix} ` : '';
+  }
+}

--- a/app/components/o-s-s/attribute/phone-number.js
+++ b/app/components/o-s-s/attribute/phone-number.js
@@ -1,0 +1,1 @@
+export { default } from '@upfluence/oss-components/components/o-s-s/attribute/phone-number';

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -36,14 +36,29 @@
       <OSS::InputContainer @placeholder="search" @value={{this.shopUrl}} />
       <OSS::PasswordInput @value="azeaze" />
     </div>
-    <div class="fx-row fx-1 fx-gap-px-10 margin-md">
+    <div class="fx-row fx-1 fx-gap-px-10 margin-md width-pc-50">
       <OSS::AttributesPanel @title="Title" @icon="fa-laptop-code" @onSave={{this.onAttributePanelSave}}
                             @onCancel={{this.onAttributePanelCancel}} @onEdit={{this.onAttributePanelEdit}}>
         <:contextual-action>
           <OSS::Button @icon="fa-plus" @square={{true}} />
         </:contextual-action>
         <:view-mode>
-          View mode
+          <OSS::Attribute::PhoneNumber @countryCode="FR" @prefix="+33" @number="642424242" />
+          <OSS::Attribute::PhoneNumber @countryCode="nope" @number="+33642424242" />
+          <OSS::Attribute::PhoneNumber @prefix="+33" />
+          <OSS::Attribute::RevealableEmail @lockTooltip="This will fail"
+                                           @onRevealEmail={{this.onRevealEmailError}} />
+          {{#if this.revealed}}
+            <OSS::Attribute::Text @label="Email address" @value="john.doe@gmail.com" />
+          {{else}}
+            <OSS::Attribute::RevealableEmail @tooltip="Click on lock to reveal"
+                                             @onRevealEmail={{this.onRevealEmailSuccess}} />
+          {{/if}}
+          <OSS::Attribute::Country @countryCode="US" />
+          <OSS::Attribute::Country @countryCode="" />
+          <OSS::Attribute::Text @label="Label with tooltip copyable" @value="Hello World"
+                                @tooltip="Hello World" />
+          <OSS::Attribute::Text @label="Label not copyable" @value="Hello World" @copyable={{false}} />
         </:view-mode>
         <:edition-mode>
           Edition mode
@@ -56,23 +71,6 @@
     <div class="fx-row fx-1 fx-gap-px-10 margin-md">
       <OSS::Copy @value="I am the value copied" @inline={{true}} />
       <OSS::Copy @value="I am the value copied" />
-    </div>
-    <div class="fx-row fx-1 fx-gap-px-10 margin-md width-pc-50">
-      <OSS::ContentPanel class="fx-1">
-        <OSS::Attribute::RevealableEmail @lockTooltip="This will fail"
-                                         @onRevealEmail={{this.onRevealEmailError}} />
-        {{#if this.revealed}}
-          <OSS::Attribute::Text @label="Email address" @value="john.doe@gmail.com" />
-        {{else}}
-          <OSS::Attribute::RevealableEmail @tooltip="Click on lock to reveal"
-                                           @onRevealEmail={{this.onRevealEmailSuccess}} />
-        {{/if}}
-        <OSS::Attribute::Country @countryCode="US" />
-        <OSS::Attribute::Country @countryCode="" />
-        <OSS::Attribute::Text @label="Label with tooltip copyable" @value="Hello World"
-                              @tooltip="Hello World" />
-        <OSS::Attribute::Text @label="Label not copyable" @value="Hello World" @copyable={{false}} />
-      </OSS::ContentPanel>
     </div>
     <div class="fx-row fx-1 fx-gap-px-10 margin-md">
       <OSS::Illustration @src="/@upfluence/oss-components/assets/images/no-records.svg" />

--- a/tests/integration/components/o-s-s/attribute/phone-number-test.ts
+++ b/tests/integration/components/o-s-s/attribute/phone-number-test.ts
@@ -1,0 +1,46 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Component | o-s-s/attribute/phone-number', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function (assert) {
+    await render(hbs`<OSS::Attribute::PhoneNumber />`);
+
+    assert.dom('[data-control-name="attribute-phone-number"]').exists();
+  });
+
+  test('If the number is passed, it is displayed', async function (assert) {
+    await render(hbs`<OSS::Attribute::PhoneNumber @number="+1 212 666 666" />`);
+
+    assert.dom('.oss-attribute__value').hasText('+1 212 666 666');
+  });
+
+  test('If the number is undefined, a dash is displayed', async function (assert) {
+    await render(hbs`<OSS::Attribute::PhoneNumber @prefix="+44" @number="" />`);
+
+    assert.dom('.oss-attribute__value').hasText('-');
+  });
+
+  test('If the prefix is passed with a number, they are both displayed', async function (assert) {
+    await render(hbs`<OSS::Attribute::PhoneNumber @prefix="+44" @number="123 123" />`);
+
+    assert.dom('.oss-attribute__value').hasText('+44 123 123');
+  });
+
+  test('If the countryCode matches one in the dictionary, a flag is displayed', async function (assert) {
+    await render(hbs`<OSS::Attribute::PhoneNumber @countryCode="US" @prefix="+1" @number="123 123" />`);
+
+    assert.dom('.oss-attribute__value').hasText('+1 123 123');
+    assert.dom('.fflag-US').exists();
+  });
+
+  test("If the countryCode doesn't match one in the dictionary, no flag is displayed", async function (assert) {
+    await render(hbs`<OSS::Attribute::PhoneNumber @countryCode="random" @prefix="+1" @number="123 123" />`);
+
+    assert.dom('.oss-attribute__value').hasText('+1 123 123');
+    assert.dom('.fflag-US').doesNotExist();
+  });
+});

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -63,6 +63,7 @@ oss-components:
     cancel: Cancel
   attribute:
     country: Country
+    phone_number: Phone number
     email:
       label: Email address
       lock_tooltip: Reveal email


### PR DESCRIPTION
### What does this PR do?
Adds OSS::Attribute::PhoneNumber along with documentation and tests
![Screenshot 2023-11-09 at 14 12 21](https://github.com/upfluence/oss-components/assets/5032005/6c3d8fe9-27f3-4457-b2e1-0fd8a998091e)

### Good PR checklist
- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [x] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled