### PR TITLE
Adds OSS::Attribute::TagArray component along with tests and documentation

### DIFF
--- a/addon/components/o-s-s/attribute/removable-text.hbs
+++ b/addon/components/o-s-s/attribute/removable-text.hbs
@@ -1,0 +1,19 @@
+<OSS::Attribute::Base @copyable={{false}} data-control-name="attribute-removable-text"
+                      {{on "mouseenter" (fn (mut this.displayRemoveIcon) true)}}
+                      {{on "mouseleave" (fn (mut this.displayRemoveIcon) false)}}
+                      ...attributes>
+  <:label>
+    <span>{{@label}}</span>
+  </:label>
+  <:value>
+    <div class="fx-row fx-xalign-center fx-gap-px-6">
+      <span class="fx-1">{{this.value}}</span>
+      {{#if this.loading}}
+        <OSS::Icon @icon="fa-circle-notch fa-spin" />
+      {{else if this.displayRemoveIcon}}
+        <OSS::Icon @icon="fa-trash" {{on "click" this.onRemove}} role="button"
+                   {{enable-tooltip title=this.removeTooltip placement="top"}} />
+      {{/if}}
+    </div>
+  </:value>
+</OSS::Attribute::Base>

--- a/addon/components/o-s-s/attribute/removable-text.stories.js
+++ b/addon/components/o-s-s/attribute/removable-text.stories.js
@@ -1,0 +1,63 @@
+import hbs from 'htmlbars-inline-precompile';
+import { action } from '@storybook/addon-actions';
+
+export default {
+  title: 'Components/OSS::Attribute::RemovableText',
+  component: 'removable-text',
+  argTypes: {
+    label: {
+      description: 'The label of the component.',
+      table: {
+        defaultValue: { summary: 'undefined' }
+      },
+      control: { type: 'text' },
+      type: { required: true }
+    },
+    removeTooltip: {
+      description: 'Overwrites the default "Remove" tooltip that is visible on component hover',
+      table: {
+        defaultValue: { summary: 'undefined' }
+      },
+      control: { type: 'text' }
+    },
+    onRemove: {
+      description:
+        'The callback method triggered when a user clicks on the trash icon. It should return a promise which allows the spinner to stop being displayed when needed',
+      type: { required: true },
+      table: {
+        category: 'Actions',
+        type: {
+          summary: 'onRemove(): Promise<void>'
+        }
+      }
+    }
+  },
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'Member of the Attribute displays. The OSS::Attribute::RemovableText displays a label, a value and a remove icon on hover.'
+      }
+    }
+  }
+};
+
+const defaultArgs = {
+  label: 'City',
+  value: 'Paris',
+  removeTooltip: undefined,
+  onRemove: action('onRemove')
+};
+
+const Template = (args) => ({
+  template: hbs`
+    <div style="padding: 12px; background: white">
+      <OSS::Attribute::RemovableText @label={{this.label}} @value={{this.value}}
+                                    @removeTooltip={{this.lockTooltip}} @onRemove={{this.onRemove}} />
+    </div>
+  `,
+  context: args
+});
+
+export const Default = Template.bind({});
+Default.args = defaultArgs;

--- a/addon/components/o-s-s/attribute/removable-text.stories.js
+++ b/addon/components/o-s-s/attribute/removable-text.stories.js
@@ -13,6 +13,13 @@ export default {
       control: { type: 'text' },
       type: { required: true }
     },
+    value: {
+      description: 'The value that should be displayed. Will default to a dash if non is filled.',
+      table: {
+        defaultValue: { summary: '-' }
+      },
+      control: { type: 'text' }
+    },
     removeTooltip: {
       description: 'Overwrites the default "Remove" tooltip that is visible on component hover',
       table: {

--- a/addon/components/o-s-s/attribute/removable-text.ts
+++ b/addon/components/o-s-s/attribute/removable-text.ts
@@ -1,0 +1,41 @@
+import { isBlank } from '@ember/utils';
+import Component from '@glimmer/component';
+import { inject as service } from '@ember/service';
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+import { assert } from '@ember/debug';
+
+interface OSSAttributeRemovableTextArgs {
+  label: string;
+  value?: string;
+  removeTooltip?: string;
+  onRemove(): Promise<unknown>;
+}
+
+export default class OSSAttributeRemovableText extends Component<OSSAttributeRemovableTextArgs> {
+  @service declare intl: any;
+  @tracked loading: boolean = false;
+
+  constructor(owner: unknown, args: OSSAttributeRemovableTextArgs) {
+    super(owner, args);
+    assert('[component][OSS::Attribute::RemovableText] @label parameter is required', typeof args.label === 'string');
+    assert(
+      '[component][OSS::Attribute::RemovableText] @onRemove method is required',
+      typeof args.onRemove === 'function'
+    );
+  }
+
+  get value(): string {
+    return isBlank(this.args.value) ? '-' : this.args.value!;
+  }
+
+  get removeTooltip(): string {
+    return this.args.removeTooltip ?? this.intl.t('oss-components.attribute.removable_text.remove_tooltip');
+  }
+
+  @action
+  onRemove(): void {
+    this.loading = true;
+    this.args.onRemove().finally(() => (this.loading = false));
+  }
+}

--- a/addon/components/o-s-s/attribute/tag-array.hbs
+++ b/addon/components/o-s-s/attribute/tag-array.hbs
@@ -1,0 +1,17 @@
+<OSS::Attribute::Base class="oss-attribute--auto-height oss-attribute--no-hover-effect"
+                      data-control-name="attribute-tag-array" ...attributes>
+  <:label>
+    <span>{{@label}}</span>
+  </:label>
+  <:value>
+    {{#if this.displayTags}}
+      <div class="fx-row fx-wrap fx-gap-px-3">
+        {{#each @tags as |tagLabel|}}
+          <OSS::Tag @label={{tagLabel}} @skin="secondary" />
+        {{/each}}
+      </div>
+    {{else}}
+      <span>-</span>
+    {{/if}}
+  </:value>
+</OSS::Attribute::Base>

--- a/addon/components/o-s-s/attribute/tag-array.stories.js
+++ b/addon/components/o-s-s/attribute/tag-array.stories.js
@@ -1,0 +1,54 @@
+import hbs from 'htmlbars-inline-precompile';
+
+export default {
+  title: 'Components/OSS::Attribute::TagArray',
+  component: 'tag-array',
+  argTypes: {
+    label: {
+      description: 'The label of the component.',
+      table: {
+        type: {
+          summary: 'string'
+        },
+        defaultValue: { summary: 'undefined' }
+      },
+      control: { type: 'text' },
+      type: { required: true }
+    },
+    tags: {
+      description: 'An array of tags which will be displayed next to the label.',
+      table: {
+        type: {
+          summary: 'string[]'
+        },
+        defaultValue: { summary: '[]' }
+      },
+      control: { type: 'array' }
+    }
+  },
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'Member of the Attribute displays. The OSS::Attribute::TagArray displays all the tags that are provided in the @tags parameter.'
+      }
+    }
+  }
+};
+
+const defaultArgs = {
+  label: 'Fruits',
+  tags: ['watermelon', 'vodkamelon', 'whiskeymelon', 'tequilamelon']
+};
+
+const Template = (args) => ({
+  template: hbs`
+    <div style="padding: 12px; background: white">
+      <OSS::Attribute::TagArray @label={{this.label}} @tags={{this.tags}} />
+    </div>
+  `,
+  context: args
+});
+
+export const Default = Template.bind({});
+Default.args = defaultArgs;

--- a/addon/components/o-s-s/attribute/tag-array.ts
+++ b/addon/components/o-s-s/attribute/tag-array.ts
@@ -1,0 +1,18 @@
+import { assert } from '@ember/debug';
+import Component from '@glimmer/component';
+
+interface OSSAttributeTagArrayArgs {
+  label: string;
+  tags?: Array<string>;
+}
+
+export default class OSSAttributeTagArray extends Component<OSSAttributeTagArrayArgs> {
+  constructor(owner: unknown, args: OSSAttributeTagArrayArgs) {
+    super(owner, args);
+    assert('[component][OSS::Attribute::TagArray] @label parameter is required', typeof args.label === 'string');
+  }
+
+  get displayTags(): boolean {
+    return (this.args.tags || []).length > 0;
+  }
+}

--- a/app/components/o-s-s/attribute/removable-text.js
+++ b/app/components/o-s-s/attribute/removable-text.js
@@ -1,0 +1,1 @@
+export { default } from '@upfluence/oss-components/components/o-s-s/attribute/removable-text';

--- a/app/components/o-s-s/attribute/tag-array.js
+++ b/app/components/o-s-s/attribute/tag-array.js
@@ -1,0 +1,1 @@
+export { default } from '@upfluence/oss-components/components/o-s-s/attribute/tag-array';

--- a/app/components/o-s-s/attribute/tagada.js
+++ b/app/components/o-s-s/attribute/tagada.js
@@ -1,0 +1,1 @@
+export { default } from '@upfluence/oss-components/components/o-s-s/attribute/tag-array';

--- a/app/styles/atoms/attribute.less
+++ b/app/styles/atoms/attribute.less
@@ -38,4 +38,20 @@
   &__copy {
     margin-left: auto;
   }
+
+  &--auto-height {
+    height: auto;
+    max-height: max-content;
+    
+    .oss-attribute__label {
+      align-self: flex-start;
+      height: 24px;
+    }
+  }
+
+  &--no-hover-effect {
+    &:hover {
+      background: initial;
+    }
+  }
 }

--- a/tests/dummy/app/controllers/application.js
+++ b/tests/dummy/app/controllers/application.js
@@ -161,6 +161,17 @@ export default class ApplicationController extends Controller {
   }
 
   @action
+  onRemove() {
+    console.log('on remove');
+    return new Promise((res) => {
+      setTimeout(() => {
+        this.revealed = true;
+        return res('success');
+      }, 1000);
+    });
+  }
+
+  @action
   redirectTo(route) {
     console.log('Redirect to', route);
   }

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -44,7 +44,8 @@
         </:contextual-action>
         <:view-mode>
           <div class="fx-col fx-gap-px-9">
-            <OSS::Attribute::TagArray @label="Pies" @tags={{array "Apple pie" "Pecan pie" "Pumpkin pie" "Raspberry PI"}} />
+            <OSS::Attribute::TagArray @label="Pies"
+                                      @tags={{array "Apple pie" "Pecan pie" "Pumpkin pie" "Raspberry PI"}} />
             <OSS::Attribute::TagArray @label="Fruits" @tags={{array "apple" "banana" "pitaya" "jackfruit"
                                       "mango" "orange" "blueberry" "papaya" "pineapple" "watermelon" "vodkamelon"}} />
             <OSS::Attribute::TagArray @label="Fruits" />
@@ -61,9 +62,9 @@
             <OSS::Attribute::Text @label="Label with tooltip copyable" @value="Hello World"
                                   @tooltip="Hello World" />
             <OSS::Attribute::Text @label="Label not copyable" @value="Hello World" @copyable={{false}} />
-          <OSS::Attribute::PhoneNumber @countryCode="FR" @prefix="+33" @number="642424242" />
-          <OSS::Attribute::PhoneNumber @countryCode="nope" @number="+33642424242" />
-          <OSS::Attribute::PhoneNumber @prefix="+33" />
+            <OSS::Attribute::PhoneNumber @countryCode="FR" @prefix="+33" @number="642424242" />
+            <OSS::Attribute::PhoneNumber @countryCode="nope" @number="+33642424242" />
+            <OSS::Attribute::PhoneNumber @prefix="+33" />
           </div>
         </:view-mode>
         <:edition-mode>

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -43,22 +43,28 @@
           <OSS::Button @icon="fa-plus" @square={{true}} />
         </:contextual-action>
         <:view-mode>
+          <div class="fx-col fx-gap-px-9">
+            <OSS::Attribute::TagArray @label="Pies" @tags={{array "Apple pie" "Pecan pie" "Pumpkin pie" "Raspberry PI"}} />
+            <OSS::Attribute::TagArray @label="Fruits" @tags={{array "apple" "banana" "pitaya" "jackfruit"
+                                      "mango" "orange" "blueberry" "papaya" "pineapple" "watermelon" "vodkamelon"}} />
+            <OSS::Attribute::TagArray @label="Fruits" />
+            <OSS::Attribute::RevealableEmail @lockTooltip="This will fail"
+                                             @onRevealEmail={{this.onRevealEmailError}} />
+            {{#if this.revealed}}
+              <OSS::Attribute::Text @label="Email address" @value="john.doe@gmail.com" />
+            {{else}}
+              <OSS::Attribute::RevealableEmail @tooltip="Click on lock to reveal"
+                                               @onRevealEmail={{this.onRevealEmailSuccess}} />
+            {{/if}}
+            <OSS::Attribute::Country @countryCode="US" />
+            <OSS::Attribute::Country @countryCode="" />
+            <OSS::Attribute::Text @label="Label with tooltip copyable" @value="Hello World"
+                                  @tooltip="Hello World" />
+            <OSS::Attribute::Text @label="Label not copyable" @value="Hello World" @copyable={{false}} />
           <OSS::Attribute::PhoneNumber @countryCode="FR" @prefix="+33" @number="642424242" />
           <OSS::Attribute::PhoneNumber @countryCode="nope" @number="+33642424242" />
           <OSS::Attribute::PhoneNumber @prefix="+33" />
-          <OSS::Attribute::RevealableEmail @lockTooltip="This will fail"
-                                           @onRevealEmail={{this.onRevealEmailError}} />
-          {{#if this.revealed}}
-            <OSS::Attribute::Text @label="Email address" @value="john.doe@gmail.com" />
-          {{else}}
-            <OSS::Attribute::RevealableEmail @tooltip="Click on lock to reveal"
-                                             @onRevealEmail={{this.onRevealEmailSuccess}} />
-          {{/if}}
-          <OSS::Attribute::Country @countryCode="US" />
-          <OSS::Attribute::Country @countryCode="" />
-          <OSS::Attribute::Text @label="Label with tooltip copyable" @value="Hello World"
-                                @tooltip="Hello World" />
-          <OSS::Attribute::Text @label="Label not copyable" @value="Hello World" @copyable={{false}} />
+          </div>
         </:view-mode>
         <:edition-mode>
           Edition mode

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -44,6 +44,8 @@
         </:contextual-action>
         <:view-mode>
           <div class="fx-col fx-gap-px-9">
+            <OSS::Attribute::RemovableText @label="city" @onRemove={{this.onRemove}} @removeTooltip="Click to delete" />
+            <OSS::Attribute::RemovableText @label="city" @value="Paris" @onRemove={{this.onRemove}} />
             <OSS::Attribute::TagArray @label="Pies"
                                       @tags={{array "Apple pie" "Pecan pie" "Pumpkin pie" "Raspberry PI"}} />
             <OSS::Attribute::TagArray @label="Fruits" @tags={{array "apple" "banana" "pitaya" "jackfruit"

--- a/tests/integration/components/o-s-s/attribute/removable-text-test.ts
+++ b/tests/integration/components/o-s-s/attribute/removable-text-test.ts
@@ -1,0 +1,72 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { click, render, triggerEvent } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+import sinon from 'sinon';
+
+module('Integration | Component | o-s-s/attribute/removable-text', function (hooks) {
+  setupRenderingTest(hooks);
+
+  hooks.beforeEach(function () {
+    this.onRemove = sinon.stub().resolves();
+  });
+
+  test('it renders', async function (assert) {
+    await render(hbs`<OSS::Attribute::RemovableText @label="label" @onRemove={{this.onRemove}} />`);
+
+    assert.dom('[data-control-name="attribute-removable-text"]').exists();
+  });
+
+  test('It displays the @label', async function (assert) {
+    await render(hbs`<OSS::Attribute::RemovableText @label="city" @onRemove={{this.onRemove}} />`);
+
+    assert.dom('.oss-attribute__label').hasText('city');
+  });
+
+  test('If the value is provided, it is displayed', async function (assert) {
+    await render(hbs`<OSS::Attribute::RemovableText @label="city" @value="Lyon" @onRemove={{this.onRemove}} />`);
+
+    assert.dom('.oss-attribute__value').hasText('Lyon');
+  });
+
+  test('If the value is not provided, it displays a dash', async function (assert) {
+    await render(hbs`<OSS::Attribute::RemovableText @label="city" @onRemove={{this.onRemove}} />`);
+
+    assert.dom('.oss-attribute__value').hasText('-');
+  });
+
+  module('Remove tooltip', () => {
+    test('If the @removeTooltip paramater is passed, the string contents are used as tooltip for the lock icon', async function (assert) {
+      await render(
+        hbs`<OSS::Attribute::RemovableText @label="city" @onRemove={{this.onRemove}} @removeTooltip="Click to remove" />`
+      );
+
+      await triggerEvent('.oss-attribute', 'mouseenter');
+      await assert.tooltip('.fa-trash').hasTitle('Click to remove');
+    });
+
+    test('If the @removeTooltip paramater is not passed, the default text is used', async function (assert) {
+      await render(hbs`<OSS::Attribute::RemovableText @label="city" @onRemove={{this.onRemove}} />`);
+
+      await triggerEvent('.oss-attribute', 'mouseenter');
+      await assert.tooltip('.fa-trash').hasTitle('Remove');
+    });
+  });
+
+  test('Clicking on the trash icon calls the @onRemove method', async function (assert) {
+    await render(hbs`<OSS::Attribute::RemovableText @label="city" @value="Lyon" @onRemove={{this.onRemove}} />`);
+
+    await triggerEvent('.oss-attribute', 'mouseenter');
+    await click('.fa-trash');
+    assert.true(this.onRemove.calledOnce);
+  });
+
+  test('Clicking on the trash icon displays a loader', async function (assert) {
+    this.onRemove.returns(new Promise(() => {}));
+    await render(hbs`<OSS::Attribute::RemovableText @label="city" @value="Lyon" @onRemove={{this.onRemove}} />`);
+
+    await triggerEvent('.oss-attribute', 'mouseenter');
+    await click('.fa-trash');
+    assert.dom('.fa-circle-notch.fa-spin').exists();
+  });
+});

--- a/tests/integration/components/o-s-s/attribute/tag-array-test.ts
+++ b/tests/integration/components/o-s-s/attribute/tag-array-test.ts
@@ -1,0 +1,36 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+import findAll from '@ember/test-helpers/dom/find-all';
+
+module('Integration | Component | o-s-s/attribute/tag-array', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function (assert) {
+    await render(hbs`<OSS::Attribute::TagArray @label="Fruits" />`);
+
+    assert.dom('[data-control-name="attribute-tag-array"]').exists();
+  });
+
+  test('it displays the @label parameter', async function (assert) {
+    await render(hbs`<OSS::Attribute::TagArray @label="Fruits" />`);
+
+    assert.dom('.oss-attribute__label').hasText('Fruits');
+  });
+
+  test('If @tags are passed to the component, they are displayed', async function (assert) {
+    this.tags = ['watermelon', 'vodkamelon', 'whiskeymelon', 'tequilamelon'];
+    await render(hbs`<OSS::Attribute::TagArray @label="Fruits" @tags={{this.tags}} />`);
+
+    assert.dom('.oss-attribute__value .fx-row.fx-wrap').exists();
+    const allUpfTags = findAll('.upf-tag');
+    assert.equal(allUpfTags.length, this.tags.length);
+  });
+
+  test('If @tags are not passed to the component, a dash is displayed', async function (assert) {
+    await render(hbs`<OSS::Attribute::TagArray @label="Fruits" />`);
+
+    assert.dom('.oss-attribute__value').hasText('-');
+  });
+});

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -67,3 +67,5 @@ oss-components:
     email:
       label: Email address
       lock_tooltip: Reveal email
+    removable_text:
+      remove_tooltip: Remove


### PR DESCRIPTION
Adds OSS::Attribute::TagArray component along with tests and documentation
![Screenshot 2023-11-10 at 11 48 53](https://github.com/upfluence/oss-components/assets/5032005/68beaea3-6ce8-4276-b09e-6110a29ff17d)
<img width="474" alt="Screenshot 2023-11-10 at 15 57 58" src="https://github.com/upfluence/oss-components/assets/5032005/de221225-1c99-4576-b5af-a12e37eab8a6">
![Screenshot 2023-11-10 at 16 37 03](https://github.com/upfluence/oss-components/assets/5032005/35e82f98-58d7-409d-a71c-8612e581cde6)

### Good PR checklist
- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [x] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled