### PR TITLE
Bump @fortawesome/fontawesome-pro to ^6.4.2

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,15 +3,10 @@
 
 const mergeTrees = require('broccoli-merge-trees');
 const Funnel = require('broccoli-funnel');
-const fs = require('fs');
 const cacheKeyForTree = require('calculate-cache-key-for-tree');
 const { name, version } = require('./package');
 
-let faPath = 'node_modules/@fortawesome/fontawesome-pro';
-
-if (!fs.existsSync(faPath)) {
-  faPath = 'node_modules/@fortawesome/fontawesome-free';
-}
+const faPath = 'node_modules/@fortawesome/fontawesome-pro';
 
 module.exports = {
   name,

--- a/package.json
+++ b/package.json
@@ -36,8 +36,7 @@
   "dependencies": {
     "@ember/render-modifiers": "^2.1.0",
     "@embroider/macros": "^1.7.1",
-    "@fortawesome/fontawesome-free": "^5.x",
-    "@fortawesome/fontawesome-pro": "^5.15.4",
+    "@fortawesome/fontawesome-pro": "^6.4.2",
     "babel-plugin-debug-macros": "^0.3.1",
     "bootstrap": "^3.3.7",
     "calculate-cache-key-for-tree": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2531,15 +2531,10 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@fortawesome/fontawesome-free@^5.x":
-  version "5.15.4"
-  resolved "https://npm.fontawesome.com/@fortawesome/fontawesome-free/-/5.15.4/fontawesome-free-5.15.4.tgz#ecda5712b61ac852c760d8b3c79c96adca5554e5"
-  integrity sha512-eYm8vijH/hpzr/6/1CJ/V/Eb1xQFW2nnUKArb3z+yUWv7HTwj6M7SP957oMjfZjAHU6qpoNc2wQvIxBLWYa/Jg==
-
-"@fortawesome/fontawesome-pro@^5.15.4":
-  version "5.15.4"
-  resolved "https://npm.fontawesome.com/@fortawesome/fontawesome-pro/-/5.15.4/fontawesome-pro-5.15.4.tgz#aae79a86621a79ae972772ad2906a13ade650a06"
-  integrity sha512-ApOqpDdKgA79xfLZH3B5PucZxj+TZyQUSrZ4bKkbJCR+zjmveQ4/gp/uXc5bNNhsdtJUy16BYJ/lAVydca2Y5Q==
+"@fortawesome/fontawesome-pro@^6.4.2":
+  version "6.4.2"
+  resolved "https://npm.fontawesome.com/@fortawesome/fontawesome-pro/-/6.4.2/fontawesome-pro-6.4.2.tgz#1acc12423b4b35885c96423cf896ae73e1b9b85a"
+  integrity sha512-b7VtzrgoASuCbnWJ1A17Sw3wemaFGukyBk0Y2ks/rgcnhlJ1uzdyv2uM3QbEaq9OgyZAKGJD1Tli6qHRI68zSQ==
 
 "@gar/promisify@^1.0.1":
   version "1.1.2"


### PR DESCRIPTION
### What does this PR do?

Bump @fortawesome/fontawesome-pro to ^6.4.2 and remove fallback on free version

Related to: https://linear.app/upfluence/issue/ENG-1760/upgrade-to-font-awesome-6

### What are the observable changes?

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled
