### PR TITLE
Added: option to pass custom data set to currency input + cleanup

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,5 +1,6 @@
 'use strict';
 
+// eslint-disable-next-line no-undef
 module.exports = {
   arrowParens: 'always',
   bracketSpacing: true,
@@ -9,13 +10,5 @@ module.exports = {
   singleQuote: true,
   tabWidth: 2,
   trailingComma: 'none',
-  useTabs: false,
-  overrides: [
-    {
-      files: '*.hbs',
-      options: {
-        singleQuote: false
-      }
-    }
-  ]
+  useTabs: false
 };

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,6 +1,5 @@
 'use strict';
 
-// eslint-disable-next-line no-undef
 module.exports = {
   arrowParens: 'always',
   bracketSpacing: true,
@@ -10,5 +9,13 @@ module.exports = {
   singleQuote: true,
   tabWidth: 2,
   trailingComma: 'none',
-  useTabs: false
+  useTabs: false,
+  overrides: [
+    {
+      files: '*.hbs',
+      options: {
+        singleQuote: false
+      }
+    }
+  ]
 };

--- a/addon/components/o-s-s/currency-input.hbs
+++ b/addon/components/o-s-s/currency-input.hbs
@@ -1,7 +1,10 @@
 <div class="currency-input-container fx-1 {{if @errorMessage 'currency-input-container--errored'}}" ...attributes>
   <div class="currency-input {{if @onlyCurrency 'onlycurrency'}} upf-input fx-row fx-1 fx-xalign-center">
-    <div class="currency-selector fx-row fx-gap-px-12 fx-malign-space-between" role="button"
-         {{on "click" this.toggleCurrencySelector}}>
+    <div
+      class="currency-selector fx-row fx-gap-px-12 fx-malign-space-between"
+      role="button"
+      {{on "click" this.toggleCurrencySelector}}
+    >
       <div class="fx-col">
         <div class="fx-row fx-gap-px-9">
           <span>{{this.selectedCurrencySymbol}}</span>
@@ -21,20 +24,32 @@
     </div>
     {{#unless @onlyCurrency}}
       <Input
-        class="fx-1" type="number" @value={{this.localValue}} min="0" autocomplete="off" placeholder={{this.placeholder}}
-        {{on "keydown" this.onlyNumeric}} {{on "keyup" this.notifyChanges}} {{on "paste" this.handlePaste}} />
+        @value={{this.localValue}}
+        class="fx-1"
+        type="number"
+        min="0"
+        autocomplete="off"
+        placeholder={{this.placeholder}}
+        {{on "keydown" this.onlyNumeric}}
+        {{on "keyup" this.notifyChanges}}
+        {{on "paste" this.handlePaste}}
+      />
     {{/unless}}
   </div>
   {{#if @errorMessage}}
     <div class="font-color-error-500 margin-top-px-6 fx-row fx-gap-px-6 fx-xalign-center">
-      <OSS::Icon @icon="fa-exclamation-triangle" /> {{@errorMessage}}
+      <OSS::Icon @icon="fa-exclamation-triangle" />
+      {{@errorMessage}}
     </div>
   {{/if}}
   {{#if this.currencySelectorShown}}
-    <OSS::InfiniteSelect @items={{this.filteredCurrencies}} @onSearch={{this.onSearch}}
-                         @onSelect={{this.onSelect}}
-                         @searchPlaceholder={{t "oss-components.currency-input.search"}}
-                         {{on-click-outside this.hideCurrencySelector}}>
+    <OSS::InfiniteSelect
+      @items={{this.filteredCurrencies}}
+      @onSearch={{this.onSearch}}
+      @onSelect={{this.onSelect}}
+      @searchPlaceholder={{t "oss-components.currency-input.search"}}
+      {{on-click-outside this.hideCurrencySelector}}
+    >
       <:option as |currency|>
         <div class="fx-row fx-xalign-center {{if (eq this.selectedCurrency currency) 'row-selected'}}">
           <span class="symbol text-color-default-light margin-left-xx-sm">{{currency.symbol}}</span>

--- a/addon/components/o-s-s/currency-input.stories.js
+++ b/addon/components/o-s-s/currency-input.stories.js
@@ -72,6 +72,16 @@ export default {
         category: 'Actions',
         type: { summary: 'onChange(currency: string, value: number): void' }
       }
+    },
+    allowedCurrencies: {
+      description: 'Allows passing a custom set of selectable currencies to the component.',
+      table: {
+        type: {
+          summary: 'string'
+        },
+        defaultValue: { summary: 'undefined' }
+      },
+      control: { type: 'array' }
     }
   },
   parameters: {
@@ -89,14 +99,19 @@ const defaultArgs = {
   currency: 'USD',
   onlyCurrency: false,
   errorMessage: '',
-  onChange: action('onChange')
+  onChange: action('onChange'),
+  allowCurrencyUpdate: true,
+  allowedCurrencies: undefined,
+  placeholder: undefined
 };
 
 const Template = (args) => ({
   template: hbs`
       <div style="width:270px">
         <OSS::CurrencyInput @value={{this.value}} @currency={{this.currency}} @onChange={{this.onChange}}
-                            @onlyCurrency={{this.onlyCurrency}} @errorMessage={{this.errorMessage}} />
+                            @onlyCurrency={{this.onlyCurrency}} @errorMessage={{this.errorMessage}}
+                            @allowCurrencyUpdate={{this.allowCurrencyUpdate}} @allowedCurrencies={{this.allowedCurrencies}}
+                            @placeholder={{this.placeholder}} />
       </div>
   `,
   context: args

--- a/addon/components/o-s-s/currency-input.ts
+++ b/addon/components/o-s-s/currency-input.ts
@@ -4,7 +4,7 @@ import { assert } from '@ember/debug';
 import { action } from '@ember/object';
 import { isEmpty } from '@ember/utils';
 
-type Currency = {
+export type Currency = {
   code: string;
   symbol: string;
 };

--- a/addon/components/o-s-s/currency-input.ts
+++ b/addon/components/o-s-s/currency-input.ts
@@ -4,6 +4,11 @@ import { assert } from '@ember/debug';
 import { action } from '@ember/object';
 import { isEmpty } from '@ember/utils';
 
+type Currency = {
+  code: string;
+  symbol: string;
+};
+
 interface OSSCurrencyInputArgs {
   currency: string;
   value: number;
@@ -12,15 +17,57 @@ interface OSSCurrencyInputArgs {
   onlyCurrency?: boolean;
   placeholder?: string;
   errorMessage?: string;
+  allowedCurrencies?: Currency[];
 }
 
-const NUMERIC_ONLY = /^[0-9]$/i;
+const NUMERIC_ONLY = /^\d$/i;
 const NOT_NUMERIC_FLOAT = /[^0-9,.]/g;
+const PLATFORM_CURRENCIES: Currency[] = [
+  { code: 'USD', symbol: '$' },
+  { code: 'EUR', symbol: '€' },
+  { code: 'JPY', symbol: '¥' },
+  { code: 'GBP', symbol: '£' },
+  { code: 'AUD', symbol: 'A$' },
+  { code: 'CAD', symbol: 'C$' },
+  { code: 'CHF', symbol: 'Fr' },
+  { code: 'CNY', symbol: '¥' },
+  { code: 'SEK', symbol: 'kr' },
+  { code: 'NZD', symbol: 'NZ$' },
+  { code: 'MXN', symbol: '$' },
+  { code: 'SGD', symbol: 'S$' },
+  { code: 'HKD', symbol: 'HK$' },
+  { code: 'NOK', symbol: 'kr' },
+  { code: 'KRW', symbol: '₩' },
+  { code: 'TRY', symbol: '₺' },
+  { code: 'RUB', symbol: '₽' },
+  { code: 'INR', symbol: '₹' },
+  { code: 'BRL', symbol: 'R$' },
+  { code: 'ZAR', symbol: 'R' },
+  { code: 'IDR', symbol: 'Rp' },
+  { code: 'PHP', symbol: '₱' },
+  { code: 'THB', symbol: '฿' },
+  { code: 'DKK', symbol: 'kr' },
+  { code: 'PLN', symbol: 'zł' }
+];
+const AUTHORIZED_INPUTS = [
+  'Backspace',
+  'Delete',
+  'ArrowLeft',
+  'ArrowRight',
+  'Tab',
+  'Shift',
+  'Control',
+  '.',
+  ',',
+  'ArrowUp',
+  'ArrowDown'
+];
 
 export default class OSSCurrencyInput extends Component<OSSCurrencyInputArgs> {
-  private _currencies = usedCurrencies;
+  private currencies = this.args.allowedCurrencies ?? PLATFORM_CURRENCIES;
+
   @tracked currencySelectorShown: boolean = false;
-  @tracked filteredCurrencies: Currency[] = this._currencies;
+  @tracked filteredCurrencies: Currency[] = this.currencies;
   @tracked localValue: number = this.args.value;
 
   constructor(owner: unknown, args: OSSCurrencyInputArgs) {
@@ -50,43 +97,40 @@ export default class OSSCurrencyInput extends Component<OSSCurrencyInputArgs> {
 
   get selectedCurrency(): Currency {
     if (isEmpty(this.args.currency)) {
-      return this._currencies[0];
+      return this.currencies[0];
     }
-    return this._currencies.find((currency: Currency) => currency.code === this.args.currency) || this._currencies[0];
+    return this.currencies.find((currency: Currency) => currency.code === this.args.currency) ?? this.currencies[0];
   }
 
   get placeholder(): string {
-    return this.args.placeholder || '0';
+    return this.args.placeholder ?? '0';
   }
 
   @action
   onlyNumeric(event: KeyboardEvent): void {
-    const authorizedInputs = [
-      'Backspace',
-      'Delete',
-      'ArrowLeft',
-      'ArrowRight',
-      'Tab',
-      'Shift',
-      'Control',
-      '.',
-      ',',
-      'ArrowUp',
-      'ArrowDown'
-    ];
-
     if (['c', 'v'].includes(event.key) && (event.metaKey || event.ctrlKey)) {
       return;
     }
 
-    if (!NUMERIC_ONLY.test(event.key) && !authorizedInputs.find((key: string) => key === event.key)) {
+    if (!NUMERIC_ONLY.test(event.key) && !AUTHORIZED_INPUTS.find((key: string) => key === event.key)) {
       event.preventDefault();
     }
   }
 
   @action
   handlePaste(event: ClipboardEvent): void {
-    this._handlePaste(event);
+    event.preventDefault();
+
+    const paste = (event.clipboardData?.getData('text') ?? '').replace(NOT_NUMERIC_FLOAT, '');
+    const target = event.target as HTMLInputElement;
+    const initialSelectionStart = target.selectionStart ?? 0;
+    const finalSelectionPosition = initialSelectionStart + paste.length;
+
+    target.setRangeText(paste, initialSelectionStart, target.selectionEnd ?? initialSelectionStart);
+    target.setSelectionRange(finalSelectionPosition, finalSelectionPosition);
+
+    this.localValue = target.value as unknown as number;
+    this.notifyChanges();
   }
 
   @action
@@ -96,7 +140,7 @@ export default class OSSCurrencyInput extends Component<OSSCurrencyInputArgs> {
 
   @action
   onSearch(keyword: any): void {
-    this.filteredCurrencies = this._currencies.filter((currency: Currency) => {
+    this.filteredCurrencies = this.currencies.filter((currency: Currency) => {
       return (
         currency.code.toLowerCase().indexOf(keyword.toLowerCase()) !== -1 || currency.symbol.indexOf(keyword) !== -1
       );
@@ -120,56 +164,6 @@ export default class OSSCurrencyInput extends Component<OSSCurrencyInputArgs> {
   @action
   hideCurrencySelector(): void {
     this.currencySelectorShown = false;
-    this.filteredCurrencies = this._currencies;
-  }
-
-  private _handlePaste(event: ClipboardEvent): void {
-    event.preventDefault();
-
-    let paste = event.clipboardData?.getData('text') || '';
-    paste = paste.replace(NOT_NUMERIC_FLOAT, '');
-
-    const target = event.target as HTMLInputElement;
-    const initialSelectionStart = target.selectionStart || 0;
-    const finalSelectionPosition = initialSelectionStart + paste.length;
-
-    target.setRangeText(paste, initialSelectionStart, target.selectionEnd || initialSelectionStart);
-    target.setSelectionRange(finalSelectionPosition, finalSelectionPosition);
-
-    this.localValue = target.value as unknown as number;
-    this.notifyChanges();
+    this.filteredCurrencies = this.currencies;
   }
 }
-
-type Currency = {
-  code: string;
-  symbol: string;
-};
-
-const usedCurrencies: Currency[] = [
-  { code: 'USD', symbol: '$' },
-  { code: 'EUR', symbol: '€' },
-  { code: 'JPY', symbol: '¥' },
-  { code: 'GBP', symbol: '£' },
-  { code: 'AUD', symbol: 'A$' },
-  { code: 'CAD', symbol: 'C$' },
-  { code: 'CHF', symbol: 'Fr' },
-  { code: 'CNY', symbol: '¥' },
-  { code: 'SEK', symbol: 'kr' },
-  { code: 'NZD', symbol: 'NZ$' },
-  { code: 'MXN', symbol: '$' },
-  { code: 'SGD', symbol: 'S$' },
-  { code: 'HKD', symbol: 'HK$' },
-  { code: 'NOK', symbol: 'kr' },
-  { code: 'KRW', symbol: '₩' },
-  { code: 'TRY', symbol: '₺' },
-  { code: 'RUB', symbol: '₽' },
-  { code: 'INR', symbol: '₹' },
-  { code: 'BRL', symbol: 'R$' },
-  { code: 'ZAR', symbol: 'R' },
-  { code: 'IDR', symbol: 'Rp' },
-  { code: 'PHP', symbol: '₱' },
-  { code: 'THB', symbol: '฿' },
-  { code: 'DKK', symbol: 'kr' },
-  { code: 'PLN', symbol: 'zł' }
-];

--- a/tests/dummy/app/controllers/application.js
+++ b/tests/dummy/app/controllers/application.js
@@ -124,6 +124,10 @@ export default class ApplicationController extends Controller {
 
   code4CodeBlock = testScript;
   countries = countries;
+  allowedCurrencies = [
+    { code: 'USD', symbol: '$' },
+    { code: 'EUR', symbol: '€' }
+  ];
 
   subdomainRegex = /^[a-zA-Z0-9]+[a-zA-Z0-9-._]*[a-zA-Z0-9]+$/;
   urlRegex = /(http(s)?:\/\/.)?(www\.)?[-a-zA-Z0-9@:%._+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_+.~#?&//=]*)/;

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -22,6 +22,20 @@
 
   <div style="width:100%; height:100vh; overflow: auto; background-color: var(--color-gray-50)">
     <div class="fx-row fx-gap-px-10 margin-md">
+      <OSS::CurrencyInput @currency={{this.currency}} @value={{this.currencyValue}}
+                          @onChange={{this.onCurrencyInputChange}}
+                          @errorMessage="This is an error message" />
+      <OSS::CurrencyInput @currency={{this.currency}} @value={{this.currencyValue}} @allowCurrencyUpdate={{false}}
+                          @onChange={{this.onCurrencyInputChange}} />
+      <OSS::CurrencyInput @currency={{this.currency}} @value={{this.currencyValue}}
+                          @onChange={{this.onCurrencyInputChange}} @allowedCurrencies={{this.allowedCurrencies}} />
+      <OSS::CurrencyInput @currency={{this.currency}} @value={{this.currencyValue}}
+                          @onChange={{this.onCurrencyInputChange}}
+                          @onlyCurrency={{true}} />
+      <OSS::CurrencyInput @currency={{this.currencyOnly}} @onChange={{this.onCurrencyOnlyChange}}
+                          @onlyCurrency={{true}} @allowedCurrencies={{this.allowedCurrencies}} />
+    </div>
+    <div class="fx-row fx-gap-px-10 margin-md">
       <div class="fx-col fx-1 fx-gap-px-5">
         <span>Country</span>
         <OSS::CountrySelector @value={{this.selectedCountry.id}} @sourceList={{this.countries}}
@@ -314,30 +328,6 @@
             {{item.name}}
           </:option>
         </OSS::Select>
-      </div>
-    </div>
-    <div class="fx-row fx-1 margin-md">
-      <OSS::CurrencyInput @currency={{this.currency}} @value={{this.currencyValue}}
-                          @onChange={{this.onCurrencyInputChange}}
-                          @errorMessage="This is an error message" />
-    </div>
-    <div class="fx-row fx-1 margin-md">
-      <OSS::CurrencyInput @currency={{this.currency}} @value={{this.currencyValue}} @allowCurrencyUpdate={{false}}
-                          @onChange={{this.onCurrencyInputChange}} />
-    </div>
-    <div class="fx-row fx-1 margin-md">
-      <OSS::CurrencyInput @currency={{this.currency}} @value={{this.currencyValue}}
-                          @onChange={{this.onCurrencyInputChange}} />
-    </div>
-    <div class="fx-row fx-1 margin-md">
-      <OSS::CurrencyInput @currency={{this.currency}} @value={{this.currencyValue}}
-                          @onChange={{this.onCurrencyInputChange}}
-                          @onlyCurrency={{true}} />
-    </div>
-    <div class="fx-row fx-1 margin-md">
-      <div class="fx-col">
-        <OSS::CurrencyInput @currency={{this.currencyOnly}} @onChange={{this.onCurrencyOnlyChange}}
-                            @onlyCurrency={{true}} />
       </div>
     </div>
     <div class="fx-row fx-1 margin-md">


### PR DESCRIPTION
### What does this PR do?
Adds a @allowedCurrencies parameter to `OSS::CurrencyInput` which allows to pass a custom set of currencies that will be displayed in the dropdown.
Also cleans up the typescript code & updates tests.

### Good PR checklist
- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [x] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled
