### PR TITLE
Allow null value for selectedToggle in OSS::Toggle-buttons

### DIFF
--- a/addon/components/o-s-s/attribute/base.hbs
+++ b/addon/components/o-s-s/attribute/base.hbs
@@ -12,8 +12,8 @@
       {{@value}}
     </span>
   {{/if}}
-  {{#if (and this.displayCopyBtn this.isCopyable)}}
-    <div class="oss-attribute__copy">
+  {{#if this.isCopyable}}
+    <div class="oss-attribute__copy {{if this.displayCopyBtn 'oss-attribute__copy--visible'}}">
       <OSS::Copy @value={{@value}} @inline={{true}} />
     </div>
   {{/if}}

--- a/addon/components/o-s-s/skeleton.ts
+++ b/addon/components/o-s-s/skeleton.ts
@@ -45,7 +45,7 @@ export default class OSSSkeleton extends Component<OSSSkeletonArgs> {
   }
 
   get computedClass(): string {
-    let style: String[] = [`fx-gap-px-${this.gap}`];
+    let style: string[] = [`fx-gap-px-${this.gap}`];
 
     this.direction === 'row' ? style.push('fx-row') : style.push('fx-col');
 

--- a/addon/components/o-s-s/social-post-badge.stories.js
+++ b/addon/components/o-s-s/social-post-badge.stories.js
@@ -54,7 +54,7 @@ export default {
       table: {
         category: 'Actions',
         type: {
-          summary: 'onToggle(postType: String): void'
+          summary: 'onToggle(postType: string): void'
         }
       }
     }

--- a/addon/components/o-s-s/toggle-buttons.hbs
+++ b/addon/components/o-s-s/toggle-buttons.hbs
@@ -1,8 +1,8 @@
 <div class="oss-toggle-buttons-container" ...attributes>
   {{#each @toggles as |toggle|}}
-  <div class="oss-toggle-buttons-btn {{if (eq @selectedToggle toggle.value) " oss-toggle-buttons-btn--selected"}}"
-    role="button" {{on "click" (fn this.onSelectToggle toggle.value)}}>
-    {{toggle.label}}
-  </div>
+    <div class="oss-toggle-buttons-btn {{if (eq @selectedToggle toggle.value) " oss-toggle-buttons-btn--selected"}}"
+      role="button" {{on "click" (fn this.onSelectToggle toggle.value)}}>
+      {{toggle.label}}
+    </div>
   {{/each}}
 </div>

--- a/addon/components/o-s-s/toggle-buttons.stories.js
+++ b/addon/components/o-s-s/toggle-buttons.stories.js
@@ -10,8 +10,7 @@ export default {
       description: 'An array of toggles passed to the component',
       table: {
         type: {
-          summary: 'toggles',
-          object: 'test'
+          summary: '{value: string, label: string}[]'
         },
         defaultValue: { summary: 'undefined' }
       },
@@ -22,11 +21,11 @@ export default {
       description: 'Value selected',
       table: {
         type: {
-          summary: 'selectedToggle'
+          summary: 'string | null'
         },
         defaultValue: { summary: 'undefined' }
       },
-      control: { type: 'object' }
+      control: { type: 'text' }
     },
     onSelection: {
       type: { required: true },
@@ -34,7 +33,7 @@ export default {
       table: {
         category: 'Actions',
         type: {
-          summary: 'onSelection(selectedToggle: String): void'
+          summary: 'onSelection(selectedToggle: string): void'
         }
       }
     }

--- a/addon/components/o-s-s/toggle-buttons.ts
+++ b/addon/components/o-s-s/toggle-buttons.ts
@@ -9,7 +9,7 @@ export type Toggle = {
 
 interface OSSToggleButtonsArgs {
   toggles: Toggle[];
-  selectedToggle: string;
+  selectedToggle: string | null;
   onSelection(selectedToggle: string): void;
 }
 
@@ -28,13 +28,13 @@ export default class OSSToggleButtons extends Component<OSSToggleButtonsArgs> {
     );
 
     assert(
-      '[component][OSS::ToggleButtons] The @selectedToggle parameter of type string is mandatory',
-      typeof args.selectedToggle === 'string'
+      '[component][OSS::ToggleButtons] The @selectedToggle parameter of type string or null is mandatory',
+      args.selectedToggle === null || typeof args.selectedToggle === 'string'
     );
 
     assert(
-      '[component][OSS::ToggleButtons] The @selectedToggle parameter should be a value of toggles',
-      args.toggles.map((item) => item.value).includes(args.selectedToggle)
+      '[component][OSS::ToggleButtons] The @selectedToggle parameter should be null or a value of toggles',
+      args.selectedToggle === null || args.toggles.map((item) => item.value).includes(args.selectedToggle)
     );
   }
 

--- a/app/styles/atoms/attribute.less
+++ b/app/styles/atoms/attribute.less
@@ -37,6 +37,12 @@
 
   &__copy {
     margin-left: auto;
+    opacity: 0;
+    transition: opacity 0.25s ease-in-out;
+
+    &--visible {
+      opacity: 1;
+    }
   }
 
   &--auto-height {

--- a/tests/integration/components/o-s-s/attribute/text-test.ts
+++ b/tests/integration/components/o-s-s/attribute/text-test.ts
@@ -44,12 +44,11 @@ module('Integration | Component | o-s-s/attribute/text', function (hooks) {
     module('Copy action', function (hooks) {
       hooks.beforeEach(function () {
         this.textForCopy = 'copied value';
-        this.displayCopyBtn = true;
       });
 
       test('The copy icon is not visible before hovering', async function (assert) {
         await render(hbs`<OSS::Attribute::Text @label="Hello" @value={{this.textForCopy}} />`);
-        assert.dom('.oss-attribute__copy').doesNotExist();
+        assert.dom('.oss-attribute__copy--visible').doesNotExist();
       });
 
       test('The text is copyable by default', async function (assert) {
@@ -62,7 +61,7 @@ module('Integration | Component | o-s-s/attribute/text', function (hooks) {
       test('The text is copyable if the @copyable argument is truthy', async function (assert) {
         await render(hbs`<OSS::Attribute::Text @label="Hello" @value={{this.textForCopy}} @copyable={{true}} />`);
         await triggerEvent('.oss-attribute', 'mouseenter');
-        assert.dom('.oss-attribute__copy').exists();
+        assert.dom('.oss-attribute__copy--visible').exists();
       });
 
       test('The text is not copyable (no copy button) if the argument is falsy', async function (assert) {

--- a/tests/integration/components/o-s-s/toggle-buttons-test.ts
+++ b/tests/integration/components/o-s-s/toggle-buttons-test.ts
@@ -111,7 +111,7 @@ module('Integration | Component | o-s-s/toggle-buttons', function (hooks) {
       setupOnerror((err: any) => {
         assert.equal(
           err.message,
-          'Assertion Failed: [component][OSS::ToggleButtons] The @selectedToggle parameter of type string is mandatory'
+          'Assertion Failed: [component][OSS::ToggleButtons] The @selectedToggle parameter of type string or null is mandatory'
         );
       });
       await render(hbs`<OSS::ToggleButtons @toggles={{this.toggles}} @onSelection={{this.onSelection}}  />`);
@@ -124,7 +124,7 @@ module('Integration | Component | o-s-s/toggle-buttons', function (hooks) {
       setupOnerror((err: any) => {
         assert.equal(
           err.message,
-          'Assertion Failed: [component][OSS::ToggleButtons] The @selectedToggle parameter should be a value of toggles'
+          'Assertion Failed: [component][OSS::ToggleButtons] The @selectedToggle parameter should be null or a value of toggles'
         );
       });
       await render(


### PR DESCRIPTION
### What does this PR do?

Allow null value for `selectedToggle` in OSS::Toggle-buttons
Add animation for copy icon in `attribute/base` component

Related to: https://linear.app/upfluence/issue/ENG-1566/[ember-influencer]-new-attributespanelcreatorinformation-component-and

### What are the observable changes?
![Peek 2023-11-30 17-11](https://github.com/upfluence/oss-components/assets/43567222/74831684-90c1-44a4-a5eb-e748bfe776cd)

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [x] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled
