### PR TITLE
OSS::Banner: add support for title named-block

### DIFF
--- a/addon/components/o-s-s/banner.hbs
+++ b/addon/components/o-s-s/banner.hbs
@@ -9,7 +9,9 @@
     <img class="upf-badge upf-badge--size-md upf-badge--shape-round" src={{@image}} alt="banner" />
   {{/if}}
   <div class="fx-col fx-1 {{if (not-eq @size 'sm') 'fx-gap-px-3'}}">
-    {{#if @title}}
+    {{#if (has-block "title")}}
+      {{yield to="title"}}
+    {{else if @title}}
       <span class="font-weight-semibold text-size-5 font-color-gray-900">{{@title}}</span>
     {{/if}}
     {{#if @subtitle}}

--- a/addon/components/o-s-s/banner.stories.js
+++ b/addon/components/o-s-s/banner.stories.js
@@ -119,6 +119,20 @@ const Template = (args) => ({
   context: args
 });
 
+const CustomTitleTemplate = (args) => ({
+  template: hbs`
+      <OSS::Banner @subtitle={{this.subtitle}} @icon={{this.icon}} @plain={{this.plain}}
+                   @image={{this.image}} @selected={{this.selected}} @disabled={{this.disabled}} @size={{this.size}}>
+        <:title>
+          <div class="fx-row fx-gap-px-6 fx-xalign-center">
+            <OSS::Icon @icon="fa-users" /> <span class="font-color-gray-500">Custom title</span>
+          </div>
+        </:title>
+      </OSS::Banner>
+  `,
+  context: args
+});
+
 const CustomIconTemplate = (args) => ({
   template: hbs`
       <OSS::Banner @title={{this.title}} @subtitle={{this.subtitle}} @icon={{this.icon}} @plain={{this.plain}}
@@ -163,3 +177,6 @@ UsageWithCustomIcon.args = defaultArgs;
 
 export const UsageWithActionsBlock = ActionTemplate.bind({});
 UsageWithActionsBlock.args = defaultArgs;
+
+export const UsageWithCustomTitle = CustomTitleTemplate.bind({});
+UsageWithCustomTitle.args = defaultArgs;

--- a/tests/integration/components/o-s-s/banner-test.ts
+++ b/tests/integration/components/o-s-s/banner-test.ts
@@ -33,6 +33,14 @@ module('Integration | Component | o-s-s/banner', function (hooks) {
     assert.dom('.upf-banner .font-weight-semibold').hasText('Test Title');
   });
 
+  test('passing a title named block uses it where the @title arg should be in the component', async function (assert) {
+    await render(hbs`<OSS::Banner><:title><div class="title-named-block">foo</div></:title></OSS::Banner>`);
+
+    assert.dom('.upf-banner .font-weight-semibold').doesNotExist();
+    assert.dom('.upf-banner .title-named-block').exists();
+    assert.dom('.upf-banner .title-named-block').hasText('foo');
+  });
+
   test('passing a subtitle in the @subtitle parameter displays the title in the component', async function (assert) {
     await render(hbs`<OSS::Banner @subtitle="Test subtitle" />`);
 


### PR DESCRIPTION
### What does this PR do?

Because sometimes we need a bit more complex things in the banner's titlte (like a powered by X logo) 

### What are the observable changes?

![Screenshot 2023-12-05 at 14 33 29](https://github.com/upfluence/oss-components/assets/4022350/13167c86-8ae1-4774-b684-2fdb1dac7e16)

<!-- This question could be adequate with multiple use cases, for example: -->

<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->

### Good PR checklist
- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [x] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled
