### PR TITLE
Fixed upf-stat__label issue

### DIFF
--- a/app/styles/base/_stats.less
+++ b/app/styles/base/_stats.less
@@ -37,12 +37,12 @@
 }
 
 .upf-stat__label {
-  color: @color-text-light;
+  color: var(--color-gray-500);
   &--with-tooltip {
     display: flex;
     gap: var(--spacing-px-6);
     align-items: center;
-    color: @color-text-light;
+    color: var(--color-gray-500);
   }
 }
 

--- a/app/styles/base/_stats.less
+++ b/app/styles/base/_stats.less
@@ -37,6 +37,10 @@
 }
 
 .upf-stat__label {
+  color: @color-text-light;
+}
+
+.upf-stat__label--with-tooltip {
   display: flex;
   gap: var(--spacing-px-6);
   align-items: center;

--- a/app/styles/base/_stats.less
+++ b/app/styles/base/_stats.less
@@ -38,13 +38,12 @@
 
 .upf-stat__label {
   color: @color-text-light;
-}
-
-.upf-stat__label--with-tooltip {
-  display: flex;
-  gap: var(--spacing-px-6);
-  align-items: center;
-  color: @color-text-light;
+  &--with-tooltip {
+    display: flex;
+    gap: var(--spacing-px-6);
+    align-items: center;
+    color: @color-text-light;
+  }
 }
 
 .upf-stat--small {

--- a/app/templates/components/upf-stat.hbs
+++ b/app/templates/components/upf-stat.hbs
@@ -29,7 +29,7 @@
 </span>
 
 {{#if label}}
-  <span class="upf-stat__label">
+  <span class={{(if tooltip 'upf-stat__label--with-tooltip' 'upf-stat__label')}}>
     {{{label}}}
     {{#if tooltip}}
       <OSS::Icon @icon="fa-info-circle" {{enable-tooltip title=tooltip}} />

--- a/app/templates/components/upf-stat.hbs
+++ b/app/templates/components/upf-stat.hbs
@@ -29,7 +29,7 @@
 </span>
 
 {{#if label}}
-  <span class={{concat 'upf-stat__label' (if tooltip '--with-tooltip')}}>
+  <span class={{if tooltip 'upf-stat__label--with-tooltip' 'upf-stat__label'}}>
     {{{label}}}
     {{#if tooltip}}
       <OSS::Icon @icon="fa-info-circle" {{enable-tooltip title=tooltip}} />

--- a/app/templates/components/upf-stat.hbs
+++ b/app/templates/components/upf-stat.hbs
@@ -1,28 +1,28 @@
-<span class="upf-stat__name">
+<span class='upf-stat__name'>
   {{name}}
 
   {{#if icon}}
-    {{#if (eq iconPlacement "top")}}
-      <span class="upf-stat__icon" {{enable-tooltip title=this.iconLabel}}>
+    {{#if (eq iconPlacement 'top')}}
+      <span class='upf-stat__icon' {{enable-tooltip title=this.iconLabel}}>
         {{#if iconUrl}}
-          <a href="{{iconUrl}}" target="_blank" rel="noopener noreferrer">
-            <i class="fa fa-{{icon}} {{iconClass}}"></i>
+          <a href='{{iconUrl}}' target='_blank' rel='noopener noreferrer'>
+            <i class='fa fa-{{icon}} {{iconClass}}'></i>
           </a>
         {{else}}
-          <i class="fa fa-{{icon}} {{iconClass}}"></i>
+          <i class='fa fa-{{icon}} {{iconClass}}'></i>
         {{/if}}
       </span>
     {{/if}}
   {{/if}}
 </span>
 
-<span class={{concat "upf-stat__data " dataClass (unless data " upf-stat__data--null")}}>
+<span class={{concat 'upf-stat__data ' dataClass (unless data ' upf-stat__data--null')}}>
   {{data}}
 
   {{#if icon}}
-    {{#if (eq iconPlacement "right")}}
-      <span class="upf-stat__icon" {{enable-tooltip title=this.iconLabel}}>
-        <i class="fa fa-{{icon}} {{iconClass}}"></i>
+    {{#if (eq iconPlacement 'right')}}
+      <span class='upf-stat__icon' {{enable-tooltip title=this.iconLabel}}>
+        <i class='fa fa-{{icon}} {{iconClass}}'></i>
       </span>
     {{/if}}
   {{/if}}
@@ -32,7 +32,7 @@
   <span class={{if tooltip 'upf-stat__label--with-tooltip' 'upf-stat__label'}}>
     {{{label}}}
     {{#if tooltip}}
-      <OSS::Icon @icon="fa-info-circle" {{enable-tooltip title=tooltip}} />
+      <OSS::Icon @icon='fa-info-circle' {{enable-tooltip title=tooltip}} />
     {{/if}}
   </span>
 {{/if}}

--- a/app/templates/components/upf-stat.hbs
+++ b/app/templates/components/upf-stat.hbs
@@ -29,7 +29,7 @@
 </span>
 
 {{#if label}}
-  <span class={{(if tooltip 'upf-stat__label--with-tooltip' 'upf-stat__label')}}>
+  <span class={{concat 'upf-stat__label' (if tooltip '--with-tooltip')}}>
     {{{label}}}
     {{#if tooltip}}
       <OSS::Icon @icon="fa-info-circle" {{enable-tooltip title=tooltip}} />


### PR DESCRIPTION
### What does this PR do?
It fixes the display of upf stat label

Related to: #<!-- enter issue number here -->
https://linear.app/upfluence/issue/ENG-2079/creator-media-stats-have-bad-alignment-in-sidepanel
### What are the observable changes?
Fixes display issues that emerged with [this commit](https://github.com/upfluence/oss-components/commit/18b0769fc88941eb1cfa285592ecc07457f90689). A condition is added in order to switch classes when a tooltip is present. 

### Good PR checklist
- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled
