### PR TITLE
Resolve deps differently depending on whether the parent is an addon or an app (inspired by EBM)

### DIFF
--- a/index.js
+++ b/index.js
@@ -81,8 +81,7 @@ module.exports = {
   _resolvePackagePath(pkgPath) {
     let parts = pkgPath.split('/');
     let pkg = parts[0];
-    console.log('===>', this.project.root, this.root, this.parent.pkg);
-    const basedir = parentIsAddon(this.parent.pkg) ? this.root : this.project.root;
+    let basedir = parentIsAddon(this.parent.pkg) ? this.root : this.project.root;
     let result = path.dirname(resolve.sync(`${pkg}/package.json`, { basedir }));
 
     // add sub folders to path

--- a/index.js
+++ b/index.js
@@ -81,7 +81,9 @@ module.exports = {
   _resolvePackagePath(pkgPath) {
     let parts = pkgPath.split('/');
     let pkg = parts[0];
-    let result = path.dirname(resolve.sync(`${pkg}/package.json`, { basedir: this.project.root }));
+    console.log('===>', this.project.root, this.root, this.parent.pkg);
+    const basedir = parentIsAddon(this.parent.pkg) ? this.root : this.project.root;
+    let result = path.dirname(resolve.sync(`${pkg}/package.json`, { basedir }));
 
     // add sub folders to path
     if (parts.length > 1) {
@@ -91,3 +93,7 @@ module.exports = {
     return result;
   }
 };
+
+function parentIsAddon(parentPkg) {
+  return parentPkg.keywords && parentPkg.keywords.includes('ember-addon');
+}

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "money-formatter": "^0.1.4"
   },
   "peerDependencies": {
-    "qunit": "^2"
+    "qunit": "^2.x"
   },
   "devDependencies": {
     "@babel/core": "^7.11.6",


### PR DESCRIPTION
### What does this PR do?

Resolve deps differently depending on whether the parent is an addon or an app (inspired by EBM)

### What are the observable changes?
<!-- This question could be adequate with multiple use cases, for example: -->

<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->

### Good PR checklist
- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled
