### PR TITLE
Fixed: OSS::TogglableSection padding & alignment + option to pass a badge

### DIFF
--- a/addon/components/o-s-s/togglable-section.hbs
+++ b/addon/components/o-s-s/togglable-section.hbs
@@ -5,6 +5,8 @@
       <img class="upf-badge upf-badge--size-md upf-badge--shape-round" src={{@iconUrl}} alt={{@title}} />
     {{else if @icon}}
       <OSS::Icon @style={{fa-icon-style @icon}} @icon={{fa-icon-value @icon}} />
+    {{else if @badgeIcon}}
+      <OSS::Badge @icon={{@badgeIcon}} />
     {{/if}}
     <div class="fx-col fx-1 fx-gap-px-3">
       <span class="font-weight-semibold font-size-md font-color-gray-900">{{@title}}</span>

--- a/addon/components/o-s-s/togglable-section.stories.js
+++ b/addon/components/o-s-s/togglable-section.stories.js
@@ -44,6 +44,16 @@ export default {
         type: 'text'
       }
     },
+    badgeIcon: {
+      description: 'Displays a font-awesome icon in a default OSS::Badge',
+      table: {
+        type: { summary: 'string' },
+        defaultValue: { summary: 'undefined' }
+      },
+      control: {
+        type: 'text'
+      }
+    },
     toggled: {
       description: 'Whether the section is toggled on or not',
       table: {
@@ -79,6 +89,7 @@ const defaultArgs = {
   subtitle: '',
   toggled: false,
   iconUrl: '',
+  badgeIcon: undefined,
   icon: '',
   onChange: action('onChange')
 };
@@ -87,7 +98,7 @@ const Template = (args) => ({
   template: hbs`
     <OSS::TogglableSection
       @title={{this.title}} @subtitle={{this.subtitle}} @toggled={{this.toggled}} @iconUrl={{this.iconUrl}}
-      @icon={{this.icon}} @onChange={{this.onChange}}>
+      @badgeIcon={{this.badgeIcon}} @icon={{this.icon}} @onChange={{this.onChange}}>
       <:contents>
         Setting content
       </:contents>

--- a/addon/components/o-s-s/togglable-section.ts
+++ b/addon/components/o-s-s/togglable-section.ts
@@ -6,6 +6,7 @@ interface CampaignTogglableSectionArgs {
   toggled: boolean;
   iconUrl?: string;
   icon?: string;
+  badgeIcon?: string;
   subtitle?: string;
   onChange(value: boolean): void;
 }

--- a/app/styles/molecules/togglable-section.less
+++ b/app/styles/molecules/togglable-section.less
@@ -1,5 +1,7 @@
 .togglable-section {
   &:extend(.upf-banner);
+  padding: 0;
+  height: fit-content;
 
   .inner-header {
     border-top-right-radius: var(--border-radius-md);

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -190,10 +190,16 @@
       <OSS::Copy @value="I am the value copied" @inline={{true}} />
       <OSS::Copy @value="I am the value copied" />
     </div>
-    <div class="fx-row fx-1 fx-gap-px-10 margin-md">
+    <div class="fx-row fx-1 fx-gap-px-10 margin-md padding-md" style="background: white">
       <OSS::Illustration @src="/@upfluence/oss-components/assets/images/no-records.svg" />
       <OSS::TogglableSection @title="This is a title" @subtitle="This is a subtitle" @toggled={{this.togglable}}
                              @icon="far fa-hourglass" @onChange={{this.onToggle}}>
+        <:contents>
+          <span>This is a Contents named block</span>
+        </:contents>
+      </OSS::TogglableSection>
+      <OSS::TogglableSection @title="This is a title" @subtitle="This is a subtitle" @toggled={{this.togglable}}
+                             @badgeIcon="far fa-hourglass" @onChange={{this.onToggle}}>
         <:contents>
           <span>This is a Contents named block</span>
         </:contents>

--- a/tests/integration/components/o-s-s/togglable-section-test.ts
+++ b/tests/integration/components/o-s-s/togglable-section-test.ts
@@ -65,6 +65,13 @@ module('Integration | Component | o-s-s/togglable-section', function (hooks) {
     assert.dom('.far.fa-hourglass').exists();
   });
 
+  test('It displays a default badge with an icon if @badgeIcon is passed', async function (assert) {
+    await render(
+      hbs`<OSS::TogglableSection @title="title" @badgeIcon="far fa-hourglass" @onChange={{this.onChange}} @toggled={{false}} />`
+    );
+    assert.dom('.upf-badge .far.fa-hourglass').exists();
+  });
+
   module('Toggle behavior', () => {
     async function renderComponent() {
       await render(hbs`<OSS::TogglableSection @title={{this.title}} @subtitle={{this.subtitle}}


### PR DESCRIPTION
### What does this PR do?
Fixes layout padding & alignment, see videos :
broken/old design:

https://github.com/upfluence/oss-components/assets/5032005/0db90846-c12b-422b-9fdf-9b67d72b03ef

Fixed version:

https://github.com/upfluence/oss-components/assets/5032005/1652c458-5297-48e9-870d-ed06d0461871


In the software the changes will be from (ugly) :
![Screenshot 2024-02-14 at 11 00 35](https://github.com/upfluence/oss-components/assets/5032005/e8374007-d187-4ed3-9c4e-79991d4d3627)

to (nice):

![Screenshot 2024-02-14 at 11 00 27](https://github.com/upfluence/oss-components/assets/5032005/083d2136-57d2-4985-8c80-43a42f3920ec)


Also added the option to pass a default badgeIcon directly.

### Good PR checklist
- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [x] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled