### PR TITLE
Added: TogglableSection small rework plus added options

### DIFF
--- a/addon/components/o-s-s/togglable-section.hbs
+++ b/addon/components/o-s-s/togglable-section.hbs
@@ -1,6 +1,6 @@
 <div class="togglable-section fx-1 fx-col border fx-xalign-center" ...attributes>
-  <div class="fx-row fx-gap-px-12 fx-xalign-center width-pc-100 padding-px-18 inner-header
-              {{if @toggled "background-color-gray-50"}}">
+  <div class="header-block fx-row {{this.paddingClass}} fx-gap-px-12 fx-xalign-center width-pc-100 inner-header
+              {{if @toggled "background-color-gray-50"}}" {{on "click" this.onHeaderClick}} role="button">
     {{#if @iconUrl}}
       <img class="upf-badge upf-badge--size-md upf-badge--shape-round" src={{@iconUrl}} alt={{@title}} />
     {{else if @icon}}
@@ -12,11 +12,11 @@
       <span class="font-weight-semibold font-size-md font-color-gray-900">{{@title}}</span>
       <span class="font-color-gray-500">{{@subtitle}}</span>
     </div>
-    <OSS::ToggleSwitch @value={{@toggled}} @onChange={{@onChange}} />
+    <OSS::ToggleSwitch @value={{@toggled}} @onChange={{this.noop}} @disabled={{@disabled}} />
   </div>
   {{#if (and (has-block "contents") @toggled)}}
     <hr class="margin-px-0 width-pc-100" />
-    <div class="width-pc-100 padding-px-18 content-block">
+    <div class="width-pc-100 {{this.paddingClass}} content-block">
       {{yield to="contents"}}
     </div>
   {{/if}}

--- a/addon/components/o-s-s/togglable-section.stories.js
+++ b/addon/components/o-s-s/togglable-section.stories.js
@@ -1,8 +1,10 @@
 import { hbs } from 'ember-cli-htmlbars';
 import { action } from '@storybook/addon-actions';
 
+const COMPONENT_SIZES = ['sm', 'md'];
+
 export default {
-  title: 'Components/OSS::ToggableSection',
+  title: 'Components/OSS::TogglableSection',
   argTypes: {
     title: {
       description: 'Title',
@@ -64,6 +66,26 @@ export default {
         type: 'boolean'
       }
     },
+    disabled: {
+      description: 'Whether the toggle is disabled or not',
+      table: {
+        defaultValue: { summary: 'undefined' }
+      },
+      control: {
+        type: 'boolean'
+      }
+    },
+    size: {
+      description: 'Adjust the size of the component. Currently available options are `sm` and `md`. Defaults to `md`.',
+      table: {
+        type: COMPONENT_SIZES.join('|'),
+        defaultValue: { summary: 'md' }
+      },
+      options: COMPONENT_SIZES,
+      control: {
+        type: 'select'
+      }
+    },
     onChange: {
       description: 'Action to run when a user toggles on/off the section',
       table: {
@@ -86,11 +108,13 @@ export default {
 
 const defaultArgs = {
   title: 'Settings',
-  subtitle: '',
+  subtitle: 'Subtitle string',
   toggled: false,
   iconUrl: '',
-  badgeIcon: undefined,
+  badgeIcon: 'fa-search',
   icon: '',
+  size: undefined,
+  disabled: undefined,
   onChange: action('onChange')
 };
 
@@ -98,7 +122,8 @@ const Template = (args) => ({
   template: hbs`
     <OSS::TogglableSection
       @title={{this.title}} @subtitle={{this.subtitle}} @toggled={{this.toggled}} @iconUrl={{this.iconUrl}}
-      @badgeIcon={{this.badgeIcon}} @icon={{this.icon}} @onChange={{this.onChange}}>
+      @badgeIcon={{this.badgeIcon}} @icon={{this.icon}} @onChange={{this.onChange}}
+      @disabled={{this.disabled}} @size={{this.size}}>
       <:contents>
         Setting content
       </:contents>

--- a/addon/components/o-s-s/togglable-section.ts
+++ b/addon/components/o-s-s/togglable-section.ts
@@ -1,5 +1,6 @@
 import Component from '@glimmer/component';
 import { assert } from '@ember/debug';
+import { action } from '@ember/object';
 
 interface CampaignTogglableSectionArgs {
   title: string;
@@ -8,6 +9,8 @@ interface CampaignTogglableSectionArgs {
   icon?: string;
   badgeIcon?: string;
   subtitle?: string;
+  size?: 'sm' | 'md';
+  disabled?: boolean;
   onChange(value: boolean): void;
 }
 
@@ -19,4 +22,17 @@ export default class CampaignTogglableSection extends Component<CampaignTogglabl
     assert('[OSS::TogglableSection] The @toggled parameter is mandatory', typeof args.toggled === 'boolean');
     assert('[OSS::TogglableSection] The @onChange function is mandatory', args.onChange);
   }
+
+  get paddingClass(): 'padding-px-12' | 'padding-px-18' {
+    return this.args.size === 'sm' ? 'padding-px-12' : 'padding-px-18';
+  }
+
+  @action
+  onHeaderClick(): void {
+    if (this.args.disabled) return;
+    this.args.onChange(!this.args.toggled);
+  }
+
+  @action
+  noop(): void {}
 }

--- a/app/styles/molecules/togglable-section.less
+++ b/app/styles/molecules/togglable-section.less
@@ -1,16 +1,25 @@
 .togglable-section {
-  &:extend(.upf-banner);
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--border-radius-md);
   padding: 0;
   height: fit-content;
-
-  .inner-header {
-    border-top-right-radius: var(--border-radius-md);
-    border-top-left-radius: var(--border-radius-md);
-    transition: background-color 300ms linear, border-radius 300ms linear;
-  }
+  overflow: hidden;
+  background-color: var(--color-white);
 
   .content-block {
     animation: append-animation 300ms linear;
+  }
+
+  .header-block:hover {
+    background-color: var(--color-gray-50);
+  }
+
+  &--size-sm {
+    padding: var(--spacing-px-12);
+  }
+
+  &--size-md {
+    padding: var(--spacing-px-18);
   }
 
   @keyframes append-animation {

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -27,6 +27,32 @@
         @validates={{this.onPasswordValidation}}
       />
     </div>
+    <div class="fx-row fx-gap-px-10 margin-md padding-md" style="background-color:sandybrown">
+      <OSS::TogglableSection @title="This is a title" @subtitle="This is a subtitle" @toggled={{this.togglable}}
+                             @icon="far fa-hourglass" @onChange={{this.onToggle}}>
+        <:contents>
+          <span>This is a Contents named block</span>
+        </:contents>
+      </OSS::TogglableSection>
+      <OSS::TogglableSection @title="This is a title" @subtitle="This is a subtitle" @toggled={{this.togglable}}
+                             @icon="far fa-hourglass" @onChange={{this.onToggle}} @size="sm">
+        <:contents>
+          <span>This is a Contents named block</span>
+        </:contents>
+      </OSS::TogglableSection>
+    </div>
+    <div class="fx-row fx-gap-px-10 margin-md padding-md" style="background-color:sandybrown">
+      <OSS::TogglableSection @title="This is a title" @subtitle="This is a subtitle" @toggled={{this.togglable}}
+                             @badgeIcon="far fa-hourglass" @onChange={{this.onToggle}} />
+      <OSS::TogglableSection @title="This is a title" @subtitle="This is a subtitle" @toggled={{this.togglable}}
+                             @badgeIcon="far fa-hourglass" @onChange={{this.onToggle}} @size="sm" />
+    </div>
+    <div class="fx-row fx-gap-px-10 margin-md padding-md" style="background-color:sandybrown">
+      <OSS::TogglableSection @title="This is a title" @subtitle="This is a subtitle" @toggled={{this.togglable}}
+                             @badgeIcon="far fa-hourglass" @onChange={{this.onToggle}} @disabled={{true}} />
+      <OSS::TogglableSection @title="This is a title" @subtitle="This is a subtitle" @toggled={{this.togglable}}
+                             @badgeIcon="far fa-hourglass" @onChange={{this.onToggle}} @disabled={{true}} @size="sm" />
+    </div>
     <div class="fx-row fx-gap-px-10 margin-md">
       <OSS::Banner @icon="fas fa-box-open" @title="Shopify" @selected={{true}}
                    @subtitle="Identify influencers in your Shopify customers database">
@@ -192,18 +218,6 @@
     </div>
     <div class="fx-row fx-1 fx-gap-px-10 margin-md padding-md" style="background: white">
       <OSS::Illustration @src="/@upfluence/oss-components/assets/images/no-records.svg" />
-      <OSS::TogglableSection @title="This is a title" @subtitle="This is a subtitle" @toggled={{this.togglable}}
-                             @icon="far fa-hourglass" @onChange={{this.onToggle}}>
-        <:contents>
-          <span>This is a Contents named block</span>
-        </:contents>
-      </OSS::TogglableSection>
-      <OSS::TogglableSection @title="This is a title" @subtitle="This is a subtitle" @toggled={{this.togglable}}
-                             @badgeIcon="far fa-hourglass" @onChange={{this.onToggle}}>
-        <:contents>
-          <span>This is a Contents named block</span>
-        </:contents>
-      </OSS::TogglableSection>
     </div>
     <div class="fx-row fx-1 fx-gap-px-10 margin-md">
       <OSS::Skeleton @width="70%" />

--- a/tests/integration/components/o-s-s/togglable-section-test.ts
+++ b/tests/integration/components/o-s-s/togglable-section-test.ts
@@ -20,8 +20,8 @@ module('Integration | Component | o-s-s/togglable-section', function (hooks) {
 
   test('it renders', async function (assert) {
     await render(hbs`<OSS::TogglableSection @title={{this.title}} @subtitle={{this.subtitle}}
-                                                 @iconUrl={{this.iconUrl}} @toggled={{this.toggled}}
-                                                 @onChange={{this.onChange}} />`);
+                                            @iconUrl={{this.iconUrl}} @toggled={{this.toggled}}
+                                            @onChange={{this.onChange}} />`);
     assert.dom('.togglable-section').exists();
   });
 
@@ -109,14 +109,70 @@ module('Integration | Component | o-s-s/togglable-section', function (hooks) {
       this.onChange = sinon.stub();
       await renderComponent();
       await click('.upf-toggle');
-      assert.true(
-        this.onChange.calledOnceWithExactly(
-          true,
-          sinon.match((propablyEvent: unknown) => {
-            return propablyEvent instanceof Event;
-          })
-        )
+      assert.true(this.onChange.calledOnceWithExactly(true));
+    });
+  });
+
+  module('Size behavior', () => {
+    test('If the @size param is not passed, the default size is md', async function (assert) {
+      await render(hbs`
+        <OSS::TogglableSection @title={{this.title}} @toggled={{this.toggled}} @onChange={{this.onChange}}>
+          <:contents>
+            <div>contents named block</div>
+          </:contents>
+        </OSS::TogglableSection>`);
+      assert.dom('.togglable-section .header-block').hasClass('padding-px-18');
+      await click('.upf-toggle');
+      assert.dom('.togglable-section .content-block').hasClass('padding-px-18');
+    });
+
+    test('If the @size param is set to sm, the size is sm', async function (assert) {
+      await render(hbs`
+        <OSS::TogglableSection @title={{this.title}} @toggled={{this.toggled}} @onChange={{this.onChange}} @size="sm">
+          <:contents>
+            <div>contents named block</div>
+          </:contents>
+        </OSS::TogglableSection>`);
+      assert.dom('.togglable-section .header-block').hasClass('padding-px-12');
+      await click('.upf-toggle');
+      assert.dom('.togglable-section .content-block').hasClass('padding-px-12');
+    });
+
+    test('If the @size param is set to md, the size is md', async function (assert) {
+      await render(hbs`
+        <OSS::TogglableSection @title={{this.title}} @toggled={{this.toggled}} @onChange={{this.onChange}} @size="md">
+          <:contents>
+            <div>contents named block</div>
+          </:contents>
+        </OSS::TogglableSection>`);
+      assert.dom('.togglable-section .header-block').hasClass('padding-px-18');
+      await click('.upf-toggle');
+      assert.dom('.togglable-section .content-block').hasClass('padding-px-18');
+    });
+  });
+
+  module('@Disabled behaviour', () => {
+    test('If @disabled is truthy, the toggle is disabled', async function (assert) {
+      await render(
+        hbs`<OSS::TogglableSection @title={{this.title}} @toggled={{this.toggled}} @onChange={{this.onChange}} @disabled={{true}} />`
       );
+      assert.dom('.upf-toggle').hasClass('upf-toggle--disabled');
+    });
+
+    test('If @disabled is falsy, the toggle is enabled', async function (assert) {
+      await render(
+        hbs`<OSS::TogglableSection @title={{this.title}} @toggled={{this.toggled}} @onChange={{this.onChange}} @disabled={{false}} />`
+      );
+      assert.dom('.upf-toggle').doesNotHaveClass('upf-toggle--disabled');
+    });
+
+    test('If @disabled is truthy, the toggle can still be active', async function (assert) {
+      this.toggled = true;
+      await render(
+        hbs`<OSS::TogglableSection @title={{this.title}} @toggled={{this.toggled}} @onChange={{this.onChange}} @disabled={{true}} />`
+      );
+      assert.dom('.upf-toggle').hasClass('upf-toggle--disabled');
+      assert.dom('.upf-toggle').hasClass('upf-toggle--toggled');
     });
   });
 });


### PR DESCRIPTION
### What does this PR do?

TogglableSection is not dependent on OSS::Banner anymore.

Added two new arguments:
- Disabled (sets the switch state to disabled when truthy)
- size (`sm` or `md` defaults to `md`)
![Screenshot 2024-03-08 at 16 11 04](https://github.com/upfluence/oss-components/assets/5032005/2dd81eed-9a75-4f5c-a5a9-fe4526a0fc30)
![Screenshot 2024-03-08 at 16 11 11](https://github.com/upfluence/oss-components/assets/5032005/3954021b-9892-4576-aa02-6a063d618c9c)

### Good PR checklist
- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [x] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled