### PR TITLE
oss/chip: add support for prefix named block

### DIFF
--- a/addon/components/o-s-s/chip.hbs
+++ b/addon/components/o-s-s/chip.hbs
@@ -1,8 +1,14 @@
 <div class={{this.computedClass}} ...attributes {{on "click" this.stopPropagation}}>
-  <span class="font-weight-semibold {{if @maxDisplayWidth "chip-ellipsis"}}"
-        style={{if @maxDisplayWidth this.ellipsisStyle}}
-        {{enable-tooltip title=(if @maxDisplayWidth @label '') placement='top'}}>
+  {{#if (has-block "prefix")}}
+    {{yield to="prefix"}}
+  {{/if}}
+
+  <span
+    class="font-weight-semibold {{if @maxDisplayWidth 'chip-ellipsis'}}"
+    style={{if @maxDisplayWidth this.ellipsisStyle}}
+    {{enable-tooltip title=(if @maxDisplayWidth @label "") placement="top"}}
+  >
     {{@label}}
   </span>
-  <OSS::Icon @icon="fa-times-circle" role={{unless @disabled 'button'}} {{on "click" this.onCrossClick}} />
+  <OSS::Icon @icon="fa-times-circle" role={{unless @disabled "button"}} {{on "click" this.onCrossClick}} />
 </div>

--- a/addon/components/o-s-s/chip.stories.js
+++ b/addon/components/o-s-s/chip.stories.js
@@ -80,5 +80,19 @@ const Template = (args) => ({
   context: args
 });
 
+const WithPrefixTemplate = (args) => ({
+  template: hbs`
+    <OSS::Chip @skin={{this.skin}} @label={{this.label}} @onRemove={{this.onRemove}} @disabled={{this.disabled}} @maxDisplayWidth={{this.maxDisplayWidth}}>
+      <:prefix>
+        <OSS::Icon @icon="fa-check" />
+      </:prefix>
+    </OSS::Chip>
+  `,
+  context: args
+});
+
 export const Default = Template.bind({});
 Default.args = defaultArgs;
+
+export const UsageWithPrefix = WithPrefixTemplate.bind({});
+UsageWithPrefix.args = defaultArgs;

--- a/app/styles/atoms/chip.less
+++ b/app/styles/atoms/chip.less
@@ -14,7 +14,7 @@
     white-space: nowrap;
   }
 
-  i {
+  i.fa-times-circle {
     opacity: 0.4;
     &:hover {
       opacity: 1;

--- a/tests/integration/components/o-s-s/chip-test.ts
+++ b/tests/integration/components/o-s-s/chip-test.ts
@@ -38,6 +38,7 @@ module('Integration | Component | o-s-s/chip', function (hooks) {
       assert.dom('.upf-chip').hasClass('upf-chip--disabled');
     });
   });
+
   module('@maxDisplayWidth', () => {
     test('The component adds an ellispsis if the label is wider than @maxDisplayWidth', async function (assert) {
       await render(
@@ -86,6 +87,16 @@ module('Integration | Component | o-s-s/chip', function (hooks) {
 
       assert.dom('.upf-chip').exists();
       assert.dom('.upf-chip').hasClass(`upf-chip--${SkinDefinition[this.skin as SkinType]}`);
+    });
+  });
+
+  module('prefix named-block', () => {
+    test('When the prefix named-block is passed, it renders the block', async function (assert) {
+      await render(
+        hbs`<OSS::Chip @skin={{this.skin}} @label={{this.label}} @onRemove={{this.onRemove}}><:prefix><OSS::Icon @icon="fa-users" /></:prefix></OSS::Chip>`
+      );
+      assert.dom('.upf-chip').exists();
+      assert.dom('.upf-chip i.far.fa-users').exists();
     });
   });
 


### PR DESCRIPTION
### What does this PR do?

oss/chip: add support for prefix named block

### What are the observable changes?

![Screenshot 2024-03-14 at 10 30 36](https://github.com/upfluence/oss-components/assets/4022350/b676e3af-2d32-4e5a-949d-547d11deec55)

### Good PR checklist
- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [x] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled
