### PR TITLE
Add support for OSS::AvatarGroup component

### DIFF
--- a/addon/components/o-s-s/avatar-group.hbs
+++ b/addon/components/o-s-s/avatar-group.hbs
@@ -1,4 +1,4 @@
-<div class='oss-avatar-group'>
+<div class={{concat "oss-avatar-group " (if (gt this.remainingCount 0) "oss-avatar-group--has-remaining")}}>
   {{#if @loading}}
     {{#each this.loadingAvatars}}
       <OSS::Avatar @loading={{true}} @size={{this.size}} />
@@ -10,6 +10,6 @@
   {{/if}}
 
   {{#if (gt this.remainingCount 0)}}
-    <OSS::Avatar @initials={{concat '+' this.remainingCount}} @isPlaceholder={{true}} @size={{this.size}} />
+    <OSS::Avatar @initials={{concat "+" this.remainingCount}} @size={{this.size}} />
   {{/if}}
 </div>

--- a/addon/components/o-s-s/avatar-group.hbs
+++ b/addon/components/o-s-s/avatar-group.hbs
@@ -1,0 +1,15 @@
+<div class='oss-avatar-group'>
+  {{#if @loading}}
+    {{#each this.loadingAvatars}}
+      <OSS::Avatar @loading={{true}} @size={{this.size}} />
+    {{/each}}
+  {{else}}
+    {{#each this.avatars as |avatar|}}
+      <OSS::Avatar @image={{avatar.image}} @initials={{avatar.initials}} @size={{this.size}} />
+    {{/each}}
+  {{/if}}
+
+  {{#if (gt this.remainingCount 0)}}
+    <OSS::Avatar @initials={{concat '+' this.remainingCount}} @isPlaceholder={{true}} @size={{this.size}} />
+  {{/if}}
+</div>

--- a/addon/components/o-s-s/avatar-group.stories.js
+++ b/addon/components/o-s-s/avatar-group.stories.js
@@ -1,0 +1,92 @@
+import { hbs } from 'ember-cli-htmlbars';
+
+const SizeTypes = ['xs', 'sm', 'md', 'lg'];
+
+export default {
+  title: 'Components/OSS::AvatarGroup',
+  argTypes: {
+    avatars: {
+      description: 'Avatars to display',
+      table: {
+        type: {
+          summary: '{ image?: string, initials?: string }[]'
+        }
+      },
+      control: {
+        type: '{ image?: string, initials?: string }[]'
+      }
+    },
+    size: {
+      description: 'Adjust the size of the avatars',
+      table: {
+        type: {
+          summary: SizeTypes.join('|')
+        },
+        defaultValue: { summary: 'md' }
+      },
+      options: SizeTypes,
+      control: { type: 'select' }
+    },
+    max: {
+      description: 'Maximum number of avatars to display',
+      table: {
+        type: {
+          summary: 'number'
+        },
+        defaultValue: { summary: 'undefined' }
+      },
+      control: {
+        type: 'number'
+      }
+    },
+    loading: {
+      description: 'Display loading state',
+      table: {
+        type: {
+          summary: 'boolean'
+        },
+        defaultValue: { summary: 'false' }
+      },
+      control: { type: 'boolean' }
+    },
+    loadingCount: {
+      description: 'Maximum number of avatars to display',
+      table: {
+        type: {
+          summary: 'number'
+        },
+        defaultValue: { summary: 'undefined' }
+      },
+      control: {
+        type: 'number'
+      }
+    }
+  }
+};
+
+const defaultArgs = {
+  avatars: [
+    { image: 'https://images.frandroid.com/wp-content/uploads/2019/11/jony-ive-apple.jpg', initials: 'JI' },
+    {
+      image: 'https://cdn.dribbble.com/users/485347/screenshots/2983299/8_most_influential_people_dribble-01.jpg',
+      initials: 'SF'
+    }
+  ],
+  size: 'md',
+  max: null,
+  loading: false,
+  loadingCount: null
+};
+
+const Template = (args) => ({
+  template: hbs`
+    <OSS::AvatarGroup @avatars={{this.avatars}} @size={{this.size}} @max={{this.max}} @loading={{this.loading}} @loadingCount={{this.loadingCount}} />
+  `,
+  context: args
+});
+
+export const Default = Template.bind({});
+Default.args = {
+  ...defaultArgs,
+  ...{ image: 'https://images.frandroid.com/wp-content/uploads/2019/11/jony-ive-apple.jpg' }
+};

--- a/addon/components/o-s-s/avatar-group.stories.js
+++ b/addon/components/o-s-s/avatar-group.stories.js
@@ -61,6 +61,15 @@ export default {
         type: 'number'
       }
     }
+  },
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'UI component that displays a collection of user or entity avatars grouped together in a visually cohesive manner. It typically showcases profile pictures or initials representing multiple individuals or entities, arranged horizontally. They provide a quick and intuitive way for users to identify and associate individuals within a group context, fostering a sense of community and connection.'
+      },
+      iframeHeight: 100
+    }
   }
 };
 

--- a/addon/components/o-s-s/avatar-group.ts
+++ b/addon/components/o-s-s/avatar-group.ts
@@ -1,0 +1,40 @@
+import Component from '@glimmer/component';
+
+import type { SizeType } from './avatar';
+
+type Avatar = {
+  image?: string;
+  initials?: string;
+};
+
+interface OSSAvatarGroupComponentSignature {
+  avatars: Avatar[];
+  size?: SizeType;
+  max?: number;
+  loading?: boolean;
+  loadingCount?: number;
+}
+
+const DEFAULT_LOADING_COUNT: number = 3;
+
+export default class OSSAvatarGroupComponent extends Component<OSSAvatarGroupComponentSignature> {
+  get avatars(): Avatar[] {
+    return this.args.max ? this.args.avatars.slice(0, this.args.max) : this.args.avatars;
+  }
+
+  get remainingCount(): number {
+    return this.args.max ? this.args.avatars.length - this.args.max : 0;
+  }
+
+  get size(): SizeType {
+    return this.args.size ?? 'md';
+  }
+
+  get loadingCount(): number {
+    return this.args.loadingCount ?? DEFAULT_LOADING_COUNT;
+  }
+
+  get loadingAvatars(): unknown[] {
+    return new Array(this.loadingCount);
+  }
+}

--- a/addon/components/o-s-s/avatar.hbs
+++ b/addon/components/o-s-s/avatar.hbs
@@ -1,7 +1,9 @@
 <div class={{this.computedClass}} ...attributes>
-  {{#if this.displayInitials}}
-    <span class='text-style-uppercase'>{{@initials}}</span>
-  {{else if (not @loading)}}
-    <img src={{this.image}} alt='avatar' class={{this.imageClass}} onerror={{this.imageLoadError}} loading='lazy' />
-  {{/if}}
+  {{#unless @loading}}
+    {{#if this.displayInitials}}
+      <span class="text-style-uppercase">{{@initials}}</span>
+    {{else}}
+      <img src={{this.image}} alt="avatar" class={{this.imageClass}} onerror={{this.imageLoadError}} loading="lazy" />
+    {{/if}}
+  {{/unless}}
 </div>

--- a/addon/components/o-s-s/avatar.hbs
+++ b/addon/components/o-s-s/avatar.hbs
@@ -1,8 +1,7 @@
 <div class={{this.computedClass}} ...attributes>
   {{#if this.displayInitials}}
-    <span class="text-style-uppercase">{{@initials}}</span>
-  {{else}}
-    <img src={{this.image}} alt="avatar" class={{this.imageClass}}
-         onerror={{this.imageLoadError}} loading="lazy" />
+    <span class='text-style-uppercase'>{{@initials}}</span>
+  {{else if (not @loading)}}
+    <img src={{this.image}} alt='avatar' class={{this.imageClass}} onerror={{this.imageLoadError}} loading='lazy' />
   {{/if}}
 </div>

--- a/addon/components/o-s-s/avatar.stories.js
+++ b/addon/components/o-s-s/avatar.stories.js
@@ -40,6 +40,26 @@ export default {
       control: {
         type: 'text'
       }
+    },
+    loading: {
+      description: 'Display loading state',
+      table: {
+        type: {
+          summary: 'boolean'
+        },
+        defaultValue: { summary: 'false' }
+      },
+      control: { type: 'boolean' }
+    },
+    isPlaceholder: {
+      description: 'Display placeholder state',
+      table: {
+        type: {
+          summary: 'boolean'
+        },
+        defaultValue: { summary: 'false' }
+      },
+      control: { type: 'boolean' }
     }
   }
 };
@@ -47,12 +67,14 @@ export default {
 const defaultArgs = {
   size: 'md',
   image: undefined,
-  initials: undefined
+  initials: undefined,
+  loading: false,
+  isPlaceholder: false
 };
 
 const Template = (args) => ({
   template: hbs`
-    <OSS::Avatar @image={{this.image}} @initials={{this.initials}} @size={{this.size}} />
+    <OSS::Avatar @image={{this.image}} @initials={{this.initials}} @size={{this.size}} @loading={{this.loading}} @isPlaceholder={{this.isPlaceholder}} />
   `,
   context: args
 });

--- a/addon/components/o-s-s/avatar.stories.js
+++ b/addon/components/o-s-s/avatar.stories.js
@@ -50,16 +50,6 @@ export default {
         defaultValue: { summary: 'false' }
       },
       control: { type: 'boolean' }
-    },
-    isPlaceholder: {
-      description: 'Display placeholder state',
-      table: {
-        type: {
-          summary: 'boolean'
-        },
-        defaultValue: { summary: 'false' }
-      },
-      control: { type: 'boolean' }
     }
   }
 };
@@ -68,13 +58,12 @@ const defaultArgs = {
   size: 'md',
   image: undefined,
   initials: undefined,
-  loading: false,
-  isPlaceholder: false
+  loading: false
 };
 
 const Template = (args) => ({
   template: hbs`
-    <OSS::Avatar @image={{this.image}} @initials={{this.initials}} @size={{this.size}} @loading={{this.loading}} @isPlaceholder={{this.isPlaceholder}} />
+    <OSS::Avatar @image={{this.image}} @initials={{this.initials}} @size={{this.size}} @loading={{this.loading}} />
   `,
   context: args
 });

--- a/addon/components/o-s-s/avatar.ts
+++ b/addon/components/o-s-s/avatar.ts
@@ -17,7 +17,6 @@ interface OSSAvatarArgs {
   initials?: string;
   size?: SizeType;
   loading?: boolean;
-  isPlaceholder?: boolean;
 }
 
 export const DEFAULT_IMAGE_URL: string = '/assets/images/upfluence-white-logo.svg';
@@ -42,10 +41,6 @@ export default class OSSAvatar extends Component<OSSAvatarArgs> {
   get computedClass(): string {
     let classes = 'upf-avatar ';
     const size: SizeType = this.args.size || 'md';
-
-    if (this.args.isPlaceholder) {
-      classes = classes.concat('upf-avatar--placeholder ');
-    }
 
     if (this.args.loading) {
       classes = classes.concat('upf-avatar--loading ');

--- a/addon/components/o-s-s/avatar.ts
+++ b/addon/components/o-s-s/avatar.ts
@@ -3,8 +3,8 @@ import { assert } from '@ember/debug';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 
-type SizeType = 'xs' | 'sm' | 'md' | 'lg';
 type SizeDefType = { [key in SizeType]: string };
+export type SizeType = 'xs' | 'sm' | 'md' | 'lg';
 export const SizeDefinition: SizeDefType = {
   xs: 'upf-avatar--xs',
   sm: 'upf-avatar--sm',
@@ -16,6 +16,8 @@ interface OSSAvatarArgs {
   image?: string;
   initials?: string;
   size?: SizeType;
+  loading?: boolean;
+  isPlaceholder?: boolean;
 }
 
 export const DEFAULT_IMAGE_URL: string = '/assets/images/upfluence-white-logo.svg';
@@ -38,8 +40,16 @@ export default class OSSAvatar extends Component<OSSAvatarArgs> {
   }
 
   get computedClass(): string {
-    const classes = 'upf-avatar ';
+    let classes = 'upf-avatar ';
     const size: SizeType = this.args.size || 'md';
+
+    if (this.args.isPlaceholder) {
+      classes = classes.concat('upf-avatar--placeholder ');
+    }
+
+    if (this.args.loading) {
+      classes = classes.concat('upf-avatar--loading ');
+    }
 
     assert(
       `[component][OSS::Avatar] Unknown size. Available sizes are: ${Object.keys(SizeDefinition).join(', ')}`,

--- a/app/components/o-s-s/avatar-group.js
+++ b/app/components/o-s-s/avatar-group.js
@@ -1,0 +1,1 @@
+export { default } from '@upfluence/oss-components/components/o-s-s/avatar-group';

--- a/app/styles/atoms/avatar.less
+++ b/app/styles/atoms/avatar.less
@@ -61,4 +61,12 @@
       width: var(--spacing-px-24);
     }
   }
+
+  &--placeholder {
+    background-color: var(--color-gray-100);
+  }
+
+  &--loading {
+    .upf-skeleton-effect;
+  }
 }

--- a/app/styles/atoms/avatar.less
+++ b/app/styles/atoms/avatar.less
@@ -62,10 +62,6 @@
     }
   }
 
-  &--placeholder {
-    background-color: var(--color-gray-100);
-  }
-
   &--loading {
     .upf-skeleton-effect;
   }

--- a/app/styles/molecules/avatar-group.less
+++ b/app/styles/molecules/avatar-group.less
@@ -1,0 +1,15 @@
+.oss-avatar-group {
+  display: flex;
+
+  & > .upf-avatar {
+    background-color: var(--color-white);
+    border: 1px solid var(--color-white);
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    margin-right: -6px;
+    position: relative;
+  }
+}

--- a/app/styles/molecules/avatar-group.less
+++ b/app/styles/molecules/avatar-group.less
@@ -2,14 +2,19 @@
   display: flex;
 
   & > .upf-avatar {
-    background-color: var(--color-white);
     border: 1px solid var(--color-white);
     border-radius: 50%;
     display: flex;
     align-items: center;
     justify-content: center;
 
-    margin-right: -6px;
+    margin-right: calc(-1 * var(--spacing-px-6));
     position: relative;
+  }
+
+  &--has-remaining {
+    .upf-avatar:last-child {
+      background-color: var(--color-gray-100);
+    }
   }
 }

--- a/app/styles/oss-components.less
+++ b/app/styles/oss-components.less
@@ -48,6 +48,7 @@
 @import 'molecules/toggle-buttons';
 @import 'molecules/togglable-section';
 @import 'molecules/password-input';
+@import 'molecules/avatar-group';
 @import 'organisms/table';
 @import 'organisms/modal-dialog';
 @import 'organisms/split-modal';

--- a/tests/integration/components/o-s-s/avatar-group-test.ts
+++ b/tests/integration/components/o-s-s/avatar-group-test.ts
@@ -6,21 +6,57 @@ import { hbs } from 'ember-cli-htmlbars';
 module('Integration | Component | o-s-s/avatar-group', function (hooks) {
   setupRenderingTest(hooks);
 
-  test('it renders', async function (assert) {
-    // Set any properties with this.set('myProperty', 'value');
-    // Handle any actions with this.set('myAction', function (val) { ... });
+  hooks.beforeEach(function () {
+    this.avatars = [
+      {
+        image: 'http://foo.co/bar.png',
+        initials: 'TS'
+      },
+      {
+        image: 'http://foo.co/baz.png',
+        initials: 'OM'
+      }
+    ];
+  });
 
-    await render(hbs`<OSS::AvatarGroup />`);
+  test('it displays the right number of avatars', async function (assert) {
+    await render(hbs`<OSS::AvatarGroup @avatars={{this.avatars}} />`);
+    assert.dom('.upf-avatar').exists({ count: 2 });
+    assert.dom('.upf-avatar:first-child img').hasAttribute('src', 'http://foo.co/bar.png');
+    assert.dom('.upf-avatar:last-child img').hasAttribute('src', 'http://foo.co/baz.png');
+  });
 
-    assert.dom().hasText('');
+  test('if no @size arg is provided, it should default to "md"', async function (assert) {
+    await render(hbs`<OSS::AvatarGroup @avatars={{this.avatars}} />`);
+    assert.dom('.upf-avatar:first-child').hasClass('upf-avatar--md');
+    assert.dom('.upf-avatar:last-child').hasClass('upf-avatar--md');
+  });
 
-    // Template block usage:
-    await render(hbs`
-      <OSS::AvatarGroup>
-        template block text
-      </OSS::AvatarGroup>
-    `);
+  test('if a @size arg is provided, it should be used for all displayed avatars', async function (assert) {
+    await render(hbs`<OSS::AvatarGroup @avatars={{this.avatars}} @size="sm" />`);
+    assert.dom('.upf-avatar:first-child').hasClass('upf-avatar--sm');
+    assert.dom('.upf-avatar:last-child').hasClass('upf-avatar--sm');
+  });
 
-    assert.dom().hasText('template block text');
+  test('if a @max arg is provided, we should display maximum that number of avatars and display remaining ones using a placeholder', async function (assert) {
+    await render(hbs`<OSS::AvatarGroup @avatars={{this.avatars}} @max={{1}} />`);
+    assert.dom('.upf-avatar').exists({ count: 2 });
+    assert.dom('.upf-avatar:first-child img').hasAttribute('src', 'http://foo.co/bar.png');
+    assert.dom('.upf-avatar:last-child img').doesNotExist();
+    assert.dom('.upf-avatar:last-child').hasText('+1');
+  });
+
+  test('if a @loading arg is provided w/ no @loadingCount arg, we should display 3 avatars in loading state', async function (assert) {
+    await render(hbs`<OSS::AvatarGroup @avatars={{this.avatars}} @loading={{true}} />`);
+    assert.dom('.upf-avatar').exists({ count: 3 });
+    assert.dom('.upf-avatar:first-child').hasClass('upf-avatar--loading');
+    assert.dom('.upf-avatar:nth-child(2)').hasClass('upf-avatar--loading');
+    assert.dom('.upf-avatar:nth-child(3)').hasClass('upf-avatar--loading');
+  });
+
+  test('if a @loading arg is provided w/ @loadingCount arg, we should display {{@loadingCount}} avatars in loading state', async function (assert) {
+    await render(hbs`<OSS::AvatarGroup @avatars={{this.avatars}} @loading={{true}} @loadingCount={{1}} />`);
+    assert.dom('.upf-avatar').exists({ count: 1 });
+    assert.dom('.upf-avatar:first-child').hasClass('upf-avatar--loading');
   });
 });

--- a/tests/integration/components/o-s-s/avatar-group-test.ts
+++ b/tests/integration/components/o-s-s/avatar-group-test.ts
@@ -1,0 +1,26 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Component | o-s-s/avatar-group', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function (assert) {
+    // Set any properties with this.set('myProperty', 'value');
+    // Handle any actions with this.set('myAction', function (val) { ... });
+
+    await render(hbs`<OSS::AvatarGroup />`);
+
+    assert.dom().hasText('');
+
+    // Template block usage:
+    await render(hbs`
+      <OSS::AvatarGroup>
+        template block text
+      </OSS::AvatarGroup>
+    `);
+
+    assert.dom().hasText('template block text');
+  });
+});

--- a/tests/integration/components/o-s-s/avatar-test.ts
+++ b/tests/integration/components/o-s-s/avatar-test.ts
@@ -61,11 +61,6 @@ module('Integration | Component | o-s-s/avatar', function (hooks) {
     });
   });
 
-  test('When @isPlaceholder is thruthy, the right class is applied on the component', async function (assert) {
-    await render(hbs`<OSS::Avatar @isPlaceholder={{true}} />`);
-    assert.dom('.upf-avatar').hasClass('upf-avatar--placeholder');
-  });
-
   test('When @loading is thruthy, the right class is applied on the component', async function (assert) {
     await render(hbs`<OSS::Avatar @loading={{true}} />`);
     assert.dom('.upf-avatar').hasClass('upf-avatar--loading');

--- a/tests/integration/components/o-s-s/avatar-test.ts
+++ b/tests/integration/components/o-s-s/avatar-test.ts
@@ -61,6 +61,16 @@ module('Integration | Component | o-s-s/avatar', function (hooks) {
     });
   });
 
+  test('When @isPlaceholder is thruthy, the right class is applied on the component', async function (assert) {
+    await render(hbs`<OSS::Avatar @isPlaceholder={{true}} />`);
+    assert.dom('.upf-avatar').hasClass('upf-avatar--placeholder');
+  });
+
+  test('When @loading is thruthy, the right class is applied on the component', async function (assert) {
+    await render(hbs`<OSS::Avatar @loading={{true}} />`);
+    assert.dom('.upf-avatar').hasClass('upf-avatar--loading');
+  });
+
   module('Error behavior', function () {
     test('it throws an error if the wrong size argument is passed', async function (assert: Assert) {
       setupOnerror((err: Error) => {


### PR DESCRIPTION
### What does this PR do?

- Add support for OSS::AvatarGroup component
- Add support for loading/placeholder states on OSS::Avatar

### What are the observable changes?

![Screenshot 2024-03-29 at 14 54 51](https://github.com/upfluence/oss-components/assets/4022350/21b59e4f-5225-4691-a84d-0a03802cd9e7)
![Screenshot 2024-03-29 at 14 54 38](https://github.com/upfluence/oss-components/assets/4022350/97b0adb9-7623-4110-b3b1-fddd8073e819)



### Good PR checklist
- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [x] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled
