### PR TITLE
[VEL-2833] Reintroduce portal-based select updates

### DIFF
--- a/addon/components/o-s-s/power-select.hbs
+++ b/addon/components/o-s-s/power-select.hbs
@@ -4,6 +4,7 @@
   open={{this.isOpen}}
   {{did-insert this.registerContainer}}
   {{did-insert (fn this.ensureBlockPresence (has-block "selected-item") (has-block "option-item"))}}
+  {{will-destroy this.disconnectObserver}}
   {{on "toggle" this.handleSelectorClose}}
   ...attributes
 >

--- a/addon/components/o-s-s/power-select.hbs
+++ b/addon/components/o-s-s/power-select.hbs
@@ -4,7 +4,6 @@
   {{did-insert this.registerContainer}}
   {{did-insert (fn this.ensureBlockPresence (has-block "selected-item") (has-block "option-item"))}}
   {{will-destroy this.disconnectObserver}}
-  {{on "toggle" this.handleSelectorClose}}
   ...attributes
 >
   <div class="upf-power-select__array-container" role="button" {{on "click" this.toggleDropdown}}>

--- a/addon/components/o-s-s/power-select.hbs
+++ b/addon/components/o-s-s/power-select.hbs
@@ -1,8 +1,13 @@
-<div class="upf-power-select fx-1 fx-col" ...attributes
-     {{did-insert (fn this.ensureBlockPresence (has-block "selected-item") (has-block "option-item"))}}>
-  <div class="upf-power-select__array-container" role="button"
-       {{on "click" this.toggleSelect}}>
-    <div class="array-input-container fx-row padding-px-6 {{if this.displaySelect 'active'}}" >
+<details
+  class="upf-power-select fx-1 fx-col"
+  data-toggle="oss-dropdown"
+  {{did-insert this.registerContainer}}
+  {{did-insert (fn this.ensureBlockPresence (has-block "selected-item") (has-block "option-item"))}}
+  {{on "toggle" this.handleSelectorClose}}
+  ...attributes
+>
+  <summary class="upf-power-select__array-container" role="button" {{on "click" this.toggleDropdown}}>
+    <div class="array-input-container fx-row padding-px-6 {{if this.isOpen 'active'}}">
       <div class="fx-row fx-xalign-center fx-1 padding-left-px-6 padding-right-px-24 fx-gap-px-6 fx-wrap">
         {{#each @selectedItems as |selectedItem|}}
           {{yield selectedItem to="selected-item"}}
@@ -12,34 +17,55 @@
           </span>
         {{/each}}
       </div>
-        <OSS::Icon @icon={{if this.displaySelect "fa-chevron-up" "fa-chevron-down"}}
-            class="dropdown-icon" />
+      <OSS::Icon @icon={{if this.isOpen "fa-chevron-up" "fa-chevron-down"}} class="dropdown-icon" />
     </div>
-  </div>
+  </summary>
 
-  {{#if this.displaySelect}}
-    {{#if (has-block "empty-state")}}
-      <OSS::InfiniteSelect @items={{@items}} @onSearch={{@onSearch}} @inline={{false}} @onSelect={{this.onSelect}}
-                           @searchPlaceholder={{@searchPlaceholder}} @loading={{@loading}} @loadingMore={{@loadingMore}}
-                           @onBottomReached={{@onBottomReached}}
-                           {{on-click-outside this.hideSelect}}>
-        <:option as |item|>
-          {{yield item to="option-item"}}
-        </:option>
+  {{#if this.isOpen}}
+    {{#in-element this.portalTarget insertBefore=null}}
+      {{#if (has-block "empty-state")}}
+        <OSS::InfiniteSelect
+          @items={{@items}}
+          @onSearch={{@onSearch}}
+          @inline={{false}}
+          @onSelect={{this.onSelect}}
+          @searchPlaceholder={{@searchPlaceholder}}
+          @loading={{@loading}}
+          @loadingMore={{@loadingMore}}
+          @onBottomReached={{@onBottomReached}}
+          class="margin-top-px-0"
+          id={{this.portalId}}
+          {{on "click" this.noop}}
+          {{on-click-outside this.onClickOutside}}
+        >
+          <:option as |item|>
+            {{yield item to="option-item"}}
+          </:option>
 
-        <:empty-state>
-          {{yield to="empty-state"}}
-        </:empty-state>
-      </OSS::InfiniteSelect>
-    {{else}}
-      <OSS::InfiniteSelect @items={{@items}} @onSearch={{@onSearch}} @inline={{false}} @onSelect={{this.onSelect}}
-                           @searchPlaceholder={{@searchPlaceholder}} @loading={{@loading}} @loadingMore={{@loadingMore}}
-                           @onBottomReached={{@onBottomReached}}
-                           {{on-click-outside this.hideSelect}}>
-        <:option as |item|>
-          {{yield item to="option-item"}}
-        </:option>
-      </OSS::InfiniteSelect>
-    {{/if}}
+          <:empty-state>
+            {{yield to="empty-state"}}
+          </:empty-state>
+        </OSS::InfiniteSelect>
+      {{else}}
+        <OSS::InfiniteSelect
+          @items={{@items}}
+          @onSearch={{@onSearch}}
+          @inline={{false}}
+          @onSelect={{this.onSelect}}
+          @searchPlaceholder={{@searchPlaceholder}}
+          @loading={{@loading}}
+          @loadingMore={{@loadingMore}}
+          @onBottomReached={{@onBottomReached}}
+          class="margin-top-px-0"
+          id={{this.portalId}}
+          {{on "click" this.noop}}
+          {{on-click-outside this.onClickOutside}}
+        >
+          <:option as |item|>
+            {{yield item to="option-item"}}
+          </:option>
+        </OSS::InfiniteSelect>
+      {{/if}}
+    {{/in-element}}
   {{/if}}
-</div>
+</details>

--- a/addon/components/o-s-s/power-select.hbs
+++ b/addon/components/o-s-s/power-select.hbs
@@ -1,7 +1,6 @@
 <div
   class="upf-power-select fx-1 fx-col"
   data-toggle="oss-dropdown"
-  open={{this.isOpen}}
   {{did-insert this.registerContainer}}
   {{did-insert (fn this.ensureBlockPresence (has-block "selected-item") (has-block "option-item"))}}
   {{will-destroy this.disconnectObserver}}

--- a/addon/components/o-s-s/power-select.hbs
+++ b/addon/components/o-s-s/power-select.hbs
@@ -1,12 +1,13 @@
-<details
+<div
   class="upf-power-select fx-1 fx-col"
   data-toggle="oss-dropdown"
+  open={{this.isOpen}}
   {{did-insert this.registerContainer}}
   {{did-insert (fn this.ensureBlockPresence (has-block "selected-item") (has-block "option-item"))}}
   {{on "toggle" this.handleSelectorClose}}
   ...attributes
 >
-  <summary class="upf-power-select__array-container" role="button" {{on "click" this.toggleDropdown}}>
+  <div class="upf-power-select__array-container" role="button" {{on "click" this.toggleDropdown}}>
     <div class="array-input-container fx-row padding-px-6 {{if this.isOpen 'active'}}">
       <div class="fx-row fx-xalign-center fx-1 padding-left-px-6 padding-right-px-24 fx-gap-px-6 fx-wrap">
         {{#each @selectedItems as |selectedItem|}}
@@ -19,7 +20,7 @@
       </div>
       <OSS::Icon @icon={{if this.isOpen "fa-chevron-up" "fa-chevron-down"}} class="dropdown-icon" />
     </div>
-  </summary>
+  </div>
 
   {{#if this.isOpen}}
     {{#in-element this.portalTarget insertBefore=null}}
@@ -33,7 +34,7 @@
           @loading={{@loading}}
           @loadingMore={{@loadingMore}}
           @onBottomReached={{@onBottomReached}}
-          class="margin-top-px-0"
+          class={{concat "margin-top-px-0 upf-power-select__dropdown " this.dropdownAddressableClass}}
           id={{this.portalId}}
           {{on "click" this.noop}}
           {{on-click-outside this.onClickOutside}}
@@ -56,7 +57,7 @@
           @loading={{@loading}}
           @loadingMore={{@loadingMore}}
           @onBottomReached={{@onBottomReached}}
-          class="margin-top-px-0"
+          class={{concat "margin-top-px-0 upf-power-select__dropdown " this.dropdownAddressableClass}}
           id={{this.portalId}}
           {{on "click" this.noop}}
           {{on-click-outside this.onClickOutside}}
@@ -68,4 +69,4 @@
       {{/if}}
     {{/in-element}}
   {{/if}}
-</details>
+</div>

--- a/addon/components/o-s-s/power-select.stories.js
+++ b/addon/components/o-s-s/power-select.stories.js
@@ -100,7 +100,7 @@ export default {
     },
     addressableAs: {
       description:
-        'A string to use as base to target the portaled-dropdown component in CSS. When provided, you will be able to use `${addressableAs}__dropdown` in CSS.',
+        'A string identifier to use as base to target the portaled-dropdown component in CSS. When provided, you will be able to use `${addressableAs}__dropdown` in CSS.',
       table: {
         type: {
           summary: 'string'

--- a/addon/components/o-s-s/power-select.stories.js
+++ b/addon/components/o-s-s/power-select.stories.js
@@ -97,6 +97,15 @@ export default {
           summary: 'onBottomReached(): void'
         }
       }
+    },
+    addressableAs: {
+      description:
+        'A string to use as base to target the portaled-dropdown component in CSS. When provided, you will be able to use `${addressableAs}__dropdown` in CSS.',
+      table: {
+        type: {
+          summary: 'string'
+        }
+      }
     }
   },
   parameters: {
@@ -116,6 +125,7 @@ const defaultArgs = {
   loadingMore: false,
   placeholder: 'My placeholder',
   searchPlaceholder: 'My search placeholder',
+  addressableAs: undefined,
   onSearch: action('onSearch'),
   onChange: action('onChange', { allowFunction: true }),
   onBottomReached: action('onBottomReached')
@@ -127,7 +137,7 @@ const Template = (args) => ({
       <OSS::PowerSelect class='padding-sm' @selectedItems={{this.selectedItems}} @items={{this.items}}
                         @onSearch={{this.onSearch}} @onChange={{this.onChange}} @loading={{this.loading}}
                         @loadingMore={{this.loadingMore}} @placeholder={{this.placeholder}} @searchPlaceholder={{this.searchPlaceholder}}
-                        @onBottomReached={{this.onBottomReached}}>
+                        @onBottomReached={{this.onBottomReached}} @addressableAs={{this.addressableAs}}>
         <:selected-item as |selectedItem|>
           {{selectedItem}}
         </:selected-item>

--- a/addon/components/o-s-s/power-select.ts
+++ b/addon/components/o-s-s/power-select.ts
@@ -1,6 +1,5 @@
 import { assert } from '@ember/debug';
 import { action } from '@ember/object';
-import { guidFor } from '@ember/object/internals';
 import { scheduleOnce } from '@ember/runloop';
 import { isTesting } from '@embroider/macros';
 
@@ -27,20 +26,12 @@ const DEFAULT_PLACEHOLDER = 'Select an item';
 export default class OSSPowerSelect extends BaseDropdown<OSSPowerSelectArgs> {
   cleanupDrodpownAutoplacement?: () => void;
 
-  portalId: string = guidFor(this);
-
-  declare portalTarget: HTMLElement;
-
   get placeholder(): string {
     return this.args.placeholder ?? DEFAULT_PLACEHOLDER;
   }
 
   get dropdownAddressableClass(): string {
     return this.args.addressableAs ? `${this.args.addressableAs}__dropdown` : '';
-  }
-
-  noop(event: Event): void {
-    event.stopPropagation();
   }
 
   @action
@@ -92,11 +83,5 @@ export default class OSSPowerSelect extends BaseDropdown<OSSPowerSelectArgs> {
     this.cleanupDrodpownAutoplacement?.();
     this.args.onSearch?.('');
     document.querySelector(`#${this.portalId}`)?.remove();
-  }
-
-  @action
-  registerContainer(element: HTMLElement): void {
-    super.registerContainer(element);
-    this.portalTarget = isTesting() ? this.container : document.body;
   }
 }

--- a/addon/components/o-s-s/power-select.ts
+++ b/addon/components/o-s-s/power-select.ts
@@ -16,6 +16,7 @@ interface OSSPowerSelectArgs {
   loadingMore?: boolean;
   placeholder?: string;
   searchPlaceholder?: string;
+  addressableAs?: string;
   onChange: (item: any, operation: OperationType) => void;
   onSearch?: (keyword: string) => void;
   onBottomReached?: () => void;
@@ -32,6 +33,10 @@ export default class OSSPowerSelect extends BaseDropdown<OSSPowerSelectArgs> {
 
   get placeholder(): string {
     return this.args.placeholder ?? DEFAULT_PLACEHOLDER;
+  }
+
+  get dropdownAddressableClass(): string {
+    return this.args.addressableAs ? `${this.args.addressableAs}__dropdown` : '';
   }
 
   noop(event: Event): void {
@@ -74,7 +79,8 @@ export default class OSSPowerSelect extends BaseDropdown<OSSPowerSelectArgs> {
       if (referenceTarget && floatingTarget) {
         this.cleanupDrodpownAutoplacement = attachDropdown(
           referenceTarget as HTMLElement,
-          floatingTarget as HTMLElement
+          floatingTarget as HTMLElement,
+          { maxHeight: 300 }
         );
       }
     });

--- a/addon/components/o-s-s/power-select.ts
+++ b/addon/components/o-s-s/power-select.ts
@@ -56,7 +56,7 @@ export default class OSSPowerSelect extends BaseDropdown<OSSPowerSelectArgs> {
 
   @action
   handleSelectorClose(): void {
-    if (!this.container.open && document.querySelector(`#${this.portalId}`)) {
+    if (!this.container.hasAttribute('open') && document.querySelector(`#${this.portalId}`)) {
       document.querySelector(`#${this.portalId}`)!.remove();
       this.cleanupDrodpownAutoplacement?.();
       this.closeDropdown();

--- a/addon/components/o-s-s/power-select.ts
+++ b/addon/components/o-s-s/power-select.ts
@@ -55,8 +55,8 @@ export default class OSSPowerSelect extends BaseDropdown<OSSPowerSelectArgs> {
   }
 
   @action
-  handleSelectorClose(event: ToggleEvent & { target: HTMLDetailsElement }): void {
-    if (!event.target.open && document.querySelector(`#${this.portalId}`)) {
+  handleSelectorClose(): void {
+    if (!this.container.open && document.querySelector(`#${this.portalId}`)) {
       document.querySelector(`#${this.portalId}`)!.remove();
       this.cleanupDrodpownAutoplacement?.();
       this.closeDropdown();
@@ -95,7 +95,7 @@ export default class OSSPowerSelect extends BaseDropdown<OSSPowerSelectArgs> {
   }
 
   @action
-  registerContainer(element: HTMLDetailsElement): void {
+  registerContainer(element: HTMLElement): void {
     super.registerContainer(element);
     this.portalTarget = isTesting() ? this.container : document.body;
   }

--- a/addon/components/o-s-s/power-select.ts
+++ b/addon/components/o-s-s/power-select.ts
@@ -1,7 +1,11 @@
-import Component from '@glimmer/component';
-import { tracked } from '@glimmer/tracking';
 import { assert } from '@ember/debug';
 import { action } from '@ember/object';
+import { guidFor } from '@ember/object/internals';
+import { scheduleOnce } from '@ember/runloop';
+import { isTesting } from '@embroider/macros';
+
+import attachDropdown from '@upfluence/oss-components/utils/attach-dropdown';
+import BaseDropdown from './private/base-dropdown';
 
 type OperationType = 'selection' | 'deletion';
 
@@ -19,11 +23,19 @@ interface OSSPowerSelectArgs {
 
 const DEFAULT_PLACEHOLDER = 'Select an item';
 
-export default class OSSPowerSelect extends Component<OSSPowerSelectArgs> {
-  @tracked displaySelect: boolean = false;
+export default class OSSPowerSelect extends BaseDropdown<OSSPowerSelectArgs> {
+  cleanupDrodpownAutoplacement?: () => void;
+
+  portalId: string = guidFor(this);
+
+  declare portalTarget: HTMLElement;
 
   get placeholder(): string {
     return this.args.placeholder ?? DEFAULT_PLACEHOLDER;
+  }
+
+  noop(event: Event): void {
+    event.stopPropagation();
   }
 
   @action
@@ -38,19 +50,47 @@ export default class OSSPowerSelect extends Component<OSSPowerSelectArgs> {
   }
 
   @action
-  toggleSelect(event: MouseEvent): void {
-    event.stopPropagation();
-    this.displaySelect = !this.displaySelect;
-
-    if (!this.displaySelect) {
-      this.args.onSearch?.('');
+  handleSelectorClose(event: ToggleEvent & { target: HTMLDetailsElement }): void {
+    if (!event.target.open && document.querySelector(`#${this.portalId}`)) {
+      document.querySelector(`#${this.portalId}`)!.remove();
+      this.cleanupDrodpownAutoplacement?.();
+      this.closeDropdown();
     }
   }
 
   @action
-  hideSelect(_: HTMLElement, event: MouseEvent): void {
-    event.stopPropagation();
-    this.displaySelect = false;
+  toggleDropdown(event: MouseEvent): void {
+    super.toggleDropdown(event);
+
+    if (!this.isOpen) {
+      this.args.onSearch?.('');
+      return;
+    }
+
+    scheduleOnce('afterRender', this, () => {
+      const referenceTarget = this.container.querySelector('.upf-power-select__array-container');
+      const floatingTarget = document.querySelector(`#${this.portalId}`);
+
+      if (referenceTarget && floatingTarget) {
+        this.cleanupDrodpownAutoplacement = attachDropdown(
+          referenceTarget as HTMLElement,
+          floatingTarget as HTMLElement
+        );
+      }
+    });
+  }
+
+  @action
+  onClickOutside(_: HTMLElement, event: MouseEvent): void {
+    super.onClickOutside(_, event);
+    this.cleanupDrodpownAutoplacement?.();
     this.args.onSearch?.('');
+    document.querySelector(`#${this.portalId}`)?.remove();
+  }
+
+  @action
+  registerContainer(element: HTMLDetailsElement): void {
+    super.registerContainer(element);
+    this.portalTarget = isTesting() ? this.container : document.body;
   }
 }

--- a/addon/components/o-s-s/private/base-dropdown.ts
+++ b/addon/components/o-s-s/private/base-dropdown.ts
@@ -50,7 +50,7 @@ export default class OSSBaseDropdown<T> extends Component<T> {
   }
 
   closeDropdown(): void {
-    this.isOpen = false;
+    this.container.removeAttribute('open');
   }
 
   @action

--- a/addon/components/o-s-s/private/base-dropdown.ts
+++ b/addon/components/o-s-s/private/base-dropdown.ts
@@ -17,13 +17,17 @@ export default class OSSBaseDropdown<T> extends Component<T> {
     event.stopPropagation();
     event.preventDefault();
 
-    this.isOpen = !this.isOpen;
+    if (this.container.hasAttribute('open')) {
+      this.container.removeAttribute('open');
+    } else {
+      this.container.setAttribute('open', '');
+    }
+
+    this.isOpen = this.container.hasAttribute('open');
 
     if (this.isOpen) {
       this.clearExistingDropdowns();
     }
-
-    this.container.open = this.isOpen;
   }
 
   @action
@@ -36,7 +40,9 @@ export default class OSSBaseDropdown<T> extends Component<T> {
   registerContainer(element: HTMLElement): void {
     this.container = element;
     this.observer = new MutationObserver(() => {
-      if (!this.container.open) {
+      this.isOpen = this.container.hasAttribute('open');
+
+      if (!this.container.hasAttribute('open')) {
         this.handleSelectorClose();
       }
     });
@@ -44,7 +50,6 @@ export default class OSSBaseDropdown<T> extends Component<T> {
   }
 
   closeDropdown(): void {
-    this.container.open = false;
     this.isOpen = false;
   }
 
@@ -56,9 +61,9 @@ export default class OSSBaseDropdown<T> extends Component<T> {
   clearExistingDropdowns(): void {
     const openedDetails = document.querySelectorAll('[data-toggle="oss-dropdown"][open]');
 
-    openedDetails.forEach((details: HTMLDetailsElement) => {
+    openedDetails.forEach((details: HTMLElement & { open?: boolean }) => {
       if (details !== this.container) {
-        details.open = false;
+        details.removeAttribute('open');
       }
     });
   }

--- a/addon/components/o-s-s/private/base-dropdown.ts
+++ b/addon/components/o-s-s/private/base-dropdown.ts
@@ -3,7 +3,7 @@ import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 
 export default class OSSBaseDropdown<T> extends Component<T> {
-  declare container: HTMLDetailsElement;
+  declare container: HTMLElement & { open?: boolean };
 
   @tracked isOpen: boolean = false;
 
@@ -28,7 +28,7 @@ export default class OSSBaseDropdown<T> extends Component<T> {
   }
 
   @action
-  registerContainer(element: HTMLDetailsElement): void {
+  registerContainer(element: HTMLElement): void {
     this.container = element;
   }
 
@@ -38,7 +38,7 @@ export default class OSSBaseDropdown<T> extends Component<T> {
   }
 
   clearExistingDropdowns(): void {
-    const openedDetails = document.querySelectorAll('details[data-toggle="oss-dropdown"][open]');
+    const openedDetails = document.querySelectorAll('[data-toggle="oss-dropdown"][open]');
 
     openedDetails.forEach((details: HTMLDetailsElement) => {
       if (details !== this.container) {

--- a/addon/components/o-s-s/private/base-dropdown.ts
+++ b/addon/components/o-s-s/private/base-dropdown.ts
@@ -1,0 +1,49 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+
+export default class OSSBaseDropdown<T> extends Component<T> {
+  declare container: HTMLDetailsElement;
+
+  @tracked isOpen: boolean = false;
+
+  @action
+  toggleDropdown(event: MouseEvent): void {
+    event.stopPropagation();
+    event.preventDefault();
+
+    this.isOpen = !this.isOpen;
+
+    if (this.isOpen) {
+      this.clearExistingDropdowns();
+    }
+
+    this.container.open = this.isOpen;
+  }
+
+  @action
+  onClickOutside(_: HTMLElement, event: MouseEvent): void {
+    event.stopPropagation();
+    this.closeDropdown();
+  }
+
+  @action
+  registerContainer(element: HTMLDetailsElement): void {
+    this.container = element;
+  }
+
+  closeDropdown(): void {
+    this.container.open = false;
+    this.isOpen = false;
+  }
+
+  clearExistingDropdowns(): void {
+    const openedDetails = document.querySelectorAll('details[data-toggle="oss-dropdown"][open]');
+
+    openedDetails.forEach((details: HTMLDetailsElement) => {
+      if (details !== this.container) {
+        details.open = false;
+      }
+    });
+  }
+}

--- a/addon/components/o-s-s/private/base-dropdown.ts
+++ b/addon/components/o-s-s/private/base-dropdown.ts
@@ -4,8 +4,13 @@ import { action } from '@ember/object';
 
 export default class OSSBaseDropdown<T> extends Component<T> {
   declare container: HTMLElement & { open?: boolean };
+  declare observer: MutationObserver;
 
   @tracked isOpen: boolean = false;
+
+  handleSelectorClose(): void {
+    throw new Error('[component][OSS::BaseDropdown] You must implement handleSelectorClose method on the child class');
+  }
 
   @action
   toggleDropdown(event: MouseEvent): void {
@@ -30,11 +35,22 @@ export default class OSSBaseDropdown<T> extends Component<T> {
   @action
   registerContainer(element: HTMLElement): void {
     this.container = element;
+    this.observer = new MutationObserver(() => {
+      if (!this.container.open) {
+        this.handleSelectorClose();
+      }
+    });
+    this.observer.observe(this.container, { attributes: true, attributeFilter: ['open'] });
   }
 
   closeDropdown(): void {
     this.container.open = false;
     this.isOpen = false;
+  }
+
+  @action
+  disconnectObserver(): void {
+    this.observer.disconnect();
   }
 
   clearExistingDropdowns(): void {

--- a/addon/components/o-s-s/private/base-dropdown.ts
+++ b/addon/components/o-s-s/private/base-dropdown.ts
@@ -1,10 +1,14 @@
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
+import { guidFor } from '@ember/object/internals';
+import { isTesting } from '@embroider/macros';
 
 export default class OSSBaseDropdown<T> extends Component<T> {
   declare container: HTMLElement & { open?: boolean };
   declare observer: MutationObserver;
+  declare portalTarget: HTMLElement;
+  portalId: string = guidFor(this);
 
   @tracked isOpen: boolean = false;
 
@@ -39,6 +43,7 @@ export default class OSSBaseDropdown<T> extends Component<T> {
   @action
   registerContainer(element: HTMLElement): void {
     this.container = element;
+    this.portalTarget = isTesting() ? this.container : document.body;
     this.observer = new MutationObserver(() => {
       this.isOpen = this.container.hasAttribute('open');
 
@@ -49,16 +54,20 @@ export default class OSSBaseDropdown<T> extends Component<T> {
     this.observer.observe(this.container, { attributes: true, attributeFilter: ['open'] });
   }
 
-  closeDropdown(): void {
-    this.container.removeAttribute('open');
-  }
-
   @action
   disconnectObserver(): void {
     this.observer?.disconnect();
   }
 
-  clearExistingDropdowns(): void {
+  noop(event: Event): void {
+    event.stopPropagation();
+  }
+
+  closeDropdown(): void {
+    this.container.removeAttribute('open');
+  }
+
+  private clearExistingDropdowns(): void {
     const openedDetails = document.querySelectorAll('[data-toggle="oss-dropdown"][open]');
 
     openedDetails.forEach((details: HTMLElement & { open?: boolean }) => {

--- a/addon/components/o-s-s/private/base-dropdown.ts
+++ b/addon/components/o-s-s/private/base-dropdown.ts
@@ -50,7 +50,7 @@ export default class OSSBaseDropdown<T> extends Component<T> {
 
   @action
   disconnectObserver(): void {
-    this.observer.disconnect();
+    this.observer?.disconnect();
   }
 
   clearExistingDropdowns(): void {

--- a/addon/components/o-s-s/select.hbs
+++ b/addon/components/o-s-s/select.hbs
@@ -1,7 +1,6 @@
 <div
   class={{this.classNames}}
   data-toggle="oss-dropdown"
-  open={{this.isOpen}}
   {{did-insert (fn this.ensureBlockPresence (has-block "option"))}}
   {{did-insert this.registerContainer}}
   {{will-destroy this.disconnectObserver}}

--- a/addon/components/o-s-s/select.hbs
+++ b/addon/components/o-s-s/select.hbs
@@ -1,8 +1,15 @@
-<div class={{this.classNames}}
-     {{did-insert (fn this.ensureBlockPresence (has-block "option"))}}
-     ...attributes>
-  <div class="upf-input {{if this.displaySelect 'active'}} fx-row fx-1 fx-xalign-center" role="button"
-       {{on "click" this.toggleSelector}}>
+<details
+  class={{this.classNames}}
+  data-toggle="oss-dropdown"
+  {{did-insert (fn this.ensureBlockPresence (has-block "option"))}}
+  {{did-insert this.registerContainer}}
+  {{on "toggle" this.handleSelectorClose}}
+  ...attributes
+>
+  <summary
+    class="upf-input {{if this.isOpen 'active'}} fx-row fx-1 fx-xalign-center"
+    {{on "click" this.toggleDropdown}}
+  >
     <div class="fx-row fx-1 fx-malign-space-between fx-xalign-center">
       {{#if @value}}
         {{#if (has-block "selected")}}
@@ -13,41 +20,49 @@
       {{else}}
         <span class="upf-input--placeholder">{{this.placeholder}}</span>
       {{/if}}
-      <OSS::Icon @icon="fa-chevron-{{if this.displaySelect 'up' 'down'}}" class="margin-left-px-6" />
+      <OSS::Icon @icon="fa-chevron-{{if this.isOpen 'up' 'down'}}" class="margin-left-px-6" />
     </div>
-  </div>
+  </summary>
 
-  {{#if this.displaySelect}}
-    <OSS::InfiniteSelect
-      @items={{@items}}
-      @onSearch={{this.onSearch}}
-      @onSelect={{this.onSelect}}
-      @searchEnabled={{this.searchEnabled}}
-      @searchPlaceholder={{this.searchPlaceholder}}
-      {{on-click-outside this.onClickOutside useCapture=true}}>
-      <:option as |item|>
-        <div class="item-wrapper fx-row fx-xalign-center fx-malign-space-between {{if (eq @value item) 'selected'}}">
-          {{#if (has-block "option")}}
-            {{yield item to="option"}}
-          {{/if}}
+  {{#if this.isOpen}}
+    {{#in-element this.portalTarget insertBefore=null}}
+      <OSS::InfiniteSelect
+        @items={{@items}}
+        @onSearch={{this.onSearch}}
+        @onSelect={{this.onSelect}}
+        @searchEnabled={{this.searchEnabled}}
+        @searchPlaceholder={{this.searchPlaceholder}}
+        id={{this.portalId}}
+        class="margin-top-px-0"
+        {{on-click-outside this.onClickOutside}}
+        {{on "click" this.noop}}
+      >
+        <:option as |item|>
+          <div class="item-wrapper fx-row fx-xalign-center fx-malign-space-between {{if (eq @value item) 'selected'}}">
+            {{#if (has-block "option")}}
+              {{yield item to="option"}}
+            {{/if}}
 
-          {{#if (eq @value item)}}
-            <OSS::Icon @icon="fa-check" class="font-color-primary-500 padding-right-px-6" />
-          {{/if}}
-        </div>
-      </:option>
-    </OSS::InfiniteSelect>
+            {{#if (eq @value item)}}
+              <OSS::Icon @icon="fa-check" class="font-color-primary-500 padding-right-px-6" />
+            {{/if}}
+          </div>
+        </:option>
+      </OSS::InfiniteSelect>
+    {{/in-element}}
   {{/if}}
 
   {{#if @errorMessage}}
     <div class="font-color-error-500 margin-top-px-6 fx-row fx-gap-px-6 fx-xalign-center">
-      <OSS::Icon @icon="fa-exclamation-triangle" /> {{@errorMessage}}
+      <OSS::Icon @icon="fa-exclamation-triangle" />
+      {{@errorMessage}}
     </div>
   {{/if}}
 
   {{#if @successMessage}}
     <div class="font-color-success-500 margin-top-px-6 fx-row fx-gap-px-6 fx-xalign-center">
-      <OSS::Icon @icon="fa-check-circle" /> {{@successMessage}}
+      <OSS::Icon @icon="fa-check-circle" />
+      {{@successMessage}}
     </div>
   {{/if}}
-</div>
+</details>

--- a/addon/components/o-s-s/select.hbs
+++ b/addon/components/o-s-s/select.hbs
@@ -1,15 +1,13 @@
-<details
+<div
   class={{this.classNames}}
   data-toggle="oss-dropdown"
+  open={{this.isOpen}}
   {{did-insert (fn this.ensureBlockPresence (has-block "option"))}}
   {{did-insert this.registerContainer}}
-  {{on "toggle" this.handleSelectorClose}}
+  {{will-destroy this.disconnectObserver}}
   ...attributes
 >
-  <summary
-    class="upf-input {{if this.isOpen 'active'}} fx-row fx-1 fx-xalign-center"
-    {{on "click" this.toggleDropdown}}
-  >
+  <div class="upf-input {{if this.isOpen 'active'}} fx-row fx-1 fx-xalign-center" {{on "click" this.toggleDropdown}}>
     <div class="fx-row fx-1 fx-malign-space-between fx-xalign-center">
       {{#if @value}}
         {{#if (has-block "selected")}}
@@ -22,7 +20,7 @@
       {{/if}}
       <OSS::Icon @icon="fa-chevron-{{if this.isOpen 'up' 'down'}}" class="margin-left-px-6" />
     </div>
-  </summary>
+  </div>
 
   {{#if this.isOpen}}
     {{#in-element this.portalTarget insertBefore=null}}
@@ -33,7 +31,7 @@
         @searchEnabled={{this.searchEnabled}}
         @searchPlaceholder={{this.searchPlaceholder}}
         id={{this.portalId}}
-        class="margin-top-px-0"
+        class={{concat "margin-top-px-0 oss-select-container__dropdown " this.dropdownAddressableClass}}
         {{on-click-outside this.onClickOutside}}
         {{on "click" this.noop}}
       >
@@ -65,4 +63,4 @@
       {{@successMessage}}
     </div>
   {{/if}}
-</details>
+</div>

--- a/addon/components/o-s-s/select.stories.js
+++ b/addon/components/o-s-s/select.stories.js
@@ -106,7 +106,7 @@ export default {
     },
     addressableAs: {
       description:
-        'A string to use as base to target the portaled-dropdown component in CSS. When provided, you will be able to use `${addressableAs}__dropdown` in CSS.',
+        'A string identifier to use as base to target the portaled-dropdown component in CSS. When provided, you will be able to use `${addressableAs}__dropdown` in CSS.',
       table: {
         type: {
           summary: 'string'

--- a/addon/components/o-s-s/select.stories.js
+++ b/addon/components/o-s-s/select.stories.js
@@ -103,6 +103,15 @@ export default {
           summary: 'onSearch(keyword: string): void'
         }
       }
+    },
+    addressableAs: {
+      description:
+        'A string to use as base to target the portaled-dropdown component in CSS. When provided, you will be able to use `${addressableAs}__dropdown` in CSS.',
+      table: {
+        type: {
+          summary: 'string'
+        }
+      }
     }
   },
   parameters: {
@@ -123,6 +132,7 @@ const defaultArgs = {
   disabled: false,
   errorMessage: undefined,
   successMessage: undefined,
+  addressableAs: undefined,
   onSearch: action('onSearch'),
   onChange: action('onChange')
 };
@@ -149,7 +159,7 @@ const WithSelectedNamedBlockTemplate = (args) => ({
     <OSS::Select
       @items={{this.items}} @value={{this.value}} @placeholder={{this.placeholder}}
       @disabled={{this.disabled}} @errorMessage={{this.errorMessage}} @successMessage={{this.successMessage}}
-      @onSearch={{this.onSearch}} @onChange={{this.onChange}}>
+      @onSearch={{this.onSearch}} @onChange={{this.onChange}} @addressableAs={{this.addressableAs}}>
       <:selected as |option|>
         With named block — {{option.name}}
       </:selected>

--- a/addon/components/o-s-s/select.ts
+++ b/addon/components/o-s-s/select.ts
@@ -1,10 +1,15 @@
-import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { assert } from '@ember/debug';
 import { action } from '@ember/object';
+import { guidFor } from '@ember/object/internals';
 import { inject as service } from '@ember/service';
 import { isEmpty } from '@ember/utils';
+import { scheduleOnce } from '@ember/runloop';
+import { isTesting } from '@embroider/macros';
+
 import type IntlService from 'ember-intl/services/intl';
+import attachDropdown from '@upfluence/oss-components/utils/attach-dropdown';
+import BaseDropdown from './private/base-dropdown';
 
 interface OSSSelectArgs {
   value: any;
@@ -18,10 +23,15 @@ interface OSSSelectArgs {
   onSearch?(keyword: string): void;
 }
 
-export default class OSSSelect extends Component<OSSSelectArgs> {
+export default class OSSSelect extends BaseDropdown<OSSSelectArgs> {
   @service declare intl: IntlService;
 
   @tracked displaySelect: boolean = false;
+
+  cleanupDrodpownAutoplacement?: () => void;
+  portalId: string = guidFor(this);
+
+  declare portalTarget: HTMLElement;
 
   constructor(owner: unknown, args: OSSSelectArgs) {
     super(owner, args);
@@ -66,6 +76,10 @@ export default class OSSSelect extends Component<OSSSelectArgs> {
     return classes.join(' ');
   }
 
+  noop(event: Event): void {
+    event.stopPropagation();
+  }
+
   @action
   onSelect(value: any): void {
     this.args.onChange(value);
@@ -78,16 +92,27 @@ export default class OSSSelect extends Component<OSSSelectArgs> {
   }
 
   @action
-  toggleSelector(event: PointerEvent): void {
-    event.stopPropagation();
-
+  toggleDropdown(event: PointerEvent): void {
     if (this.args.disabled) return;
 
-    if (this.displaySelect) {
-      this.hideSelector();
-    } else {
-      this.displaySelect = true;
+    super.toggleDropdown(event);
+
+    if (!this.isOpen) {
+      this.args.onSearch?.('');
+      return;
     }
+
+    scheduleOnce('afterRender', this, () => {
+      const referenceTarget = this.container.querySelector('.upf-input');
+      const floatingTarget = document.querySelector(`#${this.portalId}`);
+
+      if (referenceTarget && floatingTarget) {
+        this.cleanupDrodpownAutoplacement = attachDropdown(
+          referenceTarget as HTMLElement,
+          floatingTarget as HTMLElement
+        );
+      }
+    });
   }
 
   @action
@@ -98,8 +123,23 @@ export default class OSSSelect extends Component<OSSSelectArgs> {
 
   @action
   hideSelector(): void {
-    this.displaySelect = false;
+    this.closeDropdown();
     this.args.onSearch?.('');
+    this.cleanupDrodpownAutoplacement?.();
+    document.querySelector(`#${this.portalId}`)?.remove();
+  }
+
+  @action
+  handleSelectorClose(event: ToggleEvent & { target: HTMLDetailsElement }): void {
+    if (!event.target.open) {
+      this.hideSelector();
+    }
+  }
+
+  @action
+  registerContainer(element: HTMLDetailsElement): void {
+    super.registerContainer(element);
+    this.portalTarget = isTesting() ? this.container : document.body;
   }
 
   @action

--- a/addon/components/o-s-s/select.ts
+++ b/addon/components/o-s-s/select.ts
@@ -130,10 +130,8 @@ export default class OSSSelect extends BaseDropdown<OSSSelectArgs> {
   }
 
   @action
-  handleSelectorClose(event: ToggleEvent & { target: HTMLDetailsElement }): void {
-    if (!event.target.open) {
-      this.hideSelector();
-    }
+  handleSelectorClose(): void {
+    this.hideSelector();
   }
 
   @action

--- a/addon/components/o-s-s/select.ts
+++ b/addon/components/o-s-s/select.ts
@@ -19,6 +19,7 @@ interface OSSSelectArgs {
   disabled?: boolean;
   errorMessage?: string;
   successMessage?: string;
+  addressableAs?: string;
   onChange(value: any): void;
   onSearch?(keyword: string): void;
 }
@@ -74,6 +75,10 @@ export default class OSSSelect extends BaseDropdown<OSSSelectArgs> {
     }
 
     return classes.join(' ');
+  }
+
+  get dropdownAddressableClass(): string {
+    return this.args.addressableAs ? `${this.args.addressableAs}__dropdown` : '';
   }
 
   noop(event: Event): void {
@@ -135,7 +140,7 @@ export default class OSSSelect extends BaseDropdown<OSSSelectArgs> {
   }
 
   @action
-  registerContainer(element: HTMLDetailsElement): void {
+  registerContainer(element: HTMLElement): void {
     super.registerContainer(element);
     this.portalTarget = isTesting() ? this.container : document.body;
   }

--- a/addon/components/o-s-s/select.ts
+++ b/addon/components/o-s-s/select.ts
@@ -1,7 +1,6 @@
 import { tracked } from '@glimmer/tracking';
 import { assert } from '@ember/debug';
 import { action } from '@ember/object';
-import { guidFor } from '@ember/object/internals';
 import { inject as service } from '@ember/service';
 import { isEmpty } from '@ember/utils';
 import { scheduleOnce } from '@ember/runloop';
@@ -30,9 +29,6 @@ export default class OSSSelect extends BaseDropdown<OSSSelectArgs> {
   @tracked displaySelect: boolean = false;
 
   cleanupDrodpownAutoplacement?: () => void;
-  portalId: string = guidFor(this);
-
-  declare portalTarget: HTMLElement;
 
   constructor(owner: unknown, args: OSSSelectArgs) {
     super(owner, args);
@@ -79,10 +75,6 @@ export default class OSSSelect extends BaseDropdown<OSSSelectArgs> {
 
   get dropdownAddressableClass(): string {
     return this.args.addressableAs ? `${this.args.addressableAs}__dropdown` : '';
-  }
-
-  noop(event: Event): void {
-    event.stopPropagation();
   }
 
   @action
@@ -137,12 +129,6 @@ export default class OSSSelect extends BaseDropdown<OSSSelectArgs> {
   @action
   handleSelectorClose(): void {
     this.hideSelector();
-  }
-
-  @action
-  registerContainer(element: HTMLElement): void {
-    super.registerContainer(element);
-    this.portalTarget = isTesting() ? this.container : document.body;
   }
 
   @action

--- a/addon/utils/attach-dropdown.ts
+++ b/addon/utils/attach-dropdown.ts
@@ -12,12 +12,14 @@ import {
 export type AttachmentOptions = {
   offset?: number;
   width?: number;
+  maxHeight?: number;
   placement?: Placement;
 };
 
 const DEFAULT_ATTACHMENT_OPTIONS: AttachmentOptions = {
   offset: 12,
   width: undefined,
+  maxHeight: undefined,
   placement: 'bottom'
 };
 
@@ -26,22 +28,31 @@ export default function attachDropdown(
   floatingTarget: HTMLElement,
   options: AttachmentOptions = DEFAULT_ATTACHMENT_OPTIONS
 ) {
+  const mergedOptions = { ...DEFAULT_ATTACHMENT_OPTIONS, ...(options || {}) };
+
   const updatePosition = () => {
     computePosition(referenceTarget, floatingTarget, {
-      placement: options.placement ?? 'bottom',
+      placement: mergedOptions.placement ?? 'bottom',
       middleware: [
-        offset(options.offset ?? 0),
+        offset(mergedOptions.offset ?? 0),
         flip({
           fallbackPlacements: ['top', 'bottom']
         }),
         size({
           apply({ rects, elements }: MiddlewareState) {
-            const desiredWidth = options.width ?? rects.reference.width;
-            Object.assign(elements.floating.style, {
+            const desiredWidth = mergedOptions.width ?? rects.reference.width;
+            const floatingStyle: Record<string, string> = {
               maxWidth: `${desiredWidth}px`,
               minWidth: `${desiredWidth}px`,
               width: `${desiredWidth}px`
-            });
+            };
+
+            if (mergedOptions.maxHeight) {
+              floatingStyle.maxHeight = `${floatingStyle.maxHeight}px`;
+              elements.floating.style.setProperty('--floating-max-height', `${mergedOptions.maxHeight}px`);
+            }
+
+            Object.assign(elements.floating.style, floatingStyle);
           }
         }),
         hide()

--- a/app/styles/base/_infinite-select.less
+++ b/app/styles/base/_infinite-select.less
@@ -9,7 +9,7 @@
 
 .upf-infinite-select--absolute {
   .upf-floating-menu;
-  height: inherit;
+  height: auto;
 }
 
 .upf-infinite-select__container {

--- a/app/styles/molecules/select.less
+++ b/app/styles/molecules/select.less
@@ -75,7 +75,6 @@
 }
 
 .oss-select-container__dropdown {
-  margin-top: var(--spacing-px-6);
   max-width: 100%;
   min-width: 100%;
   padding: var(--spacing-px-12);

--- a/app/styles/molecules/select.less
+++ b/app/styles/molecules/select.less
@@ -72,23 +72,23 @@
       border-color: var(--color-success-500);
     }
   }
+}
 
-  .upf-infinite-select {
-    margin-top: var(--spacing-px-6);
-    max-width: 100%;
-    min-width: 100%;
-    padding: var(--spacing-px-12);
+.oss-select-container__dropdown {
+  margin-top: var(--spacing-px-6);
+  max-width: 100%;
+  min-width: 100%;
+  padding: var(--spacing-px-12);
 
-    .upf-infinite-select__item {
-      padding: 0;
+  .upf-infinite-select__item {
+    padding: 0;
 
-      .item-wrapper {
-        padding: var(--spacing-px-6) var(--spacing-px-6);
-        border-radius: var(--border-radius-sm);
+    .item-wrapper {
+      padding: var(--spacing-px-6) var(--spacing-px-6);
+      border-radius: var(--border-radius-sm);
 
-        &.selected {
-          background-color: var(--color-gray-100);
-        }
+      &.selected {
+        background-color: var(--color-gray-100);
       }
     }
   }

--- a/app/styles/power-select.less
+++ b/app/styles/power-select.less
@@ -16,15 +16,6 @@
     }
   }
 
-  .upf-infinite-select {
-    top: 0;
-    left: 0;
-    height: auto;
-    width: max-content;
-    margin-top: 0;
-    padding: var(--spacing-px-12);
-  }
-
   .upf-power-infinite-select-container {
     position: relative;
     height: 100%;
@@ -38,5 +29,19 @@
 
   .has-overflow {
     padding-bottom: @spacing-x-sm;
+  }
+}
+
+.upf-power-select__dropdown {
+  overflow: hidden;
+
+  .upf-infinite-select__container {
+    max-height: var(--floating-max-height);
+  }
+
+  &:has(.upf-input) {
+    .upf-infinite-select__items-container {
+      max-height: calc(var(--floating-max-height) - 62px);
+    }
   }
 }

--- a/app/styles/power-select.less
+++ b/app/styles/power-select.less
@@ -1,6 +1,5 @@
 .upf-power-select {
   height: 100%;
-  position: relative;
 
   .upf-power-select__array-container {
     position: relative;
@@ -18,11 +17,12 @@
   }
 
   .upf-infinite-select {
+    top: 0;
+    left: 0;
     height: auto;
-    max-width: 100%;
-    min-width: 100%;
+    width: max-content;
+    margin-top: 0;
     padding: var(--spacing-px-12);
-    top: var(--spacing-px-36);
   }
 
   .upf-power-infinite-select-container {

--- a/tests/integration/components/o-s-s/power-select-test.ts
+++ b/tests/integration/components/o-s-s/power-select-test.ts
@@ -34,9 +34,9 @@ module('Integration | Component | o-s-s/power-select', function (hooks) {
 
       assert.dom('.upf-power-select').exists({ count: 1 });
       assert.dom('.upf-power-select__array-container').exists({ count: 1 });
-      assert.dom('.upf-infinite-select').doesNotExist();
+      assert.dom('.upf-power-select').hasNoAttribute('open');
       await click('.upf-power-select__array-container');
-      assert.dom('.upf-infinite-select').exists();
+      assert.dom('.upf-power-select').hasAttribute('open');
     });
 
     test('custom empty state is properly rendered', async function (assert) {
@@ -57,9 +57,9 @@ module('Integration | Component | o-s-s/power-select', function (hooks) {
 
       assert.dom('.upf-power-select').exists({ count: 1 });
       assert.dom('.upf-power-select__array-container').exists({ count: 1 });
-      assert.dom('.upf-infinite-select').doesNotExist();
+      assert.dom('.upf-power-select').hasNoAttribute('open');
       await click('.upf-power-select__array-container');
-      assert.dom('.upf-infinite-select').exists();
+      assert.dom('.upf-power-select').hasAttribute('open');
       assert.dom('.foobar').exists();
       assert.dom('.foobar').hasText('custom empty state');
     });

--- a/tests/integration/components/o-s-s/power-select-test.ts
+++ b/tests/integration/components/o-s-s/power-select-test.ts
@@ -244,6 +244,31 @@ module('Integration | Component | o-s-s/power-select', function (hooks) {
     });
   });
 
+  module('with @addressableAs', (hooks) => {
+    hooks.beforeEach(function () {
+      this.items = ['value1', 'value2', 'value3'];
+    });
+
+    test('the dropdown has the right class assigned to it', async function (assert) {
+      await render(hbs`
+        <div style="height:150px">
+          <OSS::PowerSelect @selectedItems={{this.selectedItems}} @items={{this.items}} @onSearch={{this.onSearch}} @addressableAs="foobar-select">
+            <:selected-item as |selectedItem|>
+              {{selectedItem}}
+            </:selected-item>
+            <:option-item as |item|>
+              {{item}}
+            </:option-item>
+          </OSS::PowerSelect>
+        </div>
+      `);
+
+      await click('.upf-power-select__array-container');
+      assert.dom('.upf-infinite-select').exists();
+      assert.dom('.upf-infinite-select').hasClass('foobar-select__dropdown');
+    });
+  });
+
   module('Error management', () => {
     test('without selected-item named block', async function (assert) {
       setupOnerror((err: any) => {

--- a/tests/integration/components/o-s-s/select-test.ts
+++ b/tests/integration/components/o-s-s/select-test.ts
@@ -281,6 +281,24 @@ module('Integration | Component | o-s-s/select', function (hooks) {
     });
   });
 
+  module('with @addressableAs', () => {
+    test('the dropdown has the right class assigned to it', async function (assert) {
+      await render(
+        hbs`
+          <OSS::Select @onChange={{this.onChange}} @items={{this.items}} @value={{this.value}} @addressableAs="foobar-select">
+            <:option as |item|>
+              {{item.name}}
+            </:option>
+          </OSS::Select>
+        `
+      );
+
+      await click('.upf-input div');
+      assert.dom('.upf-infinite-select').exists();
+      assert.dom('.upf-infinite-select').hasClass('foobar-select__dropdown');
+    });
+  });
+
   module('Error management', function () {
     test('it throws an error if no @onChange arg is passed', async function (assert) {
       setupOnerror((err: Error) => {


### PR DESCRIPTION
This reverts commit fe847cd33f2f4c367cbeecfc6cbb20cfbc995f31, reversing changes made to 7ccf9e6ef54241ea4c69cc87e1aaea10ebeff3b6.

### What does this PR do?

Reintroduce `OSS::Select` & `OSS::PowerSelect` updates w/ portaled-dropdowns and:
- automatic positioning
- exclusive dropdowns (prevent having two dropdowns displayed at once — this only concerns those extending the `BaseDropdown` class) 
- CSS-targetable dropdowns via the `addressableAs` arg (to style them easily despite them being renderered in a portal) 

Compared to the initial implementation, I finally ended up letting the `div` elements instead of using `details/summary`. However, I decided to replicate the `open` attribute that came in handy and is added on the component when the dropdown is being displayed.
To keep them in sync and update the `isOpen` tracked prop accordingly, I use a `MutationObserver` which allows us to track whether or not the `open` attribute is present or not.

### What are the observable changes?
<!-- This question could be adequate with multiple use cases, for example: -->

<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [x] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled
