### PR TITLE
Add disabled class for square button

### DIFF
--- a/app/styles/atoms/button.less
+++ b/app/styles/atoms/button.less
@@ -64,6 +64,7 @@
     transition: background-color 0.25s ease-in-out, border-color 0.25s ease-in-out, color 0.25s ease-in-out;
   }
 
+  &.disabled,
   &:disabled {
     .disabled-button;
   }


### PR DESCRIPTION
### What does this PR do?

Add disabled class for square button. The disabled doesn't exist when we add the `@square={{true}}` to `OSS::Button`

### What are the observable changes?

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled
