### PR TITLE
Modal dialog: Add params to disable clickOutside

### DIFF
--- a/addon/components/o-s-s/modal-dialog.stories.js
+++ b/addon/components/o-s-s/modal-dialog.stories.js
@@ -57,6 +57,17 @@ export default {
         defaultValue: { summary: 'undefined' }
       },
       control: { type: 'boolean' }
+    },
+    disableClickOutside: {
+      description:
+        '[OPTIONAL] Disable or not the ability to close the modal when clicking outside of the modal dialog.',
+      table: {
+        type: {
+          summary: 'boolean'
+        },
+        defaultValue: { summary: 'false' }
+      },
+      control: { type: 'boolean' }
     }
   },
   parameters: {
@@ -76,13 +87,14 @@ const defaultArgs = {
   subtitle: 'This is a subtitle',
   size: 'sm',
   close: action('close'),
-  enqueue: undefined
+  enqueue: undefined,
+  disableClickOutside: undefined
 };
 
 const BasicUsageTemplate = (args) => ({
   template: hbs`
       <OSS::ModalDialog @title={{this.title}} @close={{this.close}} @subtitle={{this.subtitle}} @size={{this.size}} 
-                        @enqueue={{this.enqueue}}>
+                        @enqueue={{this.enqueue}} @disableClickOutside={{this.disableClickOutside}}>
         <:content>
           Content goes here
         </:content>
@@ -97,7 +109,7 @@ const BasicUsageTemplate = (args) => ({
 const WithIllustrationTemplate = (args) => ({
   template: hbs`
       <OSS::ModalDialog @title={{this.title}} @close={{this.close}} @subtitle={{this.subtitle}} @size={{this.size}} 
-                        @enqueue={{this.enqueue}}>
+                        @enqueue={{this.enqueue}} @disableClickOutside={{this.disableClickOutside}}>
         <:illustration>
           This will contain an illustration.
         </:illustration>

--- a/addon/components/o-s-s/modal-dialog.ts
+++ b/addon/components/o-s-s/modal-dialog.ts
@@ -1,6 +1,5 @@
 import { tracked } from '@glimmer/tracking';
 import { assert } from '@ember/debug';
-import { action } from '@ember/object';
 
 import BaseModal, { type BaseModalArgs } from './private/base-modal';
 
@@ -9,7 +8,6 @@ export interface OSSModalDialogArgs extends BaseModalArgs {
   subtitle?: string;
   size?: 'sm' | 'md';
   enqueue?: boolean;
-  disableClickOutside?: boolean;
 }
 
 export default class OSSModalDialog extends BaseModal<OSSModalDialogArgs> {
@@ -43,12 +41,5 @@ export default class OSSModalDialog extends BaseModal<OSSModalDialogArgs> {
       return;
     }
     this.displayModal = true;
-  }
-
-  @action
-  onClickOutside(_: any, event: Event): void {
-    if (!this.args.disableClickOutside) {
-      super.onClickOutside(_, event);
-    }
   }
 }

--- a/addon/components/o-s-s/modal-dialog.ts
+++ b/addon/components/o-s-s/modal-dialog.ts
@@ -1,5 +1,6 @@
 import { tracked } from '@glimmer/tracking';
 import { assert } from '@ember/debug';
+import { action } from '@ember/object';
 
 import BaseModal, { type BaseModalArgs } from './private/base-modal';
 
@@ -8,6 +9,7 @@ export interface OSSModalDialogArgs extends BaseModalArgs {
   subtitle?: string;
   size?: 'sm' | 'md';
   enqueue?: boolean;
+  disableClickOutside?: boolean;
 }
 
 export default class OSSModalDialog extends BaseModal<OSSModalDialogArgs> {
@@ -41,5 +43,12 @@ export default class OSSModalDialog extends BaseModal<OSSModalDialogArgs> {
       return;
     }
     this.displayModal = true;
+  }
+
+  @action
+  onClickOutside(_: any, event: Event): void {
+    if (!this.args.disableClickOutside) {
+      super.onClickOutside(_, event);
+    }
   }
 }

--- a/addon/components/o-s-s/private/base-modal.ts
+++ b/addon/components/o-s-s/private/base-modal.ts
@@ -5,6 +5,7 @@ import Component from '@glimmer/component';
 
 export interface BaseModalArgs {
   close(): void;
+  disableClickOutside?: boolean;
 }
 
 export default class BaseModal<T extends BaseModalArgs> extends Component<T> {
@@ -65,6 +66,8 @@ export default class BaseModal<T extends BaseModalArgs> extends Component<T> {
 
   @action
   onClickOutside(_: any, event: Event): void {
+    if (this.args.disableClickOutside) return;
+
     if (event.target === this.initialTarget) {
       this.closeModal();
     }

--- a/addon/components/o-s-s/split-modal.stories.js
+++ b/addon/components/o-s-s/split-modal.stories.js
@@ -13,6 +13,17 @@ export default {
           summary: 'close(): void'
         }
       }
+    },
+    disableClickOutside: {
+      description:
+        '[OPTIONAL] Disable or not the ability to close the modal when clicking outside of the modal dialog.',
+      table: {
+        type: {
+          summary: 'boolean'
+        },
+        defaultValue: { summary: 'false' }
+      },
+      control: { type: 'boolean' }
     }
   },
   parameters: {
@@ -32,12 +43,13 @@ export default {
 };
 
 const defaultArgs = {
-  close: action('close')
+  close: action('close'),
+  disableClickOutside: false
 };
 
 const BasicUsageTemplate = (args) => ({
   template: hbs`
-      <OSS::SplitModal @close={{this.close}}>
+      <OSS::SplitModal @close={{this.close}} @disableClickOutside={{this.disableClickOutside}}>
         <:content>
           Content goes here
         </:content>

--- a/addon/components/o-s-s/split-modal.ts
+++ b/addon/components/o-s-s/split-modal.ts
@@ -1,10 +1,8 @@
 import { assert } from '@ember/debug';
 
-import BaseModal from './private/base-modal';
+import BaseModal, { type BaseModalArgs } from './private/base-modal';
 
-interface OSSSplitModalArgs {
-  close(): void;
-}
+interface OSSSplitModalArgs extends BaseModalArgs {}
 
 export default class OSSSplitModal extends BaseModal<OSSSplitModalArgs> {
   constructor(owner: unknown, args: OSSSplitModalArgs) {

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -501,7 +501,7 @@
     <div class="fx-col fx-gap-px-12 margin-md">
       <OSS::Button @skin="primary" @size="md" @label="Open MODAL" @icon="fa fa-unicorn" {{on "click" this.openModal}} />
       {{#if this.showModal}}
-        <OSS::ModalDialog @title="Example modal" @subtitle="subtitle" @close={{this.closeModal}} @size="md">
+        <OSS::ModalDialog @title="Example modal" @subtitle="subtitle" @close={{this.closeModal}} @disableClickOutside={{true}} @size="md">
           <:content>
             <div style="height: 200px; background-color: white">
               azeazeazeaze

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -501,7 +501,7 @@
     <div class="fx-col fx-gap-px-12 margin-md">
       <OSS::Button @skin="primary" @size="md" @label="Open MODAL" @icon="fa fa-unicorn" {{on "click" this.openModal}} />
       {{#if this.showModal}}
-        <OSS::ModalDialog @title="Example modal" @subtitle="subtitle" @close={{this.closeModal}} @disableClickOutside={{true}} @size="md">
+        <OSS::ModalDialog @title="Example modal" @subtitle="subtitle" @close={{this.closeModal}} @disableClickOutside={{false}} @size="md">
           <:content>
             <div style="height: 200px; background-color: white">
               azeazeazeaze

--- a/tests/integration/components/o-s-s/modal-dialog-test.ts
+++ b/tests/integration/components/o-s-s/modal-dialog-test.ts
@@ -205,6 +205,30 @@ module('Integration | Component | o-s-s/modal-dialog', function (hooks) {
     assert.dom('[data-control-name="modal-b"]').exists();
   });
 
+  module('Clicking outside', function () {
+    test('It triggers the close action', async function (assert) {
+      await render(
+        hbs`<OSS::ModalDialog @title="MODAL A" @subtitle="subtitle" @close={{this.closeModal}}
+                              data-control-name="modal-a" />`
+      );
+
+      assert.ok(this.closeModal.notCalled);
+      await click('.oss-modal-dialog-backdrop');
+      assert.ok(this.closeModal.calledOnce);
+    });
+
+    test('If the disableClickOutside parameter is truthy, it does not trigger the close action', async function (assert) {
+      await render(
+        hbs`<OSS::ModalDialog @title="MODAL A" @subtitle="subtitle" @close={{this.closeModal}}
+                              data-control-name="modal-a" @disableClickOutside={{true}}/>`
+      );
+
+      assert.ok(this.closeModal.notCalled);
+      await click('.oss-modal-dialog-backdrop');
+      assert.ok(this.closeModal.notCalled);
+    });
+  });
+
   module('Error management', function () {
     test('The component throws an error if the title parameter is not passed', async function (assert) {
       setupOnerror((err: any) => {

--- a/tests/integration/components/o-s-s/split-modal-test.ts
+++ b/tests/integration/components/o-s-s/split-modal-test.ts
@@ -69,6 +69,24 @@ module('Integration | Component | o-s-s/split-modal', function (hooks) {
     assert.true(this.closeModal.calledOnce);
   });
 
+  module('Clicking outside', function () {
+    test('It triggers the close action', async function (assert) {
+      await render(hbs`<OSS::SplitModal @close={{this.closeModal}}></OSS::SplitModal>`);
+
+      assert.ok(this.closeModal.notCalled);
+      await click('.oss-modal-dialog-backdrop');
+      assert.ok(this.closeModal.calledOnce);
+    });
+
+    test('If the disableClickOutside parameter is truthy, it does not trigger the close action', async function (assert) {
+      await render(hbs`<OSS::SplitModal @close={{this.closeModal}} @disableClickOutside={{true}}></OSS::SplitModal>`);
+
+      assert.ok(this.closeModal.notCalled);
+      await click('.oss-modal-dialog-backdrop');
+      assert.ok(this.closeModal.notCalled);
+    });
+  });
+
   module('Error management', function () {
     test('The component throws an error if the close parameter is not passed', async function (assert) {
       setupOnerror((err: any) => {


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the context of this pull request and its purpose. -->

Related to: #[DRA-651](https://linear.app/upfluence/issue/DRA-651/prevent-click-from-closing-some-modals-if-an-action-was-performed)

### What are the observable changes?
<!-- This question could be adequate with multiple use cases, for example: -->
New optional params `disableClickOutside`
<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->

### Good PR checklist
- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [x] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled
