### PR TITLE
POC: Popover Replacement by Jquery Free 

### DIFF
--- a/addon/modifiers/enable-popover.js
+++ b/addon/modifiers/enable-popover.js
@@ -17,9 +17,10 @@ export default setModifierManager(
 
       const handleMouseEnter = () => {
         const popover = document.createElement('div');
-        popover.textContent = 'azeazeazeaze new';
         popover.classList.add('oss--popover');
         popover.setAttribute('role', 'tooltip');
+
+        const placement = element.getAttribute('data-placement') || 'top';
 
         if (element.getAttribute('data-title')) {
           const titleNode = document.createTextNode(element.getAttribute('data-title'));
@@ -35,6 +36,37 @@ export default setModifierManager(
         }
 
         element.appendChild(popover);
+
+        const parentRect = element.getBoundingClientRect();
+        const popoverRect = popover.getBoundingClientRect();
+
+        let left, top;
+
+        switch (placement) {
+          case 'top':
+            top = parentRect.top - popoverRect.height;
+            left = parentRect.left + parentRect.width / 2 - popoverRect.width / 2;
+            break;
+          case 'bottom':
+            top = parentRect.bottom;
+            left = parentRect.left + parentRect.width / 2 - popoverRect.width / 2;
+            break;
+          case 'left':
+            top = parentRect.top + parentRect.height / 2 - popoverRect.height / 2;
+            left = parentRect.left - popoverRect.width;
+            break;
+          case 'right':
+            top = parentRect.top + parentRect.height / 2 - popoverRect.height / 2;
+            left = parentRect.right;
+            break;
+          default:
+            top = parentRect.top - popoverRect.height;
+            left = parentRect.left + parentRect.width / 2 - popoverRect.width / 2;
+            break;
+        }
+
+        popover.style.left = left + 'px';
+        popover.style.top = top + 'px';
 
         state.handleMouseLeave = () => {
           popover.remove();

--- a/addon/modifiers/enable-popover.js
+++ b/addon/modifiers/enable-popover.js
@@ -1,5 +1,4 @@
 import { setModifierManager, capabilities } from '@ember/modifier';
-import jQuery from 'jquery';
 
 export default setModifierManager(
   () => ({
@@ -8,20 +7,65 @@ export default setModifierManager(
     createModifier() {
       return {
         element: null,
-        handler: null
+        handleMouseEnter: null,
+        handleMouseLeave: null
       };
     },
 
-    installModifier(state, element, { positional: [trigger] }) {
+    installModifier(state, element, { positional: [trigger = 'hover'] }) {
       state.element = element;
-      trigger ??= 'hover';
 
-      jQuery(element).popover({ trigger });
+      const handleMouseEnter = () => {
+        const popover = document.createElement('div');
+        popover.textContent = 'azeazeazeaze new';
+        popover.classList.add('oss--popover');
+        popover.setAttribute('role', 'tooltip');
+
+        if (element.getAttribute('data-title')) {
+          const titleNode = document.createTextNode(element.getAttribute('data-title'));
+          const titleDiv = document.createElement('div');
+          titleDiv.appendChild(titleNode);
+          popover.appendChild(titleDiv);
+        }
+        if (element.getAttribute('data-content')) {
+          const contentNode = document.createTextNode(element.getAttribute('data-content'));
+          const contentDiv = document.createElement('div');
+          contentDiv.appendChild(contentNode);
+          popover.appendChild(contentDiv);
+        }
+
+        element.appendChild(popover);
+
+        state.handleMouseLeave = () => {
+          popover.remove();
+          element.removeEventListener('mouseleave', state.handleMouseLeave);
+        };
+
+        element.addEventListener('mouseleave', state.handleMouseLeave);
+      };
+
+      state.handleMouseEnter = handleMouseEnter;
+      element.addEventListener(trigger === 'hover' ? 'mouseenter' : trigger, handleMouseEnter);
     },
 
-    destroyModifier() {
-      // We don't need to do anything here, but a function
-      // still has to be here so we'll leave it blank.
+    updateModifier(state, { positional: [trigger = 'hover'] }) {
+      if (state.handleMouseEnter) {
+        state.element.removeEventListener(trigger === 'hover' ? 'mouseenter' : trigger, state.handleMouseEnter);
+        state.handleMouseEnter = () => {
+          state.element.addEventListener(trigger === 'hover' ? 'mouseenter' : trigger, state.handleMouseEnter);
+        };
+        state.handleMouseEnter();
+      }
+    },
+
+    destroyModifier(state) {
+      if (state.handleMouseEnter) {
+        state.element.removeEventListener('mouseleave', state.handleMouseLeave);
+        state.element.removeEventListener(
+          state.trigger === 'hover' ? 'mouseenter' : state.trigger,
+          state.handleMouseEnter
+        );
+      }
     }
   }),
   class EnablePopoverModifierManager {}

--- a/addon/modifiers/enable-popover.js
+++ b/addon/modifiers/enable-popover.js
@@ -17,20 +17,22 @@ export default setModifierManager(
 
       const handleMouseEnter = () => {
         const popover = document.createElement('div');
-        popover.classList.add('oss--popover');
+        popover.classList.add('oss--popover', 'fade-in');
         popover.setAttribute('role', 'tooltip');
-
         const placement = element.getAttribute('data-placement') || 'top';
+        popover.classList.add(placement);
 
         if (element.getAttribute('data-title')) {
           const titleNode = document.createTextNode(element.getAttribute('data-title'));
           const titleDiv = document.createElement('div');
+          titleDiv.classList.add('font-weight-semibold', 'font-size-md', 'font-color-gray-900');
           titleDiv.appendChild(titleNode);
           popover.appendChild(titleDiv);
         }
         if (element.getAttribute('data-content')) {
           const contentNode = document.createTextNode(element.getAttribute('data-content'));
           const contentDiv = document.createElement('div');
+          contentDiv.classList.add('font-color-gray-500');
           contentDiv.appendChild(contentNode);
           popover.appendChild(contentDiv);
         }
@@ -40,30 +42,7 @@ export default setModifierManager(
         const parentRect = element.getBoundingClientRect();
         const popoverRect = popover.getBoundingClientRect();
 
-        let left, top;
-
-        switch (placement) {
-          case 'top':
-            top = parentRect.top - popoverRect.height;
-            left = parentRect.left + parentRect.width / 2 - popoverRect.width / 2;
-            break;
-          case 'bottom':
-            top = parentRect.bottom;
-            left = parentRect.left + parentRect.width / 2 - popoverRect.width / 2;
-            break;
-          case 'left':
-            top = parentRect.top + parentRect.height / 2 - popoverRect.height / 2;
-            left = parentRect.left - popoverRect.width;
-            break;
-          case 'right':
-            top = parentRect.top + parentRect.height / 2 - popoverRect.height / 2;
-            left = parentRect.right;
-            break;
-          default:
-            top = parentRect.top - popoverRect.height;
-            left = parentRect.left + parentRect.width / 2 - popoverRect.width / 2;
-            break;
-        }
+        const { left, top } = this.calculatePosition(parentRect, popoverRect, placement);
 
         popover.style.left = left + 'px';
         popover.style.top = top + 'px';
@@ -98,6 +77,35 @@ export default setModifierManager(
           state.handleMouseEnter
         );
       }
+    },
+
+    calculatePosition(parentRect, popoverRect, placement) {
+      let left, top;
+
+      switch (placement) {
+        case 'top':
+          top = parentRect.top - popoverRect.height - 12;
+          left = parentRect.left + parentRect.width / 2 - popoverRect.width / 2;
+          break;
+        case 'bottom':
+          top = parentRect.bottom + 12;
+          left = parentRect.left + parentRect.width / 2 - popoverRect.width / 2;
+          break;
+        case 'left':
+          top = parentRect.top + parentRect.height / 2 - popoverRect.height / 2;
+          left = parentRect.left - popoverRect.width - 12;
+          break;
+        case 'right':
+          top = parentRect.top + parentRect.height / 2 - popoverRect.height / 2;
+          left = parentRect.right + 12;
+          break;
+        default:
+          top = parentRect.top - popoverRect.height;
+          left = parentRect.left + parentRect.width / 2 - popoverRect.width / 2;
+          break;
+      }
+
+      return { left, top };
     }
   }),
   class EnablePopoverModifierManager {}

--- a/app/styles/base/_all.less
+++ b/app/styles/base/_all.less
@@ -19,3 +19,4 @@
 @import '_toggle-switch';
 @import '_floating-menu';
 @import '_infinite-select';
+@import '_popover';

--- a/app/styles/base/_popover.less
+++ b/app/styles/base/_popover.less
@@ -1,0 +1,24 @@
+.oss--popover {
+  position: absolute;
+  background-color: white;
+  z-index: 9999;
+  padding: var(--spacing-px-12);
+  border-radius: var(--border-radius-md);
+
+  &::after {
+    content: '';
+    position: absolute;
+    width: 0;
+    height: 0;
+    border-left: var(--spacing-px-12) solid transparent;
+    border-right: var(--spacing-px-12) solid transparent;
+    border-bottom: var(--spacing-px-12) solid #fff;
+  }
+
+  &.right::after {
+    top: 50%;
+    left: auto;
+    right: calc(100% - var(--spacing-px-12));
+    transform: translateY(-50%) rotate(-90deg);
+  }
+}

--- a/app/styles/base/_popover.less
+++ b/app/styles/base/_popover.less
@@ -1,9 +1,11 @@
 .oss--popover {
   position: absolute;
-  background-color: white;
+  border-radius: var(--border-radius-md);
+  background-color: var(--color-white);
   z-index: 9999;
   padding: var(--spacing-px-12);
   border-radius: var(--border-radius-md);
+  box-shadow: var(--box-shadow-lg);
 
   &::after {
     content: '';
@@ -12,7 +14,7 @@
     height: 0;
     border-left: var(--spacing-px-12) solid transparent;
     border-right: var(--spacing-px-12) solid transparent;
-    border-bottom: var(--spacing-px-12) solid #fff;
+    border-bottom: var(--spacing-px-6) solid white;
   }
 
   &.right::after {
@@ -21,4 +23,38 @@
     right: calc(100% - var(--spacing-px-12));
     transform: translateY(-50%) rotate(-90deg);
   }
+
+  &.bottom::after {
+    top: auto;
+    bottom: 100%;
+    left: 50%;
+    transform: translateX(-50%) rotate(0deg);
+  }
+
+  &.left::after {
+    top: 50%;
+    right: auto;
+    left: calc(100% - var(--spacing-px-12));
+    transform: translateY(-50%) rotate(90deg);
+  }
+
+  &.top::after {
+    bottom: auto;
+    top: 100%;
+    left: 50%;
+    transform: translateX(-50%) rotate(180deg);
+  }
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+.fade-in {
+  animation: fadeIn 0.2s ease-in-out;
 }

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -35,15 +35,38 @@
       <OSS::Layout::Navbar::NavItem @icon='fa-code-branch' @label='Third Label' @active={{true}} />
     </div>
 
-    <div class='fx-row fx-gap-px-10 margin-md'>
-      <div
-        class='fx-col fx-gap-px-6 fx-xalign-center'
-        data-content={{'zezerzer'}}
+    <div class='fx-col fx-gap-px-10 margin-md fx-xalign-center'>
+      <p
+        data-content={{'right'}}
         data-title={{'azeazeaze'}}
         data-placement='right'
         data-html='true'
         {{(modifier 'enable-popover')}}
-      >azeazeazeazeaze</div>
+      >right</p>
+
+      <p
+        data-content={{'bottom'}}
+        data-title={{'azeazeaze'}}
+        data-placement='bottom'
+        data-html='true'
+        {{(modifier 'enable-popover')}}
+      >bottom</p>
+
+      <p
+        data-content={{'top'}}
+        data-title={{'azeazeaze'}}
+        data-placement='top'
+        data-html='true'
+        {{(modifier 'enable-popover')}}
+      >top</p>
+
+      <p
+        data-content={{'left'}}
+        data-title={{'azeazeaze'}}
+        data-placement='left'
+        data-html='true'
+        {{(modifier 'enable-popover')}}
+      >left</p>
       <OSS::PasswordInput @value={{this.password}} @validates={{this.onPasswordValidation}} />
     </div>
     <div class='fx-row fx-gap-px-10 margin-md padding-md' style='background-color:sandybrown'>

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -1,213 +1,318 @@
-<div class="fx-row">
-  <OSS::Layout::Sidebar @logo="/assets/images/upfluence-white-logo.svg" @homeAction={{fn this.redirectTo "/"}}>
+<div class='fx-row'>
+  <OSS::Layout::Sidebar @logo='/assets/images/upfluence-white-logo.svg' @homeAction={{fn this.redirectTo '/'}}>
     <:content>
-      <OSS::Layout::Sidebar::Item @icon="far fa-search" class="active" @defaultAction={{fn this.redirectTo "search"}} />
-      <OSS::Layout::Sidebar::Item @icon="far fa-list" @defaultAction={{fn this.redirectTo "list"}} />
-      <OSS::Layout::Sidebar::Item @icon="far fa-envelope" @defaultAction={{fn this.redirectTo "envelope"}} />
-      <OSS::Layout::Sidebar::Item @icon="far fa-bullhorn" @defaultAction={{fn this.redirectTo "bullhorn"}} />
-      <OSS::Layout::Sidebar::Item @icon="far fa-credit-card" @locked={{true}}
-                                  @defaultAction={{fn this.redirectTo "credit-card"}}
-                                  @lockedAction={{fn this.redirectTo "locked credit-card"}} />
-      <OSS::Layout::Sidebar::Item @icon="far fa-project-diagram" @defaultAction={{fn this.redirectTo "diagram"}} />
-      <OSS::Layout::Sidebar::Item @icon="far fa-chart-pie" @defaultAction={{fn this.redirectTo "pie"}} />
-      <OSS::Layout::Sidebar::Item @icon="far fa-bullseye-pointer" @hasNotifications={{true}}
-                                  @defaultAction={{fn this.redirectTo "pointer"}} />
+      <OSS::Layout::Sidebar::Item @icon='far fa-search' class='active' @defaultAction={{fn this.redirectTo 'search'}} />
+      <OSS::Layout::Sidebar::Item @icon='far fa-list' @defaultAction={{fn this.redirectTo 'list'}} />
+      <OSS::Layout::Sidebar::Item @icon='far fa-envelope' @defaultAction={{fn this.redirectTo 'envelope'}} />
+      <OSS::Layout::Sidebar::Item @icon='far fa-bullhorn' @defaultAction={{fn this.redirectTo 'bullhorn'}} />
+      <OSS::Layout::Sidebar::Item
+        @icon='far fa-credit-card'
+        @locked={{true}}
+        @defaultAction={{fn this.redirectTo 'credit-card'}}
+        @lockedAction={{fn this.redirectTo 'locked credit-card'}}
+      />
+      <OSS::Layout::Sidebar::Item @icon='far fa-project-diagram' @defaultAction={{fn this.redirectTo 'diagram'}} />
+      <OSS::Layout::Sidebar::Item @icon='far fa-chart-pie' @defaultAction={{fn this.redirectTo 'pie'}} />
+      <OSS::Layout::Sidebar::Item
+        @icon='far fa-bullseye-pointer'
+        @hasNotifications={{true}}
+        @defaultAction={{fn this.redirectTo 'pointer'}}
+      />
     </:content>
     <:footer>
-      <OSS::Layout::Sidebar::Item @icon="fal fa-info-circle" />
-      <OSS::Avatar @image="https://reachr-assets.s3.us-west-2.amazonaws.com/influencer-server/influencer/7219681.png"
-                   @initials="Ts" />
+      <OSS::Layout::Sidebar::Item @icon='fal fa-info-circle' />
+      <OSS::Avatar
+        @image='https://reachr-assets.s3.us-west-2.amazonaws.com/influencer-server/influencer/7219681.png'
+        @initials='Ts'
+      />
     </:footer>
   </OSS::Layout::Sidebar>
 
-  <div style="width:100%; height:100vh; overflow: auto; background-color: var(--color-gray-50)">
+  <div style='width:100%; height:100vh; overflow: auto; background-color: var(--color-gray-50)'>
     <div class='fx-col fx-gap-px-10 margin-md width-pc-20'>
       <OSS::Layout::Navbar::NavItem @icon='fa-cog' @label='First Label' />
       <OSS::Layout::Navbar::NavItem @icon='fa-code-branch' @label='Second Label' @active={{true}} />
       <OSS::Layout::Navbar::NavItem @icon='fa-code-branch' @label='Third Label' @active={{true}} />
     </div>
 
-    <div class="fx-row fx-gap-px-10 margin-md">
-      <OSS::PasswordInput
-        @value={{this.password}}
-        @validates={{this.onPasswordValidation}}
+    <div class='fx-row fx-gap-px-10 margin-md'>
+      <div
+        class='fx-col fx-gap-px-6 fx-xalign-center'
+        data-content={{'zezerzer'}}
+        data-title={{'azeazeaze'}}
+        data-placement='right'
+        data-html='true'
+        {{(modifier 'enable-popover')}}
+      >azeazeazeazeaze</div>
+      <OSS::PasswordInput @value={{this.password}} @validates={{this.onPasswordValidation}} />
+    </div>
+    <div class='fx-row fx-gap-px-10 margin-md padding-md' style='background-color:sandybrown'>
+      <OSS::TogglableSection
+        @title='This is a title'
+        @subtitle='This is a subtitle'
+        @toggled={{this.togglable}}
+        @icon='far fa-hourglass'
+        @onChange={{this.onToggle}}
+      >
+        <:contents>
+          <span>This is a Contents named block</span>
+        </:contents>
+      </OSS::TogglableSection>
+      <OSS::TogglableSection
+        @title='This is a title'
+        @subtitle='This is a subtitle'
+        @toggled={{this.togglable}}
+        @icon='far fa-hourglass'
+        @onChange={{this.onToggle}}
+        @size='sm'
+      >
+        <:contents>
+          <span>This is a Contents named block</span>
+        </:contents>
+      </OSS::TogglableSection>
+    </div>
+    <div class='fx-row fx-gap-px-10 margin-md padding-md' style='background-color:sandybrown'>
+      <OSS::TogglableSection
+        @title='This is a title'
+        @subtitle='This is a subtitle'
+        @toggled={{this.togglable}}
+        @badgeIcon='far fa-hourglass'
+        @onChange={{this.onToggle}}
+      />
+      <OSS::TogglableSection
+        @title='This is a title'
+        @subtitle='This is a subtitle'
+        @toggled={{this.togglable}}
+        @badgeIcon='far fa-hourglass'
+        @onChange={{this.onToggle}}
+        @size='sm'
       />
     </div>
-    <div class="fx-row fx-gap-px-10 margin-md padding-md" style="background-color:sandybrown">
-      <OSS::TogglableSection @title="This is a title" @subtitle="This is a subtitle" @toggled={{this.togglable}}
-                             @icon="far fa-hourglass" @onChange={{this.onToggle}}>
-        <:contents>
-          <span>This is a Contents named block</span>
-        </:contents>
-      </OSS::TogglableSection>
-      <OSS::TogglableSection @title="This is a title" @subtitle="This is a subtitle" @toggled={{this.togglable}}
-                             @icon="far fa-hourglass" @onChange={{this.onToggle}} @size="sm">
-        <:contents>
-          <span>This is a Contents named block</span>
-        </:contents>
-      </OSS::TogglableSection>
+    <div class='fx-row fx-gap-px-10 margin-md padding-md' style='background-color:sandybrown'>
+      <OSS::TogglableSection
+        @title='This is a title'
+        @subtitle='This is a subtitle'
+        @toggled={{this.togglable}}
+        @badgeIcon='far fa-hourglass'
+        @onChange={{this.onToggle}}
+        @disabled={{true}}
+      />
+      <OSS::TogglableSection
+        @title='This is a title'
+        @subtitle='This is a subtitle'
+        @toggled={{this.togglable}}
+        @badgeIcon='far fa-hourglass'
+        @onChange={{this.onToggle}}
+        @disabled={{true}}
+        @size='sm'
+      />
     </div>
-    <div class="fx-row fx-gap-px-10 margin-md padding-md" style="background-color:sandybrown">
-      <OSS::TogglableSection @title="This is a title" @subtitle="This is a subtitle" @toggled={{this.togglable}}
-                             @badgeIcon="far fa-hourglass" @onChange={{this.onToggle}} />
-      <OSS::TogglableSection @title="This is a title" @subtitle="This is a subtitle" @toggled={{this.togglable}}
-                             @badgeIcon="far fa-hourglass" @onChange={{this.onToggle}} @size="sm" />
-    </div>
-    <div class="fx-row fx-gap-px-10 margin-md padding-md" style="background-color:sandybrown">
-      <OSS::TogglableSection @title="This is a title" @subtitle="This is a subtitle" @toggled={{this.togglable}}
-                             @badgeIcon="far fa-hourglass" @onChange={{this.onToggle}} @disabled={{true}} />
-      <OSS::TogglableSection @title="This is a title" @subtitle="This is a subtitle" @toggled={{this.togglable}}
-                             @badgeIcon="far fa-hourglass" @onChange={{this.onToggle}} @disabled={{true}} @size="sm" />
-    </div>
-    <div class="fx-row fx-gap-px-10 margin-md">
-      <OSS::Banner @icon="fas fa-box-open" @title="Shopify" @selected={{true}}
-                   @subtitle="Identify influencers in your Shopify customers database">
+    <div class='fx-row fx-gap-px-10 margin-md'>
+      <OSS::Banner
+        @icon='fas fa-box-open'
+        @title='Shopify'
+        @selected={{true}}
+        @subtitle='Identify influencers in your Shopify customers database'
+      >
         <:actions>
           <OSS::RadioButton @selected={{true}} />
         </:actions>
       </OSS::Banner>
-      <OSS::Banner @icon="fas fa-box-open" @title="Import creators inside your campaign"
-                   @subtitle="Choose the creators you want to import from a list, emailing, stream, Live capture or upload an existing .CSV file. ">
+      <OSS::Banner
+        @icon='fas fa-box-open'
+        @title='Import creators inside your campaign'
+        @subtitle='Choose the creators you want to import from a list, emailing, stream, Live capture or upload an existing .CSV file. '
+      >
         <:custom-icon>
-          <OSS::Badge @text="2x" @size="lg" />
+          <OSS::Badge @text='2x' @size='lg' />
         </:custom-icon>
         <:actions>
-          <OSS::Button @skin="primary" @label="browse" @icon="fas fa-box-open" @size="md" />
-          <OSS::Button @skin="secondary" @label="test" @icon="fas fa-box-open" @size="md" />
+          <OSS::Button @skin='primary' @label='browse' @icon='fas fa-box-open' @size='md' />
+          <OSS::Button @skin='secondary' @label='test' @icon='fas fa-box-open' @size='md' />
         </:actions>
       </OSS::Banner>
     </div>
-    <div class="fx-row fx-gap-px-10 margin-md">
-      <OSS::Banner @icon="fas fa-box-open" @title="Import creators inside your campaign"
-                   @subtitle="Choose the creators you want to import from a list, emailing, stream, Live capture or upload an existing .CSV file." />
-      <OSS::Banner @title="Banner without icon"
-                   @subtitle="Choose the creators you want to import from a list, emailing, stream, Live capture or upload an existing .CSV file." />
+    <div class='fx-row fx-gap-px-10 margin-md'>
+      <OSS::Banner
+        @icon='fas fa-box-open'
+        @title='Import creators inside your campaign'
+        @subtitle='Choose the creators you want to import from a list, emailing, stream, Live capture or upload an existing .CSV file.'
+      />
+      <OSS::Banner
+        @title='Banner without icon'
+        @subtitle='Choose the creators you want to import from a list, emailing, stream, Live capture or upload an existing .CSV file.'
+      />
       <OSS::Bruce
-                  @image="https://thepressfree.com/wp-content/uploads/2021/11/Voici-pourquoi-Bruce-Banner-netait-plus-Smart-Hulk-dans-la-800x445.jpg"
-                  @title="Import creators inside your campaign" @plain={{true}}
-                  @subtitle="Choose the creators you want to import from a list, emailing, stream, Live capture or upload an existing .CSV file. ">
+        @image='https://thepressfree.com/wp-content/uploads/2021/11/Voici-pourquoi-Bruce-Banner-netait-plus-Smart-Hulk-dans-la-800x445.jpg'
+        @title='Import creators inside your campaign'
+        @plain={{true}}
+        @subtitle='Choose the creators you want to import from a list, emailing, stream, Live capture or upload an existing .CSV file. '
+      >
         <:actions>
-          <OSS::Button @skin="secondary" @label="action" @icon="fas fa-box-open" @size="md" />
+          <OSS::Button @skin='secondary' @label='action' @icon='fas fa-box-open' @size='md' />
         </:actions>
       </OSS::Bruce>
     </div>
-    <div class="fx-row fx-gap-px-10 margin-md">
-      <OSS::Banner @icon="fas fa-biohazard" @title="BioHazard" @selected={{true}} @size="sm">
+    <div class='fx-row fx-gap-px-10 margin-md'>
+      <OSS::Banner @icon='fas fa-biohazard' @title='BioHazard' @selected={{true}} @size='sm'>
         <:actions>
-          <OSS::Checkbox @checked={{true}} @onChange={{this.onCheck}} @size="sm" />
+          <OSS::Checkbox @checked={{true}} @onChange={{this.onCheck}} @size='sm' />
         </:actions>
       </OSS::Banner>
-      <OSS::Banner @icon="fas fa-helicopter" @title="Helicopter" @size="sm" @disabled={{true}}>
+      <OSS::Banner @icon='fas fa-helicopter' @title='Helicopter' @size='sm' @disabled={{true}}>
         <:actions>
-          <OSS::Icon @icon="fa-ban" />
+          <OSS::Icon @icon='fa-ban' />
         </:actions>
         <:secondary-actions>
-          <OSS::Link @label="Configure" />
+          <OSS::Link @label='Configure' />
         </:secondary-actions>
       </OSS::Banner>
-      <OSS::Banner @icon="fas fa-user-injured" @title="Injured" @selected={{false}} @size="sm">
+      <OSS::Banner @icon='fas fa-user-injured' @title='Injured' @selected={{false}} @size='sm'>
         <:actions>
-          <OSS::Checkbox @checked={{false}} @onChange={{this.onCheck}} @size="sm" />
+          <OSS::Checkbox @checked={{false}} @onChange={{this.onCheck}} @size='sm' />
         </:actions>
       </OSS::Banner>
     </div>
-    <div class="fx-row fx-gap-px-10 margin-md">
-      <OSS::CurrencyInput @currency={{this.currency}} @value={{this.currencyValue}}
-                          @onChange={{this.onCurrencyInputChange}}
-                          @errorMessage="This is an error message" />
-      <OSS::CurrencyInput @currency={{this.currency}} @value={{this.currencyValue}} @allowCurrencyUpdate={{false}}
-                          @onChange={{this.onCurrencyInputChange}} />
-      <OSS::CurrencyInput @currency={{this.currency}} @value={{this.currencyValue}}
-                          @onChange={{this.onCurrencyInputChange}} @allowedCurrencies={{this.allowedCurrencies}} />
-      <OSS::CurrencyInput @currency={{this.currency}} @value={{this.currencyValue}}
-                          @onChange={{this.onCurrencyInputChange}}
-                          @onlyCurrency={{true}} />
-      <OSS::CurrencyInput @currency={{this.currencyOnly}} @onChange={{this.onCurrencyOnlyChange}}
-                          @onlyCurrency={{true}} @allowedCurrencies={{this.allowedCurrencies}} />
+    <div class='fx-row fx-gap-px-10 margin-md'>
+      <OSS::CurrencyInput
+        @currency={{this.currency}}
+        @value={{this.currencyValue}}
+        @onChange={{this.onCurrencyInputChange}}
+        @errorMessage='This is an error message'
+      />
+      <OSS::CurrencyInput
+        @currency={{this.currency}}
+        @value={{this.currencyValue}}
+        @allowCurrencyUpdate={{false}}
+        @onChange={{this.onCurrencyInputChange}}
+      />
+      <OSS::CurrencyInput
+        @currency={{this.currency}}
+        @value={{this.currencyValue}}
+        @onChange={{this.onCurrencyInputChange}}
+        @allowedCurrencies={{this.allowedCurrencies}}
+      />
+      <OSS::CurrencyInput
+        @currency={{this.currency}}
+        @value={{this.currencyValue}}
+        @onChange={{this.onCurrencyInputChange}}
+        @onlyCurrency={{true}}
+      />
+      <OSS::CurrencyInput
+        @currency={{this.currencyOnly}}
+        @onChange={{this.onCurrencyOnlyChange}}
+        @onlyCurrency={{true}}
+        @allowedCurrencies={{this.allowedCurrencies}}
+      />
     </div>
-    <div class="fx-row fx-gap-px-10 margin-md">
-      <div class="fx-col fx-1 fx-gap-px-5">
+    <div class='fx-row fx-gap-px-10 margin-md'>
+      <div class='fx-col fx-1 fx-gap-px-5'>
         <span>Country</span>
-        <OSS::CountrySelector @value={{this.selectedCountry.id}} @sourceList={{this.countries}}
-                              @onChange={{this.onCountrySelected}} />
+        <OSS::CountrySelector
+          @value={{this.selectedCountry.id}}
+          @sourceList={{this.countries}}
+          @onChange={{this.onCountrySelected}}
+        />
       </div>
       {{this.selectedCountry.provinces.length}}
       {{#if (gt this.selectedCountry.provinces.length 0)}}
-        <div class="fx-col fx-1 fx-gap-px-5">
+        <div class='fx-col fx-1 fx-gap-px-5'>
           <span>Province</span>
           <OSS::CountrySelector @sourceList={{this.selectedCountry.provinces}} @onChange={{this.onProvinceSelected}} />
         </div>
       {{/if}}
     </div>
-    <div class="fx-col fx-1 fx-gap-px-10 margin-md width-px-200">
-      <OSS::ProgressBar @skin="success"
-                        @value={{42}}
-                        @displayValue={{true}}
-                        @label="Hello" />
-      <OSS::ProgressBar @skin="warning"
-                        @value={{21}}
-                        @displayValue={{true}}
-                        @label="Hello" />
+    <div class='fx-col fx-1 fx-gap-px-10 margin-md width-px-200'>
+      <OSS::ProgressBar @skin='success' @value={{42}} @displayValue={{true}} @label='Hello' />
+      <OSS::ProgressBar @skin='warning' @value={{21}} @displayValue={{true}} @label='Hello' />
     </div>
-    <div class="fx-row fx-1 fx-gap-px-10 margin-md">
+    <div class='fx-row fx-1 fx-gap-px-10 margin-md'>
       <OSS::StarRating @rating={{3}} @totalStars={{5}} @onChange={{this.onRatingClick}} />
-      <OSS::StarRating @rating={{this.rating}} @totalStars={{15}} @activeColor="red" @passiveColor="blue"
-                       @onChange={{this.onRatingClick}} />
+      <OSS::StarRating
+        @rating={{this.rating}}
+        @totalStars={{15}}
+        @activeColor='red'
+        @passiveColor='blue'
+        @onChange={{this.onRatingClick}}
+      />
     </div>
-    <div class="fx-row fx-1 fx-gap-px-10 margin-md">
-      <OSS::InputContainer @placeholder="search" @value={{this.shopUrl}}>
+    <div class='fx-row fx-1 fx-gap-px-10 margin-md'>
+      <OSS::InputContainer @placeholder='search' @value={{this.shopUrl}}>
         <:prefix>
-          <OSS::Icon @icon="fa-search" class="font-color-gray-500" />
+          <OSS::Icon @icon='fa-search' class='font-color-gray-500' />
         </:prefix>
         <:suffix>
           {{#if (gt this.shopUrl.length 0)}}
-            <OSS::Icon @icon="fa-times" class="font-color-gray-500" role="button"
-                       {{on "click" (fn (mut this.shopUrl) '')}} />
+            <OSS::Icon
+              @icon='fa-times'
+              class='font-color-gray-500'
+              role='button'
+              {{on 'click' (fn (mut this.shopUrl) '')}}
+            />
           {{/if}}
         </:suffix>
       </OSS::InputContainer>
-      <OSS::InputContainer @placeholder="search" @value={{this.shopUrl}} />
-      <OSS::PasswordInput @value="azeaze" />
+      <OSS::InputContainer @placeholder='search' @value={{this.shopUrl}} />
+      <OSS::PasswordInput @value='azeaze' />
     </div>
-    <div class="fx-row fx-1 fx-gap-px-10 margin-md width-pc-50">
-      <OSS::AttributesPanel @title="Title" @icon="fa-laptop-code" @onSave={{this.onAttributePanelSave}}
-                            @onCancel={{this.onAttributePanelCancel}} @onEdit={{this.onAttributePanelEdit}}>
+    <div class='fx-row fx-1 fx-gap-px-10 margin-md width-pc-50'>
+      <OSS::AttributesPanel
+        @title='Title'
+        @icon='fa-laptop-code'
+        @onSave={{this.onAttributePanelSave}}
+        @onCancel={{this.onAttributePanelCancel}}
+        @onEdit={{this.onAttributePanelEdit}}
+      >
         <:contextual-action>
-          <OSS::Button @icon="fa-plus" @square={{true}} />
+          <OSS::Button @icon='fa-plus' @square={{true}} />
         </:contextual-action>
         <:view-mode>
-          <div class="fx-col fx-gap-px-9">
-            <OSS::Attribute::RemovableText @label="city" @onRemove={{this.onRemove}} @removeTooltip="Click to delete" />
-            <OSS::Attribute::RemovableText @label="city" @value="Paris" @onRemove={{this.onRemove}} />
-            <OSS::Attribute::TagArray @label="Pies"
-                                      @tags={{array "Apple pie" "Pecan pie" "Pumpkin pie" "Raspberry PI"}} />
-            <OSS::Attribute::TagArray @label="Fruits" @tags={{array "apple" "banana" "pitaya" "jackfruit"
-                                      "mango" "orange" "blueberry" "papaya" "pineapple" "watermelon" "vodkamelon"}} />
-            <OSS::Attribute::TagArray @label="Fruits" />
-            <OSS::Attribute::RevealableEmail @lockTooltip="This will fail"
-                                             @onRevealEmail={{this.onRevealEmailError}} />
+          <div class='fx-col fx-gap-px-9'>
+            <OSS::Attribute::RemovableText @label='city' @onRemove={{this.onRemove}} @removeTooltip='Click to delete' />
+            <OSS::Attribute::RemovableText @label='city' @value='Paris' @onRemove={{this.onRemove}} />
+            <OSS::Attribute::TagArray
+              @label='Pies'
+              @tags={{array 'Apple pie' 'Pecan pie' 'Pumpkin pie' 'Raspberry PI'}}
+            />
+            <OSS::Attribute::TagArray
+              @label='Fruits'
+              @tags={{array
+                'apple'
+                'banana'
+                'pitaya'
+                'jackfruit'
+                'mango'
+                'orange'
+                'blueberry'
+                'papaya'
+                'pineapple'
+                'watermelon'
+                'vodkamelon'
+              }}
+            />
+            <OSS::Attribute::TagArray @label='Fruits' />
+            <OSS::Attribute::RevealableEmail @lockTooltip='This will fail' @onRevealEmail={{this.onRevealEmailError}} />
             {{#if this.revealed}}
-              <OSS::Attribute::Text @label="Email address" @value="john.doe@gmail.com" />
+              <OSS::Attribute::Text @label='Email address' @value='john.doe@gmail.com' />
             {{else}}
-              <OSS::Attribute::RevealableEmail @tooltip="Click on lock to reveal"
-                                               @onRevealEmail={{this.onRevealEmailSuccess}} />
+              <OSS::Attribute::RevealableEmail
+                @tooltip='Click on lock to reveal'
+                @onRevealEmail={{this.onRevealEmailSuccess}}
+              />
             {{/if}}
-            <OSS::Attribute::Country @countryCode="US" />
-            <OSS::Attribute::Country @countryCode="" />
-            <OSS::Attribute::Text @label="Label with tooltip copyable" @value="Hello World"
-                                  @tooltip="Hello World" />
-            <OSS::Attribute::Text @label="Label not copyable" @value="Hello World" @copyable={{false}} />
-            <OSS::Attribute::PhoneNumber @countryCode="FR" @prefix="+33" @number="642424242" />
-            <OSS::Attribute::PhoneNumber @countryCode="nope" @number="+33642424242" />
-            <OSS::Attribute::PhoneNumber @prefix="+33" />
-            <OSS::Attribute::RevealableEmail @lockTooltip="This will fail"
-                                             @onRevealEmail={{this.onRevealEmailError}} />
+            <OSS::Attribute::Country @countryCode='US' />
+            <OSS::Attribute::Country @countryCode='' />
+            <OSS::Attribute::Text @label='Label with tooltip copyable' @value='Hello World' @tooltip='Hello World' />
+            <OSS::Attribute::Text @label='Label not copyable' @value='Hello World' @copyable={{false}} />
+            <OSS::Attribute::PhoneNumber @countryCode='FR' @prefix='+33' @number='642424242' />
+            <OSS::Attribute::PhoneNumber @countryCode='nope' @number='+33642424242' />
+            <OSS::Attribute::PhoneNumber @prefix='+33' />
+            <OSS::Attribute::RevealableEmail @lockTooltip='This will fail' @onRevealEmail={{this.onRevealEmailError}} />
 
-            <OSS::Attribute::Country @countryCode="US" />
-            <OSS::Attribute::Country @countryCode="" />
-            <OSS::Attribute::Rating @label="Rating"
-                                    @rating={{this.starRatingValue}} />
-            <OSS::Attribute::Rating @label="Rating not provided" />
+            <OSS::Attribute::Country @countryCode='US' />
+            <OSS::Attribute::Country @countryCode='' />
+            <OSS::Attribute::Rating @label='Rating' @rating={{this.starRatingValue}} />
+            <OSS::Attribute::Rating @label='Rating not provided' />
           </div>
         </:view-mode>
         <:edition-mode>
@@ -215,138 +320,187 @@
         </:edition-mode>
       </OSS::AttributesPanel>
     </div>
-    <div class="fx-row fx-1 fx-gap-px-10 margin-md">
+    <div class='fx-row fx-1 fx-gap-px-10 margin-md'>
       <OSS::EmailInput @value={{this.emailInputValue}} @onChange={{this.onEmailInputChange}} />
     </div>
-    <div class="fx-row fx-1 fx-gap-px-10 margin-md">
-      <OSS::Copy @value="I am the value copied" @inline={{true}} />
-      <OSS::Copy @value="I am the value copied" />
+    <div class='fx-row fx-1 fx-gap-px-10 margin-md'>
+      <OSS::Copy @value='I am the value copied' @inline={{true}} />
+      <OSS::Copy @value='I am the value copied' />
     </div>
-    <div class="fx-row fx-1 fx-gap-px-10 margin-md padding-md" style="background: white">
-      <OSS::Illustration @src="/@upfluence/oss-components/assets/images/no-records.svg" />
+    <div class='fx-row fx-1 fx-gap-px-10 margin-md padding-md' style='background: white'>
+      <OSS::Illustration @src='/@upfluence/oss-components/assets/images/no-records.svg' />
     </div>
-    <div class="fx-row fx-1 fx-gap-px-10 margin-md">
-      <OSS::Skeleton @width="70%" />
+    <div class='fx-row fx-1 fx-gap-px-10 margin-md'>
+      <OSS::Skeleton @width='70%' />
       <OSS::Skeleton @width={{20}} />
     </div>
-    <div class="fx-row fx-1 fx-gap-px-10 margin-md">
-      <OSS::Skeleton @direction="column" @width="60%" @gap="12" @multiple="3" @randomize={{true}} />
+    <div class='fx-row fx-1 fx-gap-px-10 margin-md'>
+      <OSS::Skeleton @direction='column' @width='60%' @gap='12' @multiple='3' @randomize={{true}} />
     </div>
-    <div class="fx-row fx-1 fx-gap-px-10 margin-md">
-      <OSS::Skeleton @width="10%" @multiple="3" @direction="row" @randomize="true" />
+    <div class='fx-row fx-1 fx-gap-px-10 margin-md'>
+      <OSS::Skeleton @width='10%' @multiple='3' @direction='row' @randomize='true' />
     </div>
-    <div class="fx-row fx-xalign-start fx-gap-px-10 margin-md">
-      <OSS::Icon @icon="LaptopCode" />
-      <OSS::Icon @icon="LaptopCode" @style="solid" />
-      <OSS::Icon @icon="LaptopCode" @style="regular" />
-      <OSS::Icon @icon="LaptopCode" @style="light" />
-      <OSS::Icon @icon="LaptopCode" @style="duotone" />
-      <OSS::Icon @icon="FacebookSquare" @style="brand" />
+    <div class='fx-row fx-xalign-start fx-gap-px-10 margin-md'>
+      <OSS::Icon @icon='LaptopCode' />
+      <OSS::Icon @icon='LaptopCode' @style='solid' />
+      <OSS::Icon @icon='LaptopCode' @style='regular' />
+      <OSS::Icon @icon='LaptopCode' @style='light' />
+      <OSS::Icon @icon='LaptopCode' @style='duotone' />
+      <OSS::Icon @icon='FacebookSquare' @style='brand' />
     </div>
-    <div class="fx-row fx-xalign-start fx-gap-px-10 margin-md">
-      <OSS::TextArea @value={{this.numberValue}} @onChange={{this.handleNumberInput}}
-                     @errorMessage="This is an error message" @rows={{8}} @resize="vertical" />
+    <div class='fx-row fx-xalign-start fx-gap-px-10 margin-md'>
+      <OSS::TextArea
+        @value={{this.numberValue}}
+        @onChange={{this.handleNumberInput}}
+        @errorMessage='This is an error message'
+        @rows={{8}}
+        @resize='vertical'
+      />
       <OSS::TextArea @value={{this.numberValue}} @onChange={{this.handleNumberInput}} @rows={{1}} />
     </div>
 
-    <div class="fx-row fx-xalign-start fx-gap-px-10 margin-md">
-      <OSS::Button @label="Open split modal" {{on "click" this.openSplitModal}} />
-      <OSS::ButtonDropdown @icon="far fa-credit-card" @label="Dropdown button"
-                           @mainAction={{fn this.redirectTo "test"}}>
+    <div class='fx-row fx-xalign-start fx-gap-px-10 margin-md'>
+      <OSS::Button @label='Open split modal' {{on 'click' this.openSplitModal}} />
+      <OSS::ButtonDropdown
+        @icon='far fa-credit-card'
+        @label='Dropdown button'
+        @mainAction={{fn this.redirectTo 'test'}}
+      >
         <:items>
-          <div class="oss-button-dropdown__item">
-            <OSS::Icon @style="solid" @icon="fa-share" /> Share
+          <div class='oss-button-dropdown__item'>
+            <OSS::Icon @style='solid' @icon='fa-share' />
+            Share
           </div>
         </:items>
       </OSS::ButtonDropdown>
-      <OSS::ButtonDropdown @icon="far fa-hourglass" @label="Dropdown button">
+      <OSS::ButtonDropdown @icon='far fa-hourglass' @label='Dropdown button'>
         <:items>
-          <div class="oss-button-dropdown__item">
-            <OSS::Icon @style="solid" @icon="fa-share" /> Share
+          <div class='oss-button-dropdown__item'>
+            <OSS::Icon @style='solid' @icon='fa-share' />
+            Share
           </div>
         </:items>
       </OSS::ButtonDropdown>
-      <OSS::Button @label="loading" @loading={{true}} />
+      <OSS::Button @label='loading' @loading={{true}} />
       {{#if this.showSplitModal}}
         <OSS::SplitModal @close={{this.closeSplitModal}}>
           <:content>
             Content goes here
           </:content>
           <:footer>
-            <OSS::Button @label="Close" {{on "click" this.closeSplitModal}} />
+            <OSS::Button @label='Close' {{on 'click' this.closeSplitModal}} />
           </:footer>
         </OSS::SplitModal>
       {{/if}}
     </div>
-    <div class="fx-row fx-xalign-start fx-gap-px-10 margin-md">
+    <div class='fx-row fx-xalign-start fx-gap-px-10 margin-md'>
       OSS:Checkbox:
       <OSS::Checkbox @checked={{this.isChecked}} @onChange={{this.onCheck}} />
       <OSS::Checkbox @checked={{this.isChecked}} @disabled={{true}} @onChange={{this.onCheck}} />
       <OSS::Checkbox @checked={{this.isChecked}} @disabled={{true}} @partial={{true}} @onChange={{this.onCheck}} />
       <OSS::Checkbox @checked={{this.isChecked}} @partial={{true}} @onChange={{this.onCheck}} />
-      <OSS::Checkbox @checked={{this.isChecked}} @size="sm" @onChange={{this.onCheck}} />
-      <OSS::Checkbox @checked={{this.isChecked}} @size="sm" @partial={{true}} @onChange={{this.onCheck}} />
+      <OSS::Checkbox @checked={{this.isChecked}} @size='sm' @onChange={{this.onCheck}} />
+      <OSS::Checkbox @checked={{this.isChecked}} @size='sm' @partial={{true}} @onChange={{this.onCheck}} />
     </div>
-    <div class="fx-row fx-xalign-start fx-gap-px-10 margin-md">
-      <OSS::ToggleButtons @toggles={{this.toggles}} @selectedToggle={{this.selectedToggle}}
-                          @onSelection={{this.triggerSelection}} />
+    <div class='fx-row fx-xalign-start fx-gap-px-10 margin-md'>
+      <OSS::ToggleButtons
+        @toggles={{this.toggles}}
+        @selectedToggle={{this.selectedToggle}}
+        @onSelection={{this.triggerSelection}}
+      />
     </div>
-    <div class="fx-row fx-xalign-start fx-gap-px-10 margin-md">
+    <div class='fx-row fx-xalign-start fx-gap-px-10 margin-md'>
       <OSS::NumberInput @value={{this.numberValue}} @onChange={{this.handleNumberInput}} />
       <OSS::NumberInput @min={{0}} @max={{15}} @step={{5}} @onChange={{this.handleNumberInput}} />
-      <OSS::NumberInput @min={{0}} @max={{15}} @step={{5}} @minReachedTooltip="Hello" @maxReachedTooltip="you"
-                        @onChange={{this.handleNumberInput}} />
+      <OSS::NumberInput
+        @min={{0}}
+        @max={{15}}
+        @step={{5}}
+        @minReachedTooltip='Hello'
+        @maxReachedTooltip='you'
+        @onChange={{this.handleNumberInput}}
+      />
     </div>
-    <div class="fx-row fx-xalign-start fx-gap-px-10 margin-md">
-      <OSS::UrlInput @value={{this.shopifyDomain}} @prefix="https://" @placeholder="shopname" @suffix=".myshopify.com"
-                     @errorMessage="Not a valid shopify domain" @validationRegex={{this.subdomainRegex}}
-                     @onChange={{this.onUrlInputChange}} />
-      <OSS::UrlInput @prefix="https://" @placeholder="No regex specified" @onChange={{this.onUrlInputChange}}
-                     @value={{this.shopifyDomain}} />
-      <OSS::UrlInput @value={{this.shopUrl}} @prefix="https://" @placeholder="shop url"
-                     @errorMessage="Please enter a valid URL" @validationRegex={{this.urlRegex}}
-                     @onChange={{this.onUrlInputChange}} />
+    <div class='fx-row fx-xalign-start fx-gap-px-10 margin-md'>
+      <OSS::UrlInput
+        @value={{this.shopifyDomain}}
+        @prefix='https://'
+        @placeholder='shopname'
+        @suffix='.myshopify.com'
+        @errorMessage='Not a valid shopify domain'
+        @validationRegex={{this.subdomainRegex}}
+        @onChange={{this.onUrlInputChange}}
+      />
+      <OSS::UrlInput
+        @prefix='https://'
+        @placeholder='No regex specified'
+        @onChange={{this.onUrlInputChange}}
+        @value={{this.shopifyDomain}}
+      />
+      <OSS::UrlInput
+        @value={{this.shopUrl}}
+        @prefix='https://'
+        @placeholder='shop url'
+        @errorMessage='Please enter a valid URL'
+        @validationRegex={{this.urlRegex}}
+        @onChange={{this.onUrlInputChange}}
+      />
     </div>
-    <div class="fx-row fx-xalign-start fx-gap-px-10 margin-md">
-      <OSS::InputGroup @value={{this.inputValue}} @prefix="This" @placeholder="makes no" @suffix="sense"
-                       @errorMessage="This is an error message" />
-      <OSS::InputGroup @value={{this.inputValue}} @prefix="@" @placeholder="Username" />
-      <OSS::InputGroup @value={{this.inputValue}} @suffix="@example.com" @placeholder="john.doe" />
+    <div class='fx-row fx-xalign-start fx-gap-px-10 margin-md'>
+      <OSS::InputGroup
+        @value={{this.inputValue}}
+        @prefix='This'
+        @placeholder='makes no'
+        @suffix='sense'
+        @errorMessage='This is an error message'
+      />
+      <OSS::InputGroup @value={{this.inputValue}} @prefix='@' @placeholder='Username' />
+      <OSS::InputGroup @value={{this.inputValue}} @suffix='@example.com' @placeholder='john.doe' />
     </div>
-    <div class="fx-row fx-gap-px-10 margin-md">
-      <OSS::RadioButton @selected={{this.radio1}} @onChange={{fn this.onRadioBtnChange "radio1" }} />
-      <OSS::RadioButton @selected={{this.radio2}} @onChange={{fn this.onRadioBtnChange "radio2" }} />
+    <div class='fx-row fx-gap-px-10 margin-md'>
+      <OSS::RadioButton @selected={{this.radio1}} @onChange={{fn this.onRadioBtnChange 'radio1'}} />
+      <OSS::RadioButton @selected={{this.radio2}} @onChange={{fn this.onRadioBtnChange 'radio2'}} />
       <OSS::RadioButton @selected={{true}} @disabled={{true}} />
       <OSS::RadioButton @selected={{false}} @disabled={{true}} />
-      <OSS::Copy @value="I am the value copied" />
+      <OSS::Copy @value='I am the value copied' />
     </div>
-    <div class="fx-row fx-gap-px-10 margin-md fx-xalign-center">
-      <OSS::Avatar @image="https://reachr-assets.s3.us-west-2.amazonaws.com/influencer-server/influencer/7219681.png"
-                   @initials="Ts" />
-      <OSS::Avatar @initials="MI" />
+    <div class='fx-row fx-gap-px-10 margin-md fx-xalign-center'>
+      <OSS::Avatar
+        @image='https://reachr-assets.s3.us-west-2.amazonaws.com/influencer-server/influencer/7219681.png'
+        @initials='Ts'
+      />
+      <OSS::Avatar @initials='MI' />
       <OSS::Avatar />
 
-      <OSS::Avatar @size="xs" />
-      <OSS::Avatar @size="sm" />
-      <OSS::Avatar @size="md" />
-      <OSS::Avatar @size="lg" />
+      <OSS::Avatar @size='xs' />
+      <OSS::Avatar @size='sm' />
+      <OSS::Avatar @size='md' />
+      <OSS::Avatar @size='lg' />
     </div>
 
-    <div class="fx-row fx-gap-px-10 margin-md">
-      <OSS::PowerSelect @items={{null}} @selectedItems={{this.superHeroes}}
-                        @onChange={{this.onPowerSelectChange}} @onSearch={{this.onPowerSelectSearch}}>
+    <div class='fx-row fx-gap-px-10 margin-md'>
+      <OSS::PowerSelect
+        @items={{null}}
+        @selectedItems={{this.superHeroes}}
+        @onChange={{this.onPowerSelectChange}}
+        @onSearch={{this.onPowerSelectSearch}}
+      >
         <:selected-item as |selectedProduct|>
-          <OSS::Chip @label={{selectedProduct}} @onRemove={{this.onPowerSelectChange }} @maxDisplayWidth={{100}} />
+          <OSS::Chip @label={{selectedProduct}} @onRemove={{this.onPowerSelectChange}} @maxDisplayWidth={{100}} />
         </:selected-item>
         <:option-item as |item|>
           {{item}}
         </:option-item>
       </OSS::PowerSelect>
 
-      <OSS::PowerSelect @items={{null}} @selectedItems={{this.superHeroes}}
-                        @onChange={{this.onPowerSelectChange}} @onSearch={{this.onPowerSelectSearch}}>
+      <OSS::PowerSelect
+        @items={{null}}
+        @selectedItems={{this.superHeroes}}
+        @onChange={{this.onPowerSelectChange}}
+        @onSearch={{this.onPowerSelectSearch}}
+      >
         <:selected-item as |selectedProduct|>
-          <OSS::Chip @label={{selectedProduct}} @onRemove={{this.onPowerSelectChange }} @maxDisplayWidth={{100}} />
+          <OSS::Chip @label={{selectedProduct}} @onRemove={{this.onPowerSelectChange}} @maxDisplayWidth={{100}} />
         </:selected-item>
         <:option-item as |item|>
           {{item}}
@@ -356,38 +510,56 @@
         </:empty-state>
       </OSS::PowerSelect>
 
-      <OSS::PowerSelect @items={{this.superHeroes}} @selectedItems={{null}} @onChange={{this.onPowerSelectChange}}
-                        @onSearch={{this.onPowerSelectSearch}}>
+      <OSS::PowerSelect
+        @items={{this.superHeroes}}
+        @selectedItems={{null}}
+        @onChange={{this.onPowerSelectChange}}
+        @onSearch={{this.onPowerSelectSearch}}
+      >
         <:selected-item as |selectedProduct|>
-          <OSS::Chip @label={{selectedProduct}} @onRemove={{this.onPowerSelectChange }} @maxDisplayWidth={{100}} />
+          <OSS::Chip @label={{selectedProduct}} @onRemove={{this.onPowerSelectChange}} @maxDisplayWidth={{100}} />
         </:selected-item>
         <:option-item as |item|>
           {{item}}
         </:option-item>
       </OSS::PowerSelect>
     </div>
-    <div class="fx-row fx-gap-px-10 margin-md">
+    <div class='fx-row fx-gap-px-10 margin-md'>
       <OSS::NavTab @onSelection={{this.onSelectionNavTab}} @tabArray={{this.tabArrayNavTab}} />
     </div>
 
-    <div class="fx-row fx-gap-px-10 margin-md">
-      <OSS::Chip @label="Chip" @onRemove={{this.onCrossChipClick}} />
-      <OSS::Chip @skin="default" @label="Chip" @onRemove={{this.onCrossChipClick}} />
-      <OSS::Chip @skin="primary" @label="Chip" @onRemove={{this.onCrossChipClick}} />
-      <OSS::Chip @skin="success" @label="Chip" @onRemove={{this.onCrossChipClick}} />
-      <OSS::Chip @skin="danger" @label="Chip" @onRemove={{this.onCrossChipClick}} />
-      <OSS::Chip @skin="danger" @label="Chip" @disabled={{true}} @onRemove={{this.onCrossChipClick}} />
-      <OSS::Chip @skin="success" @label="Chip with a huge label" @disabled={{false}} @maxDisplayWidth={{100}}
-                 @onRemove={{this.onCrossChipClick}} />
-      <OSS::Chip @skin="danger" @label="Chip with a huge label" @disabled={{false}} @maxDisplayWidth={{160}}
-                 @onRemove={{this.onCrossChipClick}} />
-      <OSS::ChipNFish @skin="danger" @label="Chip with a huge label" @disabled={{true}}
-                      @onRemove={{this.onCrossChipClick}}
-                      @maxDisplayWidth={{50}} />
+    <div class='fx-row fx-gap-px-10 margin-md'>
+      <OSS::Chip @label='Chip' @onRemove={{this.onCrossChipClick}} />
+      <OSS::Chip @skin='default' @label='Chip' @onRemove={{this.onCrossChipClick}} />
+      <OSS::Chip @skin='primary' @label='Chip' @onRemove={{this.onCrossChipClick}} />
+      <OSS::Chip @skin='success' @label='Chip' @onRemove={{this.onCrossChipClick}} />
+      <OSS::Chip @skin='danger' @label='Chip' @onRemove={{this.onCrossChipClick}} />
+      <OSS::Chip @skin='danger' @label='Chip' @disabled={{true}} @onRemove={{this.onCrossChipClick}} />
+      <OSS::Chip
+        @skin='success'
+        @label='Chip with a huge label'
+        @disabled={{false}}
+        @maxDisplayWidth={{100}}
+        @onRemove={{this.onCrossChipClick}}
+      />
+      <OSS::Chip
+        @skin='danger'
+        @label='Chip with a huge label'
+        @disabled={{false}}
+        @maxDisplayWidth={{160}}
+        @onRemove={{this.onCrossChipClick}}
+      />
+      <OSS::ChipNFish
+        @skin='danger'
+        @label='Chip with a huge label'
+        @disabled={{true}}
+        @onRemove={{this.onCrossChipClick}}
+        @maxDisplayWidth={{50}}
+      />
     </div>
 
-    <div class="fx-row fx-1 margin-md fx-gap-px-12">
-      <div class="fx-col fx-1 fx-gap-px-12">
+    <div class='fx-row fx-1 margin-md fx-gap-px-12'>
+      <div class='fx-col fx-1 fx-gap-px-12'>
         <OSS::Select @value={{null}} @items={{this.items}} @onChange={{this.onSelect}}>
           <:option as |item|>
             {{item.name}}
@@ -400,22 +572,30 @@
           </:option>
         </OSS::Select>
 
-        <OSS::Select @value={{this.selectedItem}} @items={{this.items}} @onChange={{this.onSelect}}
-                     @errorMessage="This is an error">
+        <OSS::Select
+          @value={{this.selectedItem}}
+          @items={{this.items}}
+          @onChange={{this.onSelect}}
+          @errorMessage='This is an error'
+        >
           <:option as |item|>
             {{item.name}}
           </:option>
         </OSS::Select>
 
-        <OSS::Select @value={{this.selectedItem}} @items={{this.items}} @onChange={{this.onSelect}}
-                     @successMessage="It works">
+        <OSS::Select
+          @value={{this.selectedItem}}
+          @items={{this.items}}
+          @onChange={{this.onSelect}}
+          @successMessage='It works'
+        >
           <:option as |item|>
             {{item.name}}
           </:option>
         </OSS::Select>
       </div>
 
-      <div class="fx-col fx-1 fx-gap-px-12">
+      <div class='fx-col fx-1 fx-gap-px-12'>
         <OSS::Select @value={{this.selectedItem}} @items={{this.items}} @onChange={{this.onSelect}} @disabled={{true}}>
           <:option as |item|>
             {{item.name}}
@@ -423,246 +603,287 @@
         </OSS::Select>
       </div>
     </div>
-    <div class="fx-row fx-1 margin-md">
-      <OSS::ArrayInput @values={{this.superHeroes}} @onChange={{this.updateSuperHeroes}} class="fx-1"
-                       data-control-name="mailing-edit-template-ccs-input" />
+    <div class='fx-row fx-1 margin-md'>
+      <OSS::ArrayInput
+        @values={{this.superHeroes}}
+        @onChange={{this.updateSuperHeroes}}
+        class='fx-1'
+        data-control-name='mailing-edit-template-ccs-input'
+      />
     </div>
-    <div class="fx-row fx-gap-px-12 margin-md">
-      <OSS::Tag @label="Tag" @skin="primary" @icon="far fa-thumbs-up" />
-      <OSS::Tag @label="Tag" @skin="success" @icon="far fa-thumbs-up" />
-      <OSS::Tag @label="Tag" @skin="warning" @icon="far fa-thumbs-up" />
-      <OSS::Tag @label="Tag" @skin="danger" @icon="far fa-thumbs-up" />
-      <OSS::Tag @label="Tag" @skin="secondary" @icon="far fa-thumbs-up" />
-      <OSS::Tag @label="Tag" @icon="far fa-thumbs-up" />
-      <OSS::Tag @label="Tag" @skin="secondary" />
-      <OSS::Tag @icon="far fa-thumbs-up" />
-      <OSS::Tag @label="Tag" @skin="xtd-orange" />
-      <OSS::Tag @label="Tag" @skin="xtd-cyan" />
-      <OSS::Tag @label="Tag" @skin="xtd-yellow" />
-      <OSS::Tag @label="Tag" @skin="xtd-blue" />
-      <OSS::Tag @label="Tag" @skin="xtd-violet" />
-      <OSS::Tag @label="Tag" @skin="xtd-lime" />
-      <OSS::Tag @label="Test with a huge label sentence" @skin="danger" @icon="far fa-thumbs-up" />
-      <OSS::Tag @label="Test with a huge label sentence" {{enable-tooltip title='Test with a huge label sentence'
-    placement='top' }} @skin="danger" @icon="far fa-thumbs-up" @hasEllipsis={{true}} />
-    </div>
-
-    <div class="fx-row fx-gap-px-12 margin-md">
-      <OSS::Tag @label="Tag" @skin="primary" @icon="far fa-thumbs-up" @plain={{true}} />
-      <OSS::Tag @label="Tag" @skin="success" @icon="far fa-thumbs-up" @plain={{true}} />
-      <OSS::Tag @label="Tag" @skin="warning" @icon="far fa-thumbs-up" @plain={{true}} />
-      <OSS::Tag @label="Tag" @skin="danger" @icon="far fa-thumbs-up" @plain={{true}} />
-      <OSS::Tag @label="Tag" @skin="secondary" @icon="far fa-thumbs-up" @plain={{true}} />
-      <OSS::Tag @label="Tag" @icon="far fa-thumbs-up" @plain={{true}} />
-      <OSS::Tag @label="Tag" @skin="secondary" @plain={{true}} />
-      <OSS::Tag @icon="far fa-thumbs-up" @plain={{true}} />
-      <OSS::Tag @label="Tag" @skin="xtd-orange" @plain={{true}} />
-      <OSS::Tag @label="Tag" @skin="xtd-cyan" @plain={{true}} />
-      <OSS::Tag @label="Tag" @skin="xtd-yellow" @plain={{true}} />
-      <OSS::Tag @label="Tag" @skin="xtd-blue" @plain={{true}} />
-      <OSS::Tag @label="Tag" @skin="xtd-violet" @plain={{true}} />
-      <OSS::Tag @label="Tag" @skin="xtd-lime" @plain={{true}} />
-      <OSS::Tag @label="Test with a huge label sentence" @skin="danger" @icon="far fa-thumbs-up" @plain={{true}} />
-      <OSS::Tag @label="Test with a huge label sentence" {{enable-tooltip title='Test with a huge label sentence'
-    placement='top' }} @skin="danger" @icon="far fa-thumbs-up" @hasEllipsis={{true}} @plain={{true}} />
-      <OSS::Tag @label="normal text - <b>bold text</b>" @skin="danger" @icon="far fa-thumbs-up"
-                @plain={{true}} @htmlSafe={{true}} />
+    <div class='fx-row fx-gap-px-12 margin-md'>
+      <OSS::Tag @label='Tag' @skin='primary' @icon='far fa-thumbs-up' />
+      <OSS::Tag @label='Tag' @skin='success' @icon='far fa-thumbs-up' />
+      <OSS::Tag @label='Tag' @skin='warning' @icon='far fa-thumbs-up' />
+      <OSS::Tag @label='Tag' @skin='danger' @icon='far fa-thumbs-up' />
+      <OSS::Tag @label='Tag' @skin='secondary' @icon='far fa-thumbs-up' />
+      <OSS::Tag @label='Tag' @icon='far fa-thumbs-up' />
+      <OSS::Tag @label='Tag' @skin='secondary' />
+      <OSS::Tag @icon='far fa-thumbs-up' />
+      <OSS::Tag @label='Tag' @skin='xtd-orange' />
+      <OSS::Tag @label='Tag' @skin='xtd-cyan' />
+      <OSS::Tag @label='Tag' @skin='xtd-yellow' />
+      <OSS::Tag @label='Tag' @skin='xtd-blue' />
+      <OSS::Tag @label='Tag' @skin='xtd-violet' />
+      <OSS::Tag @label='Tag' @skin='xtd-lime' />
+      <OSS::Tag @label='Test with a huge label sentence' @skin='danger' @icon='far fa-thumbs-up' />
+      <OSS::Tag
+        @label='Test with a huge label sentence'
+        {{enable-tooltip title='Test with a huge label sentence' placement='top'}}
+        @skin='danger'
+        @icon='far fa-thumbs-up'
+        @hasEllipsis={{true}}
+      />
     </div>
 
-    <div class="fx-row fx-gap-px-12 margin-md">
-      <OSS::Alert @title="Title" @subtitle="Subtitle">
+    <div class='fx-row fx-gap-px-12 margin-md'>
+      <OSS::Tag @label='Tag' @skin='primary' @icon='far fa-thumbs-up' @plain={{true}} />
+      <OSS::Tag @label='Tag' @skin='success' @icon='far fa-thumbs-up' @plain={{true}} />
+      <OSS::Tag @label='Tag' @skin='warning' @icon='far fa-thumbs-up' @plain={{true}} />
+      <OSS::Tag @label='Tag' @skin='danger' @icon='far fa-thumbs-up' @plain={{true}} />
+      <OSS::Tag @label='Tag' @skin='secondary' @icon='far fa-thumbs-up' @plain={{true}} />
+      <OSS::Tag @label='Tag' @icon='far fa-thumbs-up' @plain={{true}} />
+      <OSS::Tag @label='Tag' @skin='secondary' @plain={{true}} />
+      <OSS::Tag @icon='far fa-thumbs-up' @plain={{true}} />
+      <OSS::Tag @label='Tag' @skin='xtd-orange' @plain={{true}} />
+      <OSS::Tag @label='Tag' @skin='xtd-cyan' @plain={{true}} />
+      <OSS::Tag @label='Tag' @skin='xtd-yellow' @plain={{true}} />
+      <OSS::Tag @label='Tag' @skin='xtd-blue' @plain={{true}} />
+      <OSS::Tag @label='Tag' @skin='xtd-violet' @plain={{true}} />
+      <OSS::Tag @label='Tag' @skin='xtd-lime' @plain={{true}} />
+      <OSS::Tag @label='Test with a huge label sentence' @skin='danger' @icon='far fa-thumbs-up' @plain={{true}} />
+      <OSS::Tag
+        @label='Test with a huge label sentence'
+        {{enable-tooltip title='Test with a huge label sentence' placement='top'}}
+        @skin='danger'
+        @icon='far fa-thumbs-up'
+        @hasEllipsis={{true}}
+        @plain={{true}}
+      />
+      <OSS::Tag
+        @label='normal text - <b>bold text</b>'
+        @skin='danger'
+        @icon='far fa-thumbs-up'
+        @plain={{true}}
+        @htmlSafe={{true}}
+      />
+    </div>
+
+    <div class='fx-row fx-gap-px-12 margin-md'>
+      <OSS::Alert @title='Title' @subtitle='Subtitle'>
         <:extra-content>
-          <div class="fx-row fx-gap-px-12">
-            <OSS::Link @label="Super Label" @icon="fas fa-hourglass" />
-            <OSS::Link @label="Super Label 2" />
+          <div class='fx-row fx-gap-px-12'>
+            <OSS::Link @label='Super Label' @icon='fas fa-hourglass' />
+            <OSS::Link @label='Super Label 2' />
           </div>
         </:extra-content>
       </OSS::Alert>
     </div>
-    <div class="fx-row fx-gap-px-12 margin-md">
-      <OSS::Alert @title="TitleTest" @subtitle="SubtitleTest" @plain={{false}} @closable={{true}} />
-      <OSS::Alert @title="Title" @subtitle="Subtitle" />
-      <OSS::Alert @skin="error" @title="Title" @subtitle="Subtitle" />
+    <div class='fx-row fx-gap-px-12 margin-md'>
+      <OSS::Alert @title='TitleTest' @subtitle='SubtitleTest' @plain={{false}} @closable={{true}} />
+      <OSS::Alert @title='Title' @subtitle='Subtitle' />
+      <OSS::Alert @skin='error' @title='Title' @subtitle='Subtitle' />
     </div>
-    <div class="fx-row fx-gap-px-12 margin-md">
-      <OSS::Alert @skin="success" @title="Title" />
-      <OSS::Alert @skin="warning" @subtitle="Subtitle" />
+    <div class='fx-row fx-gap-px-12 margin-md'>
+      <OSS::Alert @skin='success' @title='Title' />
+      <OSS::Alert @skin='warning' @subtitle='Subtitle' />
     </div>
-    <div class="fx-row fx-gap-px-12 margin-md">
-      <OSS::Button @label="Info" @size="md" {{on "click" (fn this.triggerToast "info" )}} />
-      <OSS::Button @label="Success" @size="md" {{on "click" (fn this.triggerToast "success" )}} />
-      <OSS::Button @label="Warning" @size="md" {{on "click" (fn this.triggerToast "warning" )}} />
-      <OSS::Button @label="Error" @size="md" {{on "click" (fn this.triggerToast "error" )}} />
+    <div class='fx-row fx-gap-px-12 margin-md'>
+      <OSS::Button @label='Info' @size='md' {{on 'click' (fn this.triggerToast 'info')}} />
+      <OSS::Button @label='Success' @size='md' {{on 'click' (fn this.triggerToast 'success')}} />
+      <OSS::Button @label='Warning' @size='md' {{on 'click' (fn this.triggerToast 'warning')}} />
+      <OSS::Button @label='Error' @size='md' {{on 'click' (fn this.triggerToast 'error')}} />
     </div>
-    <div class="fx-col fx-gap-px-12 margin-md">
-      <OSS::CodeBlock @content={{this.code4CodeBlock}} @scrollable={{true}} @copyable={{true}} @collapseHeight={{200}}
-                      @onCopyMessage="Copied to clipboard!" />
+    <div class='fx-col fx-gap-px-12 margin-md'>
+      <OSS::CodeBlock
+        @content={{this.code4CodeBlock}}
+        @scrollable={{true}}
+        @copyable={{true}}
+        @collapseHeight={{200}}
+        @onCopyMessage='Copied to clipboard!'
+      />
     </div>
-    <div class="fx-col fx-gap-px-12 margin-md">
-      <OSS::Button @skin="primary" @size="md" @label="Open MODAL" @icon="fa fa-unicorn" {{on "click" this.openModal}} />
+    <div class='fx-col fx-gap-px-12 margin-md'>
+      <OSS::Button @skin='primary' @size='md' @label='Open MODAL' @icon='fa fa-unicorn' {{on 'click' this.openModal}} />
       {{#if this.showModal}}
-        <OSS::ModalDialog @title="Example modal" @subtitle="subtitle" @close={{this.closeModal}} @size="md">
+        <OSS::ModalDialog @title='Example modal' @subtitle='subtitle' @close={{this.closeModal}} @size='md'>
           <:content>
-            <div style="height: 200px; background-color: white">
+            <div style='height: 200px; background-color: white'>
               azeazeazeaze
             </div>
           </:content>
           <:footer>
-            <div class="fx-1">
-              <OSS::Icon @icon="fa-info" /><a href="">More info</a>
+            <div class='fx-1'>
+              <OSS::Icon @icon='fa-info' /><a href=''>More info</a>
             </div>
-            <div class="fx-row fx-gap-px-12">
-              <OSS::Button @skin="default" @label="Close" {{on "click" this.closeModal}} />
-              <OSS::Button @skin="secondary" @label="Save" />
+            <div class='fx-row fx-gap-px-12'>
+              <OSS::Button @skin='default' @label='Close' {{on 'click' this.closeModal}} />
+              <OSS::Button @skin='secondary' @label='Save' />
             </div>
           </:footer>
         </OSS::ModalDialog>
       {{/if}}
     </div>
-    <div class="fx-col fx-gap-px-12 margin-md">
-      <div class="fx-row fx-gap-px-12">
-        <div class="fx-col fx-gap-px-12">
-          <OSS::Button @skin="destructive" @label="destructive" @icon="fas fa-box-open" @size="md" />
-          <OSS::Button @skin="destructive" @square="true" @icon="fas fa-box-open" @size="md" />
+    <div class='fx-col fx-gap-px-12 margin-md'>
+      <div class='fx-row fx-gap-px-12'>
+        <div class='fx-col fx-gap-px-12'>
+          <OSS::Button @skin='destructive' @label='destructive' @icon='fas fa-box-open' @size='md' />
+          <OSS::Button @skin='destructive' @square='true' @icon='fas fa-box-open' @size='md' />
         </div>
-        <div class="fx-col fx-gap-px-12">
-          <OSS::Button @skin="alert" @label="alert" @icon="fas fa-box-open" @size="md" />
-          <OSS::Button @skin="alert" @square="true" @icon="fas fa-box-open" @size="md" />
+        <div class='fx-col fx-gap-px-12'>
+          <OSS::Button @skin='alert' @label='alert' @icon='fas fa-box-open' @size='md' />
+          <OSS::Button @skin='alert' @square='true' @icon='fas fa-box-open' @size='md' />
         </div>
-        <div class="fx-col fx-gap-px-12">
-          <OSS::Button @skin="secondary" @label="secondary" @icon="fas fa-box-open" @size="md" />
-          <OSS::Button @skin="secondary" @square="true" @icon="fas fa-box-open" @size="md" />
+        <div class='fx-col fx-gap-px-12'>
+          <OSS::Button @skin='secondary' @label='secondary' @icon='fas fa-box-open' @size='md' />
+          <OSS::Button @skin='secondary' @square='true' @icon='fas fa-box-open' @size='md' />
         </div>
-        <div class="fx-col fx-gap-px-12">
-          <OSS::Button @skin="default" @label="default" @icon="fas fa-box-open" @size="md" />
-          <OSS::Button @skin="default" @square="true" @icon="fas fa-box-open" @size="md" />
+        <div class='fx-col fx-gap-px-12'>
+          <OSS::Button @skin='default' @label='default' @icon='fas fa-box-open' @size='md' />
+          <OSS::Button @skin='default' @square='true' @icon='fas fa-box-open' @size='md' />
         </div>
-        <div class="fx-col fx-gap-px-12">
-          <OSS::Button @skin="success" @label="success" @icon="fas fa-box-open" @size="md" />
-          <OSS::Button @skin="success" @square="true" @icon="fas fa-box-open" @size="md" />
-        </div>
-      </div>
-      <div class="fx-row fx-gap-px-12">
-        <div class="fx-col fx-gap-px-12">
-          <OSS::Button @skin="xtd-orange" @label="Extended orange" @icon="fas fa-plus" @size="md" />
-          <OSS::Button @skin="xtd-orange" @square="true" @icon="fas fa-plus" @size="md" />
-        </div>
-        <div class="fx-col fx-gap-px-12">
-          <OSS::Button @skin="xtd-yellow" @label="Extended yellow" @icon="fas fa-plus" @size="md" />
-          <OSS::Button @skin="xtd-yellow" @square="true" @icon="fas fa-plus" @size="md" />
-        </div>
-        <div class="fx-col fx-gap-px-12">
-          <OSS::Button @skin="xtd-lime" @label="Extended lime" @icon="fas fa-plus" @size="md" />
-          <OSS::Button @skin="xtd-lime" @square="true" @icon="fas fa-plus" @size="md" />
-        </div>
-        <div class="fx-col fx-gap-px-12">
-          <OSS::Button @skin="xtd-cyan" @label="Extended Cyan" @icon="fas fa-plus" @size="md" />
-          <OSS::Button @skin="xtd-cyan" @square="true" @icon="fas fa-plus" @size="md" />
-        </div>
-        <div class="fx-col fx-gap-px-12">
-          <OSS::Button @skin="xtd-blue" @label="Extended blue" @icon="fas fa-plus" @size="md" />
-          <OSS::Button @skin="xtd-blue" @square="true" @icon="fas fa-plus" @size="md" />
-        </div>
-        <div class="fx-col fx-gap-px-12">
-          <OSS::Button @skin="xtd-violet" @label="Extended violet" @icon="fas fa-plus" @size="md" />
-          <OSS::Button @skin="xtd-violet" @square="true" @icon="fas fa-plus" @size="md" />
+        <div class='fx-col fx-gap-px-12'>
+          <OSS::Button @skin='success' @label='success' @icon='fas fa-box-open' @size='md' />
+          <OSS::Button @skin='success' @square='true' @icon='fas fa-box-open' @size='md' />
         </div>
       </div>
-      <div class="fx-row fx-gap-px-12">
-        <OSS::Button @skin="primary" @size="xs" @label="XS" @icon="far fa-envelope-open" />
-        <OSS::Button @skin="primary" @size="sm" @label="SM" @icon="far fa-envelope-open" />
-        <OSS::Button @skin="primary" @size="md" @label="MD" @icon="far fa-envelope-open" />
-        <OSS::Button @skin="primary" @size="lg" @label="LG" @icon="far fa-envelope-open" />
+      <div class='fx-row fx-gap-px-12'>
+        <div class='fx-col fx-gap-px-12'>
+          <OSS::Button @skin='xtd-orange' @label='Extended orange' @icon='fas fa-plus' @size='md' />
+          <OSS::Button @skin='xtd-orange' @square='true' @icon='fas fa-plus' @size='md' />
+        </div>
+        <div class='fx-col fx-gap-px-12'>
+          <OSS::Button @skin='xtd-yellow' @label='Extended yellow' @icon='fas fa-plus' @size='md' />
+          <OSS::Button @skin='xtd-yellow' @square='true' @icon='fas fa-plus' @size='md' />
+        </div>
+        <div class='fx-col fx-gap-px-12'>
+          <OSS::Button @skin='xtd-lime' @label='Extended lime' @icon='fas fa-plus' @size='md' />
+          <OSS::Button @skin='xtd-lime' @square='true' @icon='fas fa-plus' @size='md' />
+        </div>
+        <div class='fx-col fx-gap-px-12'>
+          <OSS::Button @skin='xtd-cyan' @label='Extended Cyan' @icon='fas fa-plus' @size='md' />
+          <OSS::Button @skin='xtd-cyan' @square='true' @icon='fas fa-plus' @size='md' />
+        </div>
+        <div class='fx-col fx-gap-px-12'>
+          <OSS::Button @skin='xtd-blue' @label='Extended blue' @icon='fas fa-plus' @size='md' />
+          <OSS::Button @skin='xtd-blue' @square='true' @icon='fas fa-plus' @size='md' />
+        </div>
+        <div class='fx-col fx-gap-px-12'>
+          <OSS::Button @skin='xtd-violet' @label='Extended violet' @icon='fas fa-plus' @size='md' />
+          <OSS::Button @skin='xtd-violet' @square='true' @icon='fas fa-plus' @size='md' />
+        </div>
       </div>
-      <div class="fx-row fx-gap-px-12">
-        <OSS::Button @square="true" @skin="primary" @size="sm" @icon="far fa-envelope-open" />
-        <OSS::Button @square="true" @skin="primary" @size="md" @icon="far fa-envelope-open" />
-        <OSS::Button @square="true" @skin="primary" @size="lg" @icon="far fa-envelope-open" />
+      <div class='fx-row fx-gap-px-12'>
+        <OSS::Button @skin='primary' @size='xs' @label='XS' @icon='far fa-envelope-open' />
+        <OSS::Button @skin='primary' @size='sm' @label='SM' @icon='far fa-envelope-open' />
+        <OSS::Button @skin='primary' @size='md' @label='MD' @icon='far fa-envelope-open' />
+        <OSS::Button @skin='primary' @size='lg' @label='LG' @icon='far fa-envelope-open' />
       </div>
-
-      <div class="fx-row fx-gap-px-12 fx-xalign-center">
-        <OSS::Badge @icon="fas fa-box-open" @size="lg" />
-        <OSS::Badge @icon="fas fa-box-open" />
-        <OSS::Badge @size="md" @icon="fas fa-box-open" />
-        <OSS::Badge @size="sm" @icon="fas fa-box-open" />
+      <div class='fx-row fx-gap-px-12'>
+        <OSS::Button @square='true' @skin='primary' @size='sm' @icon='far fa-envelope-open' />
+        <OSS::Button @square='true' @skin='primary' @size='md' @icon='far fa-envelope-open' />
+        <OSS::Button @square='true' @skin='primary' @size='lg' @icon='far fa-envelope-open' />
       </div>
 
-      <div class="fx-row fx-gap-px-12 fx-xalign-center">
-        <OSS::Badge @icon="fas fa-box-open" @skin="primary" />
-        <OSS::Badge @icon="fas fa-box-open" @skin="primary" @plain={{true}} />
-        <OSS::Badge @icon="fas fa-box-open" @skin="success" />
-        <OSS::Badge @icon="fas fa-box-open" @skin="success" @plain={{true}} />
-        <OSS::Badge @icon="fas fa-box-open" @skin="alert" />
-        <OSS::Badge @icon="fas fa-box-open" @skin="alert" @plain={{true}} />
-        <OSS::Badge @icon="fas fa-box-open" @skin="error" />
-        <OSS::Badge @icon="fas fa-box-open" @skin="error" @plain={{true}} />
-        <OSS::Badge @icon="fas fa-box-open" @skin="xtd-orange" />
-        <OSS::Badge @icon="fas fa-box-open" @skin="xtd-orange" @plain={{true}} />
-        <OSS::Badge @icon="fas fa-box-open" @skin="xtd-yellow" />
-        <OSS::Badge @icon="fas fa-box-open" @skin="xtd-yellow" @plain={{true}} />
-        <OSS::Badge @icon="fas fa-box-open" @skin="xtd-lime" />
-        <OSS::Badge @icon="fas fa-box-open" @skin="xtd-lime" @plain={{true}} />
-        <OSS::Badge @icon="fas fa-box-open" @skin="xtd-cyan" />
-        <OSS::Badge @icon="fas fa-box-open" @skin="xtd-cyan" @plain={{true}} />
-        <OSS::Badge @icon="fas fa-box-open" @skin="xtd-blue" />
-        <OSS::Badge @icon="fas fa-box-open" @skin="xtd-blue" @plain={{true}} />
-        <OSS::Badge @icon="fas fa-box-open" @skin="xtd-violet" />
-        <OSS::Badge @icon="fas fa-box-open" @skin="xtd-violet" @plain={{true}} />
+      <div class='fx-row fx-gap-px-12 fx-xalign-center'>
+        <OSS::Badge @icon='fas fa-box-open' @size='lg' />
+        <OSS::Badge @icon='fas fa-box-open' />
+        <OSS::Badge @size='md' @icon='fas fa-box-open' />
+        <OSS::Badge @size='sm' @icon='fas fa-box-open' />
       </div>
 
-      <div class="fx-row fx-gap-px-12 fx-xalign-center">
-        <OSS::Badge @text="2x" @size="lg" />
-        <OSS::Badge @text="2x" />
-        <OSS::Badge @text="2x" @size="sm" />
+      <div class='fx-row fx-gap-px-12 fx-xalign-center'>
+        <OSS::Badge @icon='fas fa-box-open' @skin='primary' />
+        <OSS::Badge @icon='fas fa-box-open' @skin='primary' @plain={{true}} />
+        <OSS::Badge @icon='fas fa-box-open' @skin='success' />
+        <OSS::Badge @icon='fas fa-box-open' @skin='success' @plain={{true}} />
+        <OSS::Badge @icon='fas fa-box-open' @skin='alert' />
+        <OSS::Badge @icon='fas fa-box-open' @skin='alert' @plain={{true}} />
+        <OSS::Badge @icon='fas fa-box-open' @skin='error' />
+        <OSS::Badge @icon='fas fa-box-open' @skin='error' @plain={{true}} />
+        <OSS::Badge @icon='fas fa-box-open' @skin='xtd-orange' />
+        <OSS::Badge @icon='fas fa-box-open' @skin='xtd-orange' @plain={{true}} />
+        <OSS::Badge @icon='fas fa-box-open' @skin='xtd-yellow' />
+        <OSS::Badge @icon='fas fa-box-open' @skin='xtd-yellow' @plain={{true}} />
+        <OSS::Badge @icon='fas fa-box-open' @skin='xtd-lime' />
+        <OSS::Badge @icon='fas fa-box-open' @skin='xtd-lime' @plain={{true}} />
+        <OSS::Badge @icon='fas fa-box-open' @skin='xtd-cyan' />
+        <OSS::Badge @icon='fas fa-box-open' @skin='xtd-cyan' @plain={{true}} />
+        <OSS::Badge @icon='fas fa-box-open' @skin='xtd-blue' />
+        <OSS::Badge @icon='fas fa-box-open' @skin='xtd-blue' @plain={{true}} />
+        <OSS::Badge @icon='fas fa-box-open' @skin='xtd-violet' />
+        <OSS::Badge @icon='fas fa-box-open' @skin='xtd-violet' @plain={{true}} />
       </div>
 
-      <div class="fx-row fx-gap-px-12 fx-xalign-center">
-        <OSS::Badge @image="https://reachr-assets.s3.us-west-2.amazonaws.com/influencer-server/influencer/7219681.png"
-                    @size="lg" />
+      <div class='fx-row fx-gap-px-12 fx-xalign-center'>
+        <OSS::Badge @text='2x' @size='lg' />
+        <OSS::Badge @text='2x' />
+        <OSS::Badge @text='2x' @size='sm' />
+      </div>
+
+      <div class='fx-row fx-gap-px-12 fx-xalign-center'>
         <OSS::Badge
-                    @image="https://reachr-assets.s3.us-west-2.amazonaws.com/influencer-server/influencer/7219681.png" />
-        <OSS::Badge @image="https://reachr-assets.s3.us-west-2.amazonaws.com/influencer-server/influencer/7219681.png"
-                    @size="sm" />
+          @image='https://reachr-assets.s3.us-west-2.amazonaws.com/influencer-server/influencer/7219681.png'
+          @size='lg'
+        />
+        <OSS::Badge
+          @image='https://reachr-assets.s3.us-west-2.amazonaws.com/influencer-server/influencer/7219681.png'
+        />
+        <OSS::Badge
+          @image='https://reachr-assets.s3.us-west-2.amazonaws.com/influencer-server/influencer/7219681.png'
+          @size='sm'
+        />
       </div>
 
-      <div class="fx-row fx-gap-px-12 fx-xalign-center">
+      <div class='fx-row fx-gap-px-12 fx-xalign-center'>
         {{#each this.media as |socialMedia|}}
-          <OSS::SocialPostBadge @postType={{socialMedia.key}} @selected={{socialMedia.active}}
-                                @plain={{socialMedia.active}}
-                                @onToggle={{this.toggleMedia}} />
+          <OSS::SocialPostBadge
+            @postType={{socialMedia.key}}
+            @selected={{socialMedia.active}}
+            @plain={{socialMedia.active}}
+            @onToggle={{this.toggleMedia}}
+          />
         {{/each}}
       </div>
 
-      <div class="fx-row fx-gap-px-12">
-        <div class="fx-col fx-gap-px-12">
-          <OSS::Button @skin="destructive" @label="Count down" @icon="far fa-hourglass" @size="md" @countDown={{hash
-        callback=this.countDownAction}} />
+      <div class='fx-row fx-gap-px-12'>
+        <div class='fx-col fx-gap-px-12'>
+          <OSS::Button
+            @skin='destructive'
+            @label='Count down'
+            @icon='far fa-hourglass'
+            @size='md'
+            @countDown={{hash callback=this.countDownAction}}
+          />
         </div>
       </div>
-      <div class="fx-row fx-1">
-        <OSS::PhoneNumberInput @prefix={{this.phonePrefix}} @number={{this.phoneNumber}}
-                               @onChange={{this.onPhoneNumberChange}} />
+      <div class='fx-row fx-1'>
+        <OSS::PhoneNumberInput
+          @prefix={{this.phonePrefix}}
+          @number={{this.phoneNumber}}
+          @onChange={{this.onPhoneNumberChange}}
+        />
       </div>
     </div>
 
-    <div class="upf-table-v2 margin-md">
-      <div class="upf-table__header">
+    <div class='upf-table-v2 margin-md'>
+      <div class='upf-table__header'>
         {{#each this.tableDemo.header as |header|}}
-          <div class="upf-table__cell {{header.class}}">
+          <div class='upf-table__cell {{header.class}}'>
             {{header.title}}
           </div>
         {{/each}}
       </div>
 
-      <div class="upf-table__content">
+      <div class='upf-table__content'>
         {{#each this.tableDemo.header as |header index|}}
-          <div class="upf-table__row">
+          <div class='upf-table__row'>
             {{#each this.tableDemo.header as |header index|}}
-              <div class="upf-table__cell {{header.class}}">
+              <div class='upf-table__cell {{header.class}}'>
                 {{#if header.title}}
-                  <OSS::Tag @skin="primary" @label="Hello" />
+                  <OSS::Tag @skin='primary' @label='Hello' />
                 {{else}}
-                  <OSS::Icon @icon="fa-chevron-right" />
+                  <OSS::Icon @icon='fa-chevron-right' />
                 {{/if}}
               </div>
             {{/each}}
@@ -671,24 +892,25 @@
       </div>
     </div>
 
-    <div class="upf-table-v2 upf-table-v2--clickable margin-md">
-      <div class="upf-table__header">
+    <div class='upf-table-v2 upf-table-v2--clickable margin-md'>
+      <div class='upf-table__header'>
         {{#each this.tableDemo.header as |header|}}
-          <div class="upf-table__cell {{header.class}}">
+          <div class='upf-table__cell {{header.class}}'>
             {{header.title}}
           </div>
         {{/each}}
       </div>
 
-      <div class="upf-table__content">
+      <div class='upf-table__content'>
         {{#each this.tableDemo.header as |header index|}}
-          <div class="upf-table__row" role="button">
+          <div class='upf-table__row' role='button'>
             {{#each this.tableDemo.header as |header index|}}
-              <div class="upf-table__cell {{header.class}}">
+              <div class='upf-table__cell {{header.class}}'>
                 {{#if header.title}}
-                  Content {{index}}
+                  Content
+                  {{index}}
                 {{else}}
-                  <OSS::Icon @icon="fa-chevron-right" />
+                  <OSS::Icon @icon='fa-chevron-right' />
                 {{/if}}
               </div>
             {{/each}}
@@ -697,54 +919,83 @@
       </div>
     </div>
 
-    <div class="fx-col fx-gap-px-12 padding-px-24">
-      <div class="fx-row fx-gap-px-12">
-        <OSS::UploadArea @uploader={{this.mockUploader}} @rules={{array (hash type="filesize" value="8MB" )}} @size="lg"
-                         @subtitle="JPG, PNG, PDF (Max 800x400px - 2MB)" @onUploadSuccess={{this.onUploadSuccess}} />
+    <div class='fx-col fx-gap-px-12 padding-px-24'>
+      <div class='fx-row fx-gap-px-12'>
+        <OSS::UploadArea
+          @uploader={{this.mockUploader}}
+          @rules={{array (hash type='filesize' value='8MB')}}
+          @size='lg'
+          @subtitle='JPG, PNG, PDF (Max 800x400px - 2MB)'
+          @onUploadSuccess={{this.onUploadSuccess}}
+        />
 
-        <OSS::UploadArea @uploader={{this.mockUploader}} @rules={{array (hash type="filesize" value="8MB" )}}
-                         @subtitle="JPG, PNG, PDF (Max 800x400px - 2MB)" @onUploadSuccess={{this.onUploadSuccess}}
-                         @displayPreview={{true}} />
+        <OSS::UploadArea
+          @uploader={{this.mockUploader}}
+          @rules={{array (hash type='filesize' value='8MB')}}
+          @subtitle='JPG, PNG, PDF (Max 800x400px - 2MB)'
+          @onUploadSuccess={{this.onUploadSuccess}}
+          @displayPreview={{true}}
+        />
       </div>
 
-      <div class="fx-col fx-gap-px-12">
-        <OSS::UploadArea @uploader={{this.mockUploader}} @rules={{array (hash type="filesize" value="8MB" )}} @size="lg"
-                         @disabled={{true}} @subtitle="JPG, PNG, PDF (Max 800x400px - 2MB)"
-                         @onUploadSuccess={{this.onUploadSuccess}} />
+      <div class='fx-col fx-gap-px-12'>
+        <OSS::UploadArea
+          @uploader={{this.mockUploader}}
+          @rules={{array (hash type='filesize' value='8MB')}}
+          @size='lg'
+          @disabled={{true}}
+          @subtitle='JPG, PNG, PDF (Max 800x400px - 2MB)'
+          @onUploadSuccess={{this.onUploadSuccess}}
+        />
 
-        <OSS::UploadArea @uploader={{this.mockUploader}} @rules={{array (hash type="filesize" value="8MB" )}}
-                         @disabled={{true}} @subtitle="JPG, PNG, PDF (Max 800x400px - 2MB)"
-                         @onUploadSuccess={{this.onUploadSuccess}} />
+        <OSS::UploadArea
+          @uploader={{this.mockUploader}}
+          @rules={{array (hash type='filesize' value='8MB')}}
+          @disabled={{true}}
+          @subtitle='JPG, PNG, PDF (Max 800x400px - 2MB)'
+          @onUploadSuccess={{this.onUploadSuccess}}
+        />
       </div>
     </div>
-    <div class="fx-row fx-xalign-start fx-gap-px-10 margin-md">
-      <OSS::ContentPanel class="fx-col fx-1">
-        <span class="text-style-semibold">Title</span>
-        <span class="font-color-gray-500">Subtitle</span>
-        <hr class="width-pc-100" />
+    <div class='fx-row fx-xalign-start fx-gap-px-10 margin-md'>
+      <OSS::ContentPanel class='fx-col fx-1'>
+        <span class='text-style-semibold'>Title</span>
+        <span class='font-color-gray-500'>Subtitle</span>
+        <hr class='width-pc-100' />
         <span>Content</span>
       </OSS::ContentPanel>
-      <OSS::ContentPanel class="fx-row fx-1 fx-gap-px-10">
-        <OSS::UrlInput @value={{this.shopifyDomain}} @prefix="https://" @placeholder="shopname" @suffix=".myshopify.com"
-                       @errorMessage="Not a valid shopify domain" @validationRegex={{this.subdomainRegex}}
-                       @onChange={{this.onUrlInputChange}} />
-        <OSS::UrlInput @prefix="https://" @placeholder="No regex specified" @onChange={{this.onUrlInputChange}}
-                       @value={{this.shopifyDomain}} />
+      <OSS::ContentPanel class='fx-row fx-1 fx-gap-px-10'>
+        <OSS::UrlInput
+          @value={{this.shopifyDomain}}
+          @prefix='https://'
+          @placeholder='shopname'
+          @suffix='.myshopify.com'
+          @errorMessage='Not a valid shopify domain'
+          @validationRegex={{this.subdomainRegex}}
+          @onChange={{this.onUrlInputChange}}
+        />
+        <OSS::UrlInput
+          @prefix='https://'
+          @placeholder='No regex specified'
+          @onChange={{this.onUrlInputChange}}
+          @value={{this.shopifyDomain}}
+        />
       </OSS::ContentPanel>
     </div>
-    <div class="fx-col fx-gap-px-12 padding-px-24">
-      <OSS::Panel @icon="/assets/images/upfluence-white-logo.svg">
+    <div class='fx-col fx-gap-px-12 padding-px-24'>
+      <OSS::Panel @icon='/assets/images/upfluence-white-logo.svg'>
         <:header>
           <OSS::Avatar
-                       @image="https://reachr-assets.s3.us-west-2.amazonaws.com/influencer-server/influencer/7219681.png" />
+            @image='https://reachr-assets.s3.us-west-2.amazonaws.com/influencer-server/influencer/7219681.png'
+          />
         </:header>
         <:content>
-          <OSS::Panel::Row @label="First Label" @icon="fa-search" />
-          <OSS::Panel::Row @label="Second Label" @icon="fa-cog" />
-          <OSS::Panel::Row @label="Third Label" @icon="fa-search" />
+          <OSS::Panel::Row @label='First Label' @icon='fa-search' />
+          <OSS::Panel::Row @label='Second Label' @icon='fa-cog' />
+          <OSS::Panel::Row @label='Third Label' @icon='fa-search' />
         </:content>
         <:footer>
-          <OSS::Panel::Row @label="Logout" @icon="fa-sign-out" />
+          <OSS::Panel::Row @label='Logout' @icon='fa-sign-out' />
         </:footer>
       </OSS::Panel>
     </div>


### PR DESCRIPTION
### What does this PR do?

POC to replace the popover component in favor of a Jqueryless solution. 
The implementation template side is the same. 


Related to: #<!-- enter issue number here -->
https://linear.app/upfluence/issue/VEL-3141/removing-popover-component-in-favor-of-jquery-free-solution

### What are the observable changes?
[<!-- This question could be adequate with multiple use cases, for example: -->
](https://www.loom.com/share/1fc4a82723524a4d80c00f872c73b5dd?sid=217cc074-2f54-42ee-a23b-c122f31c82dd)
<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->

### Good PR checklist
- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled
