### PR TITLE
Updated: OSS::InputContainer with new hasError param + updated tests

### DIFF
--- a/addon/components/o-s-s/input-container.hbs
+++ b/addon/components/o-s-s/input-container.hbs
@@ -1,5 +1,5 @@
 <div class="fx-col">
-  <div class="oss-input-container {{if @errorMessage ' oss-input-container--errored'}}
+  <div class="oss-input-container {{if this.displayRedBorder ' oss-input-container--errored'}}
               {{if (has-block "prefix") ' has-prefix'}}
               {{if (has-block "suffix") ' has-suffix'}}"
        ...attributes>
@@ -21,6 +21,6 @@
     {{/if}}
   </div>
   {{#if @errorMessage}}
-    <span class="text-color-error margin-top-xxx-sm">{{@errorMessage}}</span>
+    <span class="text-color-error margin-top-px-6">{{@errorMessage}}</span>
   {{/if}}
 </div>

--- a/addon/components/o-s-s/input-container.hbs
+++ b/addon/components/o-s-s/input-container.hbs
@@ -1,5 +1,5 @@
 <div class="fx-col">
-  <div class="oss-input-container {{if this.displayRedBorder ' oss-input-container--errored'}}
+  <div class="oss-input-container {{if this.displayErrorStyle ' oss-input-container--errored'}}
               {{if (has-block "prefix") ' has-prefix'}}
               {{if (has-block "suffix") ' has-suffix'}}"
        ...attributes>

--- a/addon/components/o-s-s/input-container.stories.js
+++ b/addon/components/o-s-s/input-container.stories.js
@@ -47,7 +47,7 @@ export default {
     },
     hasError: {
       description:
-        'Allows setting a red border on the input without showing an error message. Useful for form validation.',
+        'Allows setting the error style on the input without showing an error message. Useful for form validation.',
       table: {
         type: {
           summary: 'boolean'

--- a/addon/components/o-s-s/input-container.stories.js
+++ b/addon/components/o-s-s/input-container.stories.js
@@ -45,6 +45,17 @@ export default {
       },
       control: { type: 'text' }
     },
+    hasError: {
+      description:
+        'Allows setting a red border on the input without showing an error message. Useful for form validation.',
+      table: {
+        type: {
+          summary: 'boolean'
+        },
+        defaultValue: { summary: 'undefined' }
+      },
+      control: { type: 'boolean' }
+    },
     onChange: {
       description: 'Method called every time the input is updated',
       table: {

--- a/addon/components/o-s-s/input-container.ts
+++ b/addon/components/o-s-s/input-container.ts
@@ -5,11 +5,16 @@ interface OSSInputContainerArgs {
   value?: string;
   disabled?: boolean;
   errorMessage?: string;
+  hasError?: boolean;
   placeholder?: string;
   onChange?(value: string): void;
 }
 
 export default class OSSInputContainer extends Component<OSSInputContainerArgs> {
+  get displayRedBorder(): boolean {
+    return Boolean(this.args.errorMessage) || Boolean(this.args.hasError);
+  }
+
   @action
   _onChange(value: string): void {
     if (this.args.onChange) {

--- a/addon/components/o-s-s/input-container.ts
+++ b/addon/components/o-s-s/input-container.ts
@@ -11,7 +11,7 @@ interface OSSInputContainerArgs {
 }
 
 export default class OSSInputContainer extends Component<OSSInputContainerArgs> {
-  get displayRedBorder(): boolean {
+  get displayErrorStyle(): boolean {
     return Boolean(this.args.errorMessage) || Boolean(this.args.hasError);
   }
 

--- a/tests/integration/components/o-s-s/input-container-test.js
+++ b/tests/integration/components/o-s-s/input-container-test.js
@@ -79,6 +79,41 @@ module('Integration | Component | o-s-s/input-container', function (hooks) {
     });
   });
 
+  module('Error States', () => {
+    test('Passing an @errorMessage parameter displays an error message and sets the input border to red', async function (assert) {
+      await render(hbs`<OSS::InputContainer @errorMessage="This is an error message" />`);
+      assert.dom('.oss-input-container').hasClass('oss-input-container--errored');
+      assert.dom('.text-color-error').hasText('This is an error message');
+    });
+
+    test('Setting @errorMessage parameter to an empty string does not display an error message', async function (assert) {
+      await render(hbs`<OSS::InputContainer @errorMessage="" />`);
+      assert.dom('.oss-input-container').doesNotHaveClass('oss-input-container--errored');
+      assert.dom('.text-color-error').doesNotExist();
+    });
+
+    test('Passing a @hasError parameter displays a red border around the input', async function (assert) {
+      await render(hbs`<OSS::InputContainer @hasError={{true}} />`);
+      assert.dom('.oss-input-container').hasClass('oss-input-container--errored');
+    });
+
+    test('Setting @hasError parameter to false does not display a red border around the input', async function (assert) {
+      await render(hbs`<OSS::InputContainer @hasError={{false}} />`);
+      assert.dom('.oss-input-container').doesNotHaveClass('oss-input-container--errored');
+    });
+
+    test('Setting @hasError parameter to undefined does not display a red border around the input', async function (assert) {
+      await render(hbs`<OSS::InputContainer @hasError={{undefined}} />`);
+      assert.dom('.oss-input-container').doesNotHaveClass('oss-input-container--errored');
+    });
+
+    test('Having both @errorMessage and @hasError parameters set to true displays the error message', async function (assert) {
+      await render(hbs`<OSS::InputContainer @errorMessage="This is an error message" @hasError={{true}} />`);
+      assert.dom('.oss-input-container').hasClass('oss-input-container--errored');
+      assert.dom('.text-color-error').hasText('This is an error message');
+    });
+  });
+
   module('Extra attributes', () => {
     test('passing an extra class is applied to the component', async function (assert) {
       await render(hbs`<OSS::InputContainer class="my-extra-class" />`);


### PR DESCRIPTION
### What does this PR do?
Updated: OSS::InputContainer with new hasError param + updated tests

### Good PR checklist
- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [x] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled