### PR TITLE
Added xs size to OSS::ProgressBar

### DIFF
--- a/addon/components/o-s-s/progress-bar.stories.js
+++ b/addon/components/o-s-s/progress-bar.stories.js
@@ -1,7 +1,7 @@
 import { hbs } from 'ember-cli-htmlbars';
 
 const ProgressBarSkins = ['warning', 'success'];
-const ProgressBarSizes = ['sm'];
+const ProgressBarSizes = ['sm', 'xs'];
 
 export default {
   title: 'Components/OSS::ProgressBar',

--- a/addon/components/o-s-s/progress-bar.ts
+++ b/addon/components/o-s-s/progress-bar.ts
@@ -2,7 +2,7 @@ import Component from '@glimmer/component';
 import { assert } from '@ember/debug';
 
 type ProgressBarSkins = 'warning' | 'success';
-type ProgressBarSizes = 'sm';
+type ProgressBarSizes = 'sm' | 'xs';
 
 interface OSSProgressBarArgs {
   value: number;

--- a/app/styles/molecules/progress-bar.less
+++ b/app/styles/molecules/progress-bar.less
@@ -10,6 +10,12 @@
     }
   }
 
+  &--xs {
+    .oss-progress-bar__inner {
+      height: 1px;
+    }
+  }
+
   &--warning {
     .oss-progress-bar__inner {
       background-color: var(--color-warning-500);

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -220,7 +220,7 @@
       {{/if}}
     </div>
     <div class="fx-col fx-1 fx-gap-px-10 margin-md width-px-200">
-      <OSS::ProgressBar @skin="success" @value={{42}} @displayValue={{true}} @label="Hello" />
+      <OSS::ProgressBar @skin="success" @value={{42}} @displayValue={{true}} @label="Hello" @size="xs" />
       <OSS::ProgressBar @skin="warning" @value={{21}} @displayValue={{true}} @label="Hello" />
     </div>
     <div class="fx-row fx-1 fx-gap-px-10 margin-md">

--- a/tests/integration/components/o-s-s/progress-bar-test.ts
+++ b/tests/integration/components/o-s-s/progress-bar-test.ts
@@ -56,6 +56,14 @@ module('Integration | Component | o-s-s/progress-bar', function (hooks) {
       assert.equal(innerBar.clientHeight, 10, 'Element has the correct height');
     });
 
+    test('if the value is "xs", the progress bar height is the proper height', async function (assert) {
+      await render(hbs`<OSS::ProgressBar @value={{this.checkedValue}} @size="xs" />`);
+
+      assert.dom('.oss-progress-bar').exists();
+      const innerBar = this.element.querySelector('.oss-progress-bar__inner') as Element;
+      assert.equal(innerBar.clientHeight, 1, 'Element has the correct height');
+    });
+
     test('if the value is unspecified, the progress bar height is the proper height', async function (assert) {
       await render(hbs`<OSS::ProgressBar @value={{this.checkedValue}} />`);
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the context of this pull request and its purpose. -->
<img width="439" alt="Capture d’écran 2024-07-08 à 11 52 09" src="https://github.com/upfluence/oss-components/assets/37589993/d5ccace4-9efd-4529-a47d-97a1d4b0f9a6">

Adds a new XS size for OSS::ProgressBar

Related to: #<!-- enter issue number here -->
https://linear.app/upfluence/issue/DRA-1112/[ember-identity]-identitybilingtimeline-component

### What are the observable changes?
<!-- This question could be adequate with multiple use cases, for example: -->

<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->

### Good PR checklist
- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [ ] Properly labeled
