### PR TITLE
Add disabled state for currency-input component

### DIFF
--- a/addon/components/o-s-s/currency-input.hbs
+++ b/addon/components/o-s-s/currency-input.hbs
@@ -1,4 +1,4 @@
-<div class="currency-input-container fx-1 {{if @errorMessage 'currency-input-container--errored'}}" ...attributes>
+<div class="currency-input-container fx-1  {{if this.disabled 'currency-input-container--disabled'}} {{if @errorMessage 'currency-input-container--errored'}}" ...attributes>
   <div class="currency-input {{if @onlyCurrency 'onlycurrency'}} {{if this.currencySelectorShown 'currency-input--active'}}
               fx-row fx-1 fx-xalign-center">
     <div class="currency-selector fx-row fx-gap-px-12 fx-malign-space-between fx-xalign-center"
@@ -13,7 +13,7 @@
         </div>
       </div>
 
-      {{#if this.allowCurrencyUpdate}}
+      {{#if (and this.allowCurrencyUpdate (not this.disabled))}}
         <OSS::Icon @icon="{{if this.currencySelectorShown "fa-chevron-up" "fa-chevron-down"}}"
                    class="margin-left-px-6" />
       {{/if}}

--- a/addon/components/o-s-s/currency-input.hbs
+++ b/addon/components/o-s-s/currency-input.hbs
@@ -1,6 +1,6 @@
-<div class="currency-input-container fx-1  {{if this.disabled 'currency-input-container--disabled'}} {{if @errorMessage 'currency-input-container--errored'}}" ...attributes>
-  <div class="currency-input {{if @onlyCurrency 'onlycurrency'}} {{if this.currencySelectorShown 'currency-input--active'}}
-              fx-row fx-1 fx-xalign-center">
+<div class={{this.computedClasses}} ...attributes>
+  <div class="currency-input fx-row fx-1 fx-xalign-center
+              {{if @onlyCurrency 'onlycurrency'}} {{if this.currencySelectorShown 'currency-input--active'}}">
     <div class="currency-selector fx-row fx-gap-px-12 fx-malign-space-between fx-xalign-center"
          role={{if this.allowCurrencyUpdate 'button' 'img'}}
          {{on "click" this.toggleCurrencySelector}}>

--- a/addon/components/o-s-s/currency-input.stories.js
+++ b/addon/components/o-s-s/currency-input.stories.js
@@ -25,6 +25,16 @@ export default {
       },
       control: { type: 'number' }
     },
+    disabled: {
+      description: 'Disabled state of the component',
+      table: {
+        type: { summary: 'boolean' },
+        defaultValue: { summary: 'false' }
+      },
+      control: {
+        type: 'boolean'
+      }
+    },
     onlyCurrency: {
       description: 'Display only the currency dropdown',
       table: {
@@ -97,6 +107,7 @@ export default {
 const defaultArgs = {
   value: 42,
   currency: 'USD',
+  disabled: false,
   onlyCurrency: false,
   errorMessage: '',
   onChange: action('onChange'),
@@ -111,7 +122,7 @@ const Template = (args) => ({
         <OSS::CurrencyInput @value={{this.value}} @currency={{this.currency}} @onChange={{this.onChange}}
                             @onlyCurrency={{this.onlyCurrency}} @errorMessage={{this.errorMessage}}
                             @allowCurrencyUpdate={{this.allowCurrencyUpdate}} @allowedCurrencies={{this.allowedCurrencies}}
-                            @placeholder={{this.placeholder}} />
+                            @placeholder={{this.placeholder}} @disabled={{this.disabled}} />
       </div>
   `,
   context: args

--- a/addon/components/o-s-s/currency-input.ts
+++ b/addon/components/o-s-s/currency-input.ts
@@ -113,6 +113,17 @@ export default class OSSCurrencyInput extends Component<OSSCurrencyInputArgs> {
     return this.args.disabled ?? false;
   }
 
+  get computedClasses(): string {
+    const classes = ['currency-input-container'];
+    if (this.disabled) {
+      classes.push('currency-input-container--disabled');
+    }
+    if (this.args.errorMessage) {
+      classes.push('currency-input-container--errored');
+    }
+    return classes.join(' ');
+  }
+
   @action
   onlyNumeric(event: KeyboardEvent): void {
     if (['c', 'v'].includes(event.key) && (event.metaKey || event.ctrlKey)) {

--- a/addon/components/o-s-s/currency-input.ts
+++ b/addon/components/o-s-s/currency-input.ts
@@ -13,6 +13,7 @@ interface OSSCurrencyInputArgs {
   currency: string;
   value: number;
   onChange(currency: string, value: number): void;
+  disabled?: boolean;
   allowCurrencyUpdate?: boolean;
   onlyCurrency?: boolean;
   placeholder?: string;
@@ -108,6 +109,10 @@ export default class OSSCurrencyInput extends Component<OSSCurrencyInputArgs> {
     return this.args.placeholder ?? '0';
   }
 
+  get disabled(): boolean {
+    return this.args.disabled ?? false;
+  }
+
   @action
   onlyNumeric(event: KeyboardEvent): void {
     if (['c', 'v'].includes(event.key) && (event.metaKey || event.ctrlKey)) {
@@ -159,7 +164,7 @@ export default class OSSCurrencyInput extends Component<OSSCurrencyInputArgs> {
   toggleCurrencySelector(e: any): void {
     e.stopPropagation();
 
-    if (!this.allowCurrencyUpdate) return;
+    if (!this.allowCurrencyUpdate || this.disabled) return;
     this.currencySelectorShown = !this.currencySelectorShown;
   }
 

--- a/app/styles/currency-input.less
+++ b/app/styles/currency-input.less
@@ -54,6 +54,21 @@
     }
   }
 
+  &--disabled {
+    .currency-input {
+      cursor: not-allowed;
+
+      input {
+        .input-state-disabled;
+      }
+
+      .currency-selector {
+        cursor: not-allowed;
+        background-color: var(--color-gray-100);
+      }
+    }
+  }
+
   &--errored {
     .currency-input {
       .border-color-error;

--- a/app/styles/currency-input.less
+++ b/app/styles/currency-input.less
@@ -1,4 +1,5 @@
 .currency-input-container {
+  flex: 1;
   position: relative;
 
   .currency-input {

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -175,6 +175,12 @@
         @currency={{this.currency}}
         @value={{this.currencyValue}}
         @onChange={{this.onCurrencyInputChange}}
+        @disabled={{true}}
+      />
+      <OSS::CurrencyInput
+        @currency={{this.currency}}
+        @value={{this.currencyValue}}
+        @onChange={{this.onCurrencyInputChange}}
         @errorMessage="This is an error message"
       />
       <OSS::CurrencyInput

--- a/tests/integration/components/o-s-s/currency-input-test.ts
+++ b/tests/integration/components/o-s-s/currency-input-test.ts
@@ -14,22 +14,17 @@ module('Integration | Component | o-s-s/currency-input', function (hooks) {
   });
 
   test('it renders', async function (assert) {
-    this.value = 0;
-    this.currency = '';
     await render(hbs`<OSS::CurrencyInput @onChange={{this.onChange}} />`);
-
     assert.dom('.currency-input-container').exists();
   });
 
   test('The passed @value parameter is properly displayed in the input', async function (assert) {
     await render(hbs`<OSS::CurrencyInput @value="12341234" @onChange={{this.onChange}} />`);
-
     assert.dom('input').hasValue('12341234');
   });
 
   test('It properly loads the correct currency when the @currency parameter is defined', async function (assert) {
     await render(hbs`<OSS::CurrencyInput @currency="EUR" @onChange={{this.onChange}} />`);
-
     assert.dom('.currency-selector').hasText('€');
   });
 
@@ -149,6 +144,23 @@ module('Integration | Component | o-s-s/currency-input', function (hooks) {
     assert.dom('.currency-input-container').exists();
     assert.dom('.currency-selector').hasText('$ USD');
     assert.dom('.currency-input input').doesNotExist();
+  });
+
+  module('For @disabled argument', () => {
+    test("The disabled class isn't here for undefined value", async function (assert) {
+      await render(hbs`<OSS::CurrencyInput @onChange={{this.onChange}} />`);
+      assert.dom('.currency-input-container--disabled').doesNotExist();
+    });
+
+    test("The disabled class isn't here for false value", async function (assert) {
+      await render(hbs`<OSS::CurrencyInput @onChange={{this.onChange}} @disabled={{false}} />`);
+      assert.dom('.currency-input-container--disabled').doesNotExist();
+    });
+
+    test('The disabled class is here for true value', async function (assert) {
+      await render(hbs`<OSS::CurrencyInput @onChange={{this.onChange}} @disabled={{true}} />`);
+      assert.dom('.currency-input-container--disabled').exists();
+    });
   });
 
   module('When the paste event is received', function (hooks) {


### PR DESCRIPTION
### What does this PR do?

Add disabled state for currency-input component

### What are the observable changes?
![Screenshot from 2024-07-31 14-46-28](https://github.com/user-attachments/assets/03acc417-0cd0-4485-9394-0c583fb2bb03)

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [x] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled
