### PR TITLE
Add support for an `attach-element` modifier

### DIFF
--- a/addon/components/o-s-s/popover.hbs
+++ b/addon/components/o-s-s/popover.hbs
@@ -1,0 +1,26 @@
+<div class="oss-popover oss-popover--{{this.size}}">
+  {{#if (has-block "illustration")}}
+    <div class="oss-popover__illustration">
+      {{yield to="illustration"}}
+    </div>
+  {{/if}}
+  <div class="oss-popover__body">
+    <div class="oss-popover__title-line">
+      <span class="oss-popover__title">{{@title}}</span>
+      {{#if (has-block "contextual-actions")}}
+        <span class="oss-popover__contextualactions">
+          {{yield to="contextual-actions"}}
+        </span>
+      {{/if}}
+    </div>
+    {{#if @subtitle}}
+      <span class="oss-popover__subtitle">{{@subtitle}}</span>
+    {{/if}}
+    {{#if (has-block "content")}}
+      <div class="oss-popover__content">
+        {{yield to="content"}}
+      </div>
+    {{/if}}
+  </div>
+  <div class="oss-popover__arrow oss-popover__arrow--{{@arrowplacement}}"></div>
+</div>

--- a/addon/components/o-s-s/popover.hbs
+++ b/addon/components/o-s-s/popover.hbs
@@ -1,26 +1,31 @@
-<div class="oss-popover oss-popover--{{this.size}}" ...attributes>
-  {{#if (has-block "illustration")}}
-    <div class="oss-popover__illustration">
-      {{yield to="illustration"}}
-    </div>
-  {{/if}}
-  <div class="oss-popover__body">
-    <div class="oss-popover__title-line">
-      <span class="oss-popover__title">{{@title}}</span>
-      {{#if (has-block "contextual-actions")}}
-        <span class="oss-popover__contextualactions">
-          {{yield to="contextual-actions"}}
-        </span>
-      {{/if}}
-    </div>
-    {{#if @subtitle}}
-      <span class="oss-popover__subtitle">{{@subtitle}}</span>
-    {{/if}}
-    {{#if (has-block "content")}}
-      <div class="oss-popover__content">
-        {{yield to="content"}}
+{{#in-element this.portalTarget insertBefore=null}}
+  <div class="oss-popover oss-popover--{{this.size}}" ...attributes>
+    {{#if (has-block "illustration")}}
+      <div class="oss-popover__illustration">
+        {{yield to="illustration"}}
       </div>
     {{/if}}
+    <div class="oss-popover__body">
+      <div class="oss-popover__title-line">
+        <span class="oss-popover__title">{{@title}}</span>
+        {{#if (has-block "contextual-actions")}}
+          <span class="oss-popover__contextualactions">
+            {{yield to="contextual-actions"}}
+          </span>
+        {{/if}}
+      </div>
+      {{#if @subtitle}}
+        <span class="oss-popover__subtitle">{{@subtitle}}</span>
+      {{/if}}
+      {{#if (has-block "content")}}
+        <div class="oss-popover__content">
+          {{yield to="content"}}
+        </div>
+      {{/if}}
+    </div>
+
+    {{#if this.enableArrow}}
+      <div class="oss-popover__arrow" data-floating-arrow></div>
+    {{/if}}
   </div>
-  <div class="oss-popover__arrow oss-popover__arrow--{{@arrowplacement}}"></div>
-</div>
+{{/in-element}}

--- a/addon/components/o-s-s/popover.hbs
+++ b/addon/components/o-s-s/popover.hbs
@@ -1,4 +1,4 @@
-<div class="oss-popover oss-popover--{{this.size}}">
+<div class="oss-popover oss-popover--{{this.size}}" ...attributes>
   {{#if (has-block "illustration")}}
     <div class="oss-popover__illustration">
       {{yield to="illustration"}}

--- a/addon/components/o-s-s/popover.stories.js
+++ b/addon/components/o-s-s/popover.stories.js
@@ -1,0 +1,107 @@
+import { hbs } from 'ember-cli-htmlbars';
+
+const Placements = ['top', 'right', 'bottom', 'left'];
+const Sizes = [null, 'sm', 'md'];
+
+export default {
+  title: 'Components/OSS::Popover',
+  argTypes: {
+    arrowPlacement: {
+      description: 'The arrow placement definition',
+      table: {
+        type: {
+          summary: Placements.join(' | ')
+        },
+        defaultValue: { summary: null }
+      },
+      options: Placements,
+      control: { type: 'select' }
+    },
+    size: {
+      description: 'Adjust size',
+      table: {
+        type: {
+          summary: Sizes.join('|')
+        },
+        defaultValue: { summary: 'undefined' }
+      },
+      options: Sizes,
+      control: { type: 'select' }
+    },
+    title: {
+      description: 'Title of the popover',
+      table: {
+        type: { summary: 'string' }
+      },
+      control: {
+        type: 'text'
+      }
+    },
+    subtitle: {
+      table: {
+        description: 'Subtitle of the popover (optional)',
+        type: { summary: 'string' }
+      },
+      control: {
+        type: 'text'
+      }
+    }
+  }
+};
+
+const defaultArgs = {
+  arrowPlacement: 'top',
+  title: 'Popover Title',
+  subtitle: 'Subtitle',
+  size: 'sm'
+};
+
+const Template = (args) => ({
+  template: hbs`
+    <OSS::Popover @arrowPlacement={{this.arrowPlacement}} @title={{this.title}} @subtitle={{this.subtitle}} @size={{this.size}}>
+      <:content>
+        Popover content
+      </:content>
+    </OSS::Popover>
+  `,
+  context: args
+});
+
+const WithContextualActionsTemplate = (args) => ({
+  template: hbs`
+    <OSS::Popover @arrowPlacement={{this.arrowPlacement}} @title={{this.title}} @subtitle={{this.subtitle}} @size={{this.size}}>
+      <:contextual-actions>
+        Contextual Actions
+      </:contextual-actions>
+
+      <:content>
+        Popover content
+      </:content>
+    </OSS::Popover>
+  `,
+  context: args
+});
+
+const WithIllustrationTemplate = (args) => ({
+  template: hbs`
+    <OSS::Popover @arrowPlacement={{this.arrowPlacement}} @title={{this.title}} @subtitle={{this.subtitle}} @size={{this.size}}>
+      <:illustration>
+        Illustration
+      </:illustration>
+
+      <:content>
+        Popover content
+      </:content>
+    </OSS::Popover>
+  `,
+  context: args
+});
+
+export const Default = Template.bind({});
+Default.args = defaultArgs;
+
+export const WithContextualActions = WithContextualActionsTemplate.bind({});
+WithContextualActions.args = defaultArgs;
+
+export const WithIllustration = WithIllustrationTemplate.bind({});
+WithIllustration.args = defaultArgs;

--- a/addon/components/o-s-s/popover.ts
+++ b/addon/components/o-s-s/popover.ts
@@ -1,0 +1,17 @@
+import Component from '@glimmer/component';
+
+type Placement = 'top' | 'left' | 'right' | 'bottom';
+type Size = 'sm' | 'md';
+
+interface OSSPopoverArgs {
+  arrowPlacement: Placement;
+  title: string;
+  subtitle?: string;
+  size?: Size;
+}
+
+export default class extends Component<OSSPopoverArgs> {
+  get size(): Size {
+    return this.args.size ?? 'sm';
+  }
+}

--- a/addon/components/o-s-s/popover.ts
+++ b/addon/components/o-s-s/popover.ts
@@ -8,10 +8,17 @@ interface OSSPopoverArgs {
   title: string;
   subtitle?: string;
   size?: Size;
+  enableArrow: false;
 }
 
 export default class extends Component<OSSPopoverArgs> {
+  portalTarget: HTMLElement = document.body;
+
   get size(): Size {
     return this.args.size ?? 'sm';
+  }
+
+  get enableArrow(): boolean {
+    return this.args.enableArrow ?? false;
   }
 }

--- a/addon/modifiers/attach-element.stories.js
+++ b/addon/modifiers/attach-element.stories.js
@@ -1,0 +1,95 @@
+import { hbs } from 'ember-cli-htmlbars';
+
+const PlacementDefinitions = [
+  'bottom',
+  'top',
+  'left',
+  'right',
+  'bottom-start',
+  'top-start',
+  'left-start',
+  'right-start',
+  'bottom-end',
+  'top-end',
+  'left-end',
+  'right-end'
+];
+'top' | 'right' | 'bottom' | 'left';
+
+export default {
+  title: 'Helpers & Modifiers/Modifiers/Attach Element/Definition',
+  argTypes: {
+    placement: {
+      description: 'The placement definition',
+      table: {
+        type: {
+          summary: PlacementDefinitions.join('|')
+        },
+        defaultValue: { summary: 'bottom' }
+      },
+      options: PlacementDefinitions,
+      control: { type: 'select' }
+    },
+    offset: {
+      description: 'Distance between the attached element and the reference element',
+      table: {
+        type: {
+          summary: 'number'
+        },
+        defaultValue: { summary: 'undefined' }
+      },
+      control: { type: 'number' }
+    },
+    width: {
+      description: 'Width of the attached element',
+      table: {
+        type: {
+          summary: 'number'
+        },
+        defaultValue: { summary: 'undefined' }
+      },
+      control: { type: 'number' }
+    },
+    maxHeight: {
+      description: 'Max-Height of the attached element',
+      table: {
+        type: {
+          summary: 'number'
+        },
+        defaultValue: { summary: 'undefined' }
+      },
+      control: { type: 'number' }
+    }
+  },
+  parameters: {
+    docs: {
+      description: {
+        component: 'A modifier to attach a floating element to another'
+      }
+    }
+  }
+};
+
+const DefaultUsageTemplate = (args) => ({
+  template: hbs`
+    <div class="fx-col" style="justify-content: center; height: 500px; width: 750px; background-color: white">
+      <div class="fx-row" style="justify-content: center;">
+        <span style="color: var(--color-gray-900)" class="attached-element-reference">
+          I am the reference element
+        </span>
+
+        <div style="background-color: var(--color-primary-500); color: var(--color-white); position: absolute;" {{attach-element to=".attached-element-reference" placement=this.placement}}>
+          Floating element
+        </div>
+      </div>
+    </div>
+  `,
+  context: args
+});
+export const BasicUsage = DefaultUsageTemplate.bind({});
+BasicUsage.args = {
+  placement: 'bottom',
+  offset: null,
+  width: null,
+  maxHeight: null
+};

--- a/addon/modifiers/attach-element.ts
+++ b/addon/modifiers/attach-element.ts
@@ -1,20 +1,43 @@
 // @ts-ignore
 import { setModifierManager, capabilities } from '@ember/modifier';
-import { scheduleOnce } from '@ember/runloop';
-import { type Placement } from '@floating-ui/dom';
 
-import attachDropdown from '@upfluence/oss-components/utils/attach-dropdown';
+import attachDropdown, {
+  DEFAULT_ATTACHMENT_OPTIONS,
+  type AttachmentOptions
+} from '@upfluence/oss-components/utils/attach-dropdown';
 
 type AttachElementArgs = {
   named: {
     to: string | HTMLElement;
-    placement: Placement;
-  };
+  } & AttachmentOptions;
 };
 type AttachElementState = {
   cleanupDrodpownAutoplacement?: () => void;
   referenceTarget: HTMLElement | null;
   attachedElement: HTMLElement | null;
+};
+
+const setupModifier = (state: AttachElementState, element: HTMLElement, args: AttachElementArgs) => {
+  state.referenceTarget = args.named.to instanceof HTMLElement ? args.named.to : document.querySelector(args.named.to);
+  state.attachedElement = element;
+
+  const attachmentOptions = {
+    ...DEFAULT_ATTACHMENT_OPTIONS,
+    ...Object.keys(args.named).reduce((acc: AttachmentOptions, key: string) => {
+      if (key !== 'to' && args.named[key as keyof AttachElementArgs['named']] !== undefined) {
+        acc = {
+          ...acc,
+          ...{ [key as keyof AttachmentOptions]: args.named[key as keyof Omit<AttachElementArgs['named'], 'to'>] }
+        };
+      }
+
+      return acc;
+    }, {})
+  };
+
+  if (state.referenceTarget) {
+    state.cleanupDrodpownAutoplacement = attachDropdown(state.referenceTarget, element, attachmentOptions);
+  }
 };
 
 export default setModifierManager(
@@ -30,26 +53,18 @@ export default setModifierManager(
     },
 
     installModifier(state: AttachElementState, element: HTMLElement, args: AttachElementArgs) {
-      state.referenceTarget =
-        args.named.to instanceof HTMLElement ? args.named.to : document.querySelector(args.named.to);
-      state.attachedElement = element;
-
-      if (state.referenceTarget) {
-        state.cleanupDrodpownAutoplacement = attachDropdown(state.referenceTarget, element, {
-          placement: args.named.placement ?? 'top',
-          offset: 12,
-          width: 300
-        });
-      }
+      setupModifier(state, element, args);
     },
 
     updateModifier(state: AttachElementState, args: AttachElementArgs) {
-      console.log(state, args);
+      if (!state.attachedElement) return;
+      setupModifier(state, state.attachedElement, args);
     },
 
     destroyModifier(state: AttachElementState) {
-      console.log(state);
+      state.cleanupDrodpownAutoplacement = undefined;
     }
   }),
+
   class AttachElementModifierNewManager {}
 );

--- a/addon/modifiers/attach-element.ts
+++ b/addon/modifiers/attach-element.ts
@@ -1,0 +1,55 @@
+// @ts-ignore
+import { setModifierManager, capabilities } from '@ember/modifier';
+import { scheduleOnce } from '@ember/runloop';
+import { type Placement } from '@floating-ui/dom';
+
+import attachDropdown from '@upfluence/oss-components/utils/attach-dropdown';
+
+type AttachElementArgs = {
+  named: {
+    to: string | HTMLElement;
+    placement: Placement;
+  };
+};
+type AttachElementState = {
+  cleanupDrodpownAutoplacement?: () => void;
+  referenceTarget: HTMLElement | null;
+  attachedElement: HTMLElement | null;
+};
+
+export default setModifierManager(
+  () => ({
+    capabilities: capabilities('3.22'),
+
+    createModifier() {
+      return {
+        cleanupDrodpownAutoplacement: undefined,
+        referenceTarget: null,
+        attachedElement: null
+      };
+    },
+
+    installModifier(state: AttachElementState, element: HTMLElement, args: AttachElementArgs) {
+      state.referenceTarget =
+        args.named.to instanceof HTMLElement ? args.named.to : document.querySelector(args.named.to);
+      state.attachedElement = element;
+
+      if (state.referenceTarget) {
+        state.cleanupDrodpownAutoplacement = attachDropdown(state.referenceTarget, element, {
+          placement: args.named.placement ?? 'top',
+          offset: 12,
+          width: 300
+        });
+      }
+    },
+
+    updateModifier(state: AttachElementState, args: AttachElementArgs) {
+      console.log(state, args);
+    },
+
+    destroyModifier(state: AttachElementState) {
+      console.log(state);
+    }
+  }),
+  class AttachElementModifierNewManager {}
+);

--- a/addon/utils/attach-dropdown.ts
+++ b/addon/utils/attach-dropdown.ts
@@ -1,12 +1,14 @@
 import {
   autoUpdate,
+  arrow,
   computePosition,
   flip,
   offset,
   size,
+  hide,
   type MiddlewareState,
   type Placement,
-  hide
+  type Side
 } from '@floating-ui/dom';
 
 export type AttachmentOptions = {
@@ -14,13 +16,22 @@ export type AttachmentOptions = {
   width?: number;
   maxHeight?: number;
   placement?: Placement;
+  enableArrow?: boolean;
 };
 
 export const DEFAULT_ATTACHMENT_OPTIONS: AttachmentOptions = {
   offset: 12,
   width: undefined,
   maxHeight: undefined,
-  placement: 'bottom'
+  placement: 'bottom',
+  enableArrow: false
+};
+
+const RELATIVE_ARROW_PLACEMENT: Record<Side, Side> = {
+  top: 'bottom',
+  right: 'left',
+  bottom: 'top',
+  left: 'right'
 };
 
 export default function attachDropdown(
@@ -29,35 +40,46 @@ export default function attachDropdown(
   options: AttachmentOptions = DEFAULT_ATTACHMENT_OPTIONS
 ) {
   const mergedOptions = { ...DEFAULT_ATTACHMENT_OPTIONS, ...(options || {}) };
+  const middlewares = [
+    offset(mergedOptions.offset ?? 0),
+    flip({
+      fallbackPlacements: ['top', 'bottom']
+    }),
+    size({
+      apply({ rects, elements }: MiddlewareState) {
+        const desiredWidth = mergedOptions.width ?? rects.reference.width;
+        const floatingStyle: Record<string, string> = {
+          maxWidth: `${desiredWidth}px`,
+          minWidth: `${desiredWidth}px`,
+          width: `${desiredWidth}px`
+        };
+
+        if (mergedOptions.maxHeight) {
+          floatingStyle.maxHeight = `${floatingStyle.maxHeight}px`;
+          elements.floating.style.setProperty('--floating-max-height', `${mergedOptions.maxHeight}px`);
+        }
+
+        Object.assign(elements.floating.style, floatingStyle);
+      }
+    }),
+    hide()
+  ];
+
+  let arrowEl = floatingTarget.querySelector('[data-floating-arrow]');
+
+  if (mergedOptions.enableArrow) {
+    if (!arrowEl) {
+      throw new Error('Arrow support is enabled but no [data-floating-arrow] element was found.');
+    }
+
+    middlewares.push(arrow({ element: arrowEl }));
+  }
 
   const updatePosition = () => {
     computePosition(referenceTarget, floatingTarget, {
       placement: mergedOptions.placement ?? 'bottom',
-      middleware: [
-        offset(mergedOptions.offset ?? 0),
-        flip({
-          fallbackPlacements: ['top', 'bottom']
-        }),
-        size({
-          apply({ rects, elements }: MiddlewareState) {
-            const desiredWidth = mergedOptions.width ?? rects.reference.width;
-            const floatingStyle: Record<string, string> = {
-              maxWidth: `${desiredWidth}px`,
-              minWidth: `${desiredWidth}px`,
-              width: `${desiredWidth}px`
-            };
-
-            if (mergedOptions.maxHeight) {
-              floatingStyle.maxHeight = `${floatingStyle.maxHeight}px`;
-              elements.floating.style.setProperty('--floating-max-height', `${mergedOptions.maxHeight}px`);
-            }
-
-            Object.assign(elements.floating.style, floatingStyle);
-          }
-        }),
-        hide()
-      ]
-    }).then(({ x, y, middlewareData }) => {
+      middleware: middlewares
+    }).then(({ x, y, placement, middlewareData }) => {
       Object.assign(floatingTarget.style, {
         left: `${x}px`,
         top: `${y}px`
@@ -66,6 +88,19 @@ export default function attachDropdown(
       if (middlewareData.hide) {
         Object.assign(floatingTarget.style, {
           visibility: middlewareData.hide.referenceHidden ? 'hidden' : 'visible'
+        });
+      }
+
+      if (middlewareData.arrow) {
+        const { x: arrowX, y: arrowY } = middlewareData.arrow;
+        const staticSide = RELATIVE_ARROW_PLACEMENT[placement.split('-')![0]! as Side];
+
+        Object.assign((arrowEl as HTMLElement).style, {
+          left: arrowX != null ? `${arrowX}px` : '',
+          top: arrowY != null ? `${arrowY}px` : '',
+          right: '',
+          bottom: '',
+          [staticSide]: '-4px'
         });
       }
     });

--- a/addon/utils/attach-dropdown.ts
+++ b/addon/utils/attach-dropdown.ts
@@ -16,7 +16,7 @@ export type AttachmentOptions = {
   placement?: Placement;
 };
 
-const DEFAULT_ATTACHMENT_OPTIONS: AttachmentOptions = {
+export const DEFAULT_ATTACHMENT_OPTIONS: AttachmentOptions = {
   offset: 12,
   width: undefined,
   maxHeight: undefined,

--- a/app/components/o-s-s/popover.js
+++ b/app/components/o-s-s/popover.js
@@ -1,0 +1,1 @@
+export { default } from '@upfluence/oss-components/components/o-s-s/popover';

--- a/app/modifiers/attach-element.js
+++ b/app/modifiers/attach-element.js
@@ -1,0 +1,1 @@
+export { default } from '@upfluence/oss-components/modifiers/attach-element';

--- a/app/styles/organisms/popover.less
+++ b/app/styles/organisms/popover.less
@@ -29,6 +29,7 @@
 
 .oss-popover__title-line {
   display: flex;
+  align-items: center;
   justify-content: space-between;
 }
 

--- a/app/styles/organisms/popover.less
+++ b/app/styles/organisms/popover.less
@@ -2,6 +2,8 @@
   border-radius: var(--border-radius-md);
   box-shadow: var(--box-shadow-md);
   position: absolute;
+  top: 0;
+  left: 0;
   z-index: 1;
   background-color: var(--color-white);
 }
@@ -42,37 +44,11 @@
 }
 
 .oss-popover__arrow {
-  width: 0px;
-  height: 0px;
-  border: 6px solid transparent;
   position: absolute;
+  background-color: var(--color-white);
+  box-shadow: var(--box-shadow-md);
+  width: 8px;
+  height: 8px;
+  transform: rotate(45deg);
   z-index: -1;
-}
-
-.oss-popover__arrow--top {
-  border-bottom: 6px solid var(--color-white);
-  top: -10px;
-  left: 50%;
-  transform: translateX(-50%);
-}
-
-.oss-popover__arrow--bottom {
-  border-top: 6px solid var(--color-white);
-  bottom: -10px;
-  left: 50%;
-  transform: translateX(-50%);
-}
-
-.oss-popover__arrow--left {
-  border-right: 6px solid var(--color-white);
-  left: -10px;
-  top: 50%;
-  transform: translateY(-50%);
-}
-
-.oss-popover__arrow--right {
-  border-left: 6px solid var(--color-white);
-  right: -10px;
-  top: 50%;
-  transform: translateY(-50%);
 }

--- a/app/styles/organisms/popover.less
+++ b/app/styles/organisms/popover.less
@@ -1,8 +1,8 @@
 .oss-popover {
   border-radius: var(--border-radius-md);
   box-shadow: var(--box-shadow-md);
-  position: relative;
-  z-index: 0;
+  position: absolute;
+  z-index: 1;
   background-color: var(--color-white);
 }
 

--- a/app/styles/organisms/popover.less
+++ b/app/styles/organisms/popover.less
@@ -1,0 +1,77 @@
+.oss-popover {
+  border-radius: var(--border-radius-md);
+  box-shadow: var(--box-shadow-md);
+  position: relative;
+  z-index: 0;
+  background-color: var(--color-white);
+}
+
+.oss-popover--sm {
+  width: 230px;
+}
+
+.oss-popover--md {
+  width: 280px;
+}
+
+.oss-popover__illustration {
+  border-top-left-radius: var(--border-radius-md);
+  border-top-right-radius: var(--border-radius-md);
+  overflow: hidden;
+}
+
+.oss-popover__body {
+  padding: var(--spacing-px-12);
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-px-6);
+}
+
+.oss-popover__title-line {
+  display: flex;
+  justify-content: space-between;
+}
+
+.oss-popover__title {
+  font-weight: var(--font-weight-semibold);
+}
+
+.oss-popover__subtitle {
+  color: var(--color-gray-500);
+}
+
+.oss-popover__arrow {
+  width: 0px;
+  height: 0px;
+  border: 6px solid transparent;
+  position: absolute;
+  z-index: -1;
+}
+
+.oss-popover__arrow--top {
+  border-bottom: 6px solid var(--color-white);
+  top: -10px;
+  left: 50%;
+  transform: translateX(-50%);
+}
+
+.oss-popover__arrow--bottom {
+  border-top: 6px solid var(--color-white);
+  bottom: -10px;
+  left: 50%;
+  transform: translateX(-50%);
+}
+
+.oss-popover__arrow--left {
+  border-right: 6px solid var(--color-white);
+  left: -10px;
+  top: 50%;
+  transform: translateY(-50%);
+}
+
+.oss-popover__arrow--right {
+  border-left: 6px solid var(--color-white);
+  right: -10px;
+  top: 50%;
+  transform: translateY(-50%);
+}

--- a/app/styles/oss-components.less
+++ b/app/styles/oss-components.less
@@ -60,3 +60,4 @@
 @import 'organisms/panel';
 @import 'organisms/attributes-panel';
 @import 'organisms/side-panel';
+@import 'organisms/popover';

--- a/tests/integration/components/o-s-s/popover-test.ts
+++ b/tests/integration/components/o-s-s/popover-test.ts
@@ -9,27 +9,27 @@ module('Integration | Component | o-s-s-/popover', function (hooks) {
   test('it renders with basic arguments', async function (assert) {
     await render(hbs`<OSS::Popover @title='Title test' @arrowplacement='top' />`);
 
-    assert.dom('.oss-popover').hasClass('oss-popover--sm');
-    assert.dom('.oss-popover__title').hasText('Title test');
+    assert.dom(document.querySelector('.oss-popover')).hasClass('oss-popover--sm');
+    assert.dom(document.querySelector('.oss-popover__title')).hasText('Title test');
   });
 
   test('The @subtitle param is properly rendered', async function (assert) {
     await render(hbs`<OSS::Popover @title='Title test' @arrowplacement='top' @subtitle='This is a subtitle test' />`);
 
-    assert.dom('.oss-popover__subtitle').hasText('This is a subtitle test');
+    assert.dom(document.querySelector('.oss-popover__subtitle')).hasText('This is a subtitle test');
   });
 
   module('size validation', () => {
     test('When the @size param is "SM", it renders a small component', async function (assert) {
       await render(hbs`<OSS::Popover @title='Title test' @arrowplacement='top' @size='sm' />`);
 
-      assert.dom('.oss-popover').hasClass('oss-popover--sm');
+      assert.dom(document.querySelector('.oss-popover')).hasClass('oss-popover--sm');
     });
 
     test('When the @size param is "MD", it renders a medium component', async function (assert) {
       await render(hbs`<OSS::Popover @title='Title test' @arrowplacement='top' @size='md' />`);
 
-      assert.dom('.oss-popover').hasClass('oss-popover--md');
+      assert.dom(document.querySelector('.oss-popover')).hasClass('oss-popover--md');
     });
   });
 
@@ -39,7 +39,7 @@ module('Integration | Component | o-s-s-/popover', function (hooks) {
         <:illustration>TEST1</:illustration>
       </OSS::Popover>`);
 
-      assert.dom('.oss-popover__illustration').hasText('TEST1');
+      assert.dom(document.querySelector('.oss-popover__illustration')).hasText('TEST1');
     });
 
     test('Contextual actions named-block content renders', async function (assert) {
@@ -47,7 +47,7 @@ module('Integration | Component | o-s-s-/popover', function (hooks) {
         <:contextual-actions>TEST2</:contextual-actions>
       </OSS::Popover>`);
 
-      assert.dom('.oss-popover__contextualactions').hasText('TEST2');
+      assert.dom(document.querySelector('.oss-popover__contextualactions')).hasText('TEST2');
     });
 
     test('Content named-block content renders', async function (assert) {
@@ -55,33 +55,7 @@ module('Integration | Component | o-s-s-/popover', function (hooks) {
         <:content>TEST3</:content>
       </OSS::Popover>`);
 
-      assert.dom('.oss-popover__content').hasText('TEST3');
-    });
-  });
-
-  module('arrow position validation', () => {
-    test('When the @arrowPlacement param is "top", it renders with arrow on top', async function (assert) {
-      await render(hbs`<OSS::Popover @title='Title test' @arrowplacement='top' />`);
-
-      assert.dom('.oss-popover__arrow').hasClass('oss-popover__arrow--top');
-    });
-
-    test('When the @arrowPlacement param is "bottom", it renders with arrow on bottom', async function (assert) {
-      await render(hbs`<OSS::Popover @title='Title test' @arrowplacement='bottom' />`);
-
-      assert.dom('.oss-popover__arrow').hasClass('oss-popover__arrow--bottom');
-    });
-
-    test('When the @arrowPlacement param is "right", it renders with arrow on right', async function (assert) {
-      await render(hbs`<OSS::Popover @title='Title test' @arrowplacement='right' />`);
-
-      assert.dom('.oss-popover__arrow').hasClass('oss-popover__arrow--right');
-    });
-
-    test('When the @arrowPlacement param is "left", it renders with arrow on left', async function (assert) {
-      await render(hbs`<OSS::Popover @title='Title test' @arrowplacement='left' />`);
-
-      assert.dom('.oss-popover__arrow').hasClass('oss-popover__arrow--left');
+      assert.dom(document.querySelector('.oss-popover__content')).hasText('TEST3');
     });
   });
 });

--- a/tests/integration/components/o-s-s/popover-test.ts
+++ b/tests/integration/components/o-s-s/popover-test.ts
@@ -1,0 +1,87 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Component | o-s-s-/popover', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders with basic arguments', async function (assert) {
+    await render(hbs`<OSS::Popover @title='Title test' @arrowplacement='top' />`);
+
+    assert.dom('.oss-popover').hasClass('oss-popover--sm');
+    assert.dom('.oss-popover__title').hasText('Title test');
+  });
+
+  test('The @subtitle param is properly rendered', async function (assert) {
+    await render(hbs`<OSS::Popover @title='Title test' @arrowplacement='top' @subtitle='This is a subtitle test' />`);
+
+    assert.dom('.oss-popover__subtitle').hasText('This is a subtitle test');
+  });
+
+  module('size validation', () => {
+    test('When the @size param is "SM", it renders a small component', async function (assert) {
+      await render(hbs`<OSS::Popover @title='Title test' @arrowplacement='top' @size='sm' />`);
+
+      assert.dom('.oss-popover').hasClass('oss-popover--sm');
+    });
+
+    test('When the @size param is "MD", it renders a medium component', async function (assert) {
+      await render(hbs`<OSS::Popover @title='Title test' @arrowplacement='top' @size='md' />`);
+
+      assert.dom('.oss-popover').hasClass('oss-popover--md');
+    });
+  });
+
+  module('named-block content validation', () => {
+    test('Illustration named-block content renders', async function (assert) {
+      await render(hbs`<OSS::Popover @title='Title test' @arrowplacement='top'>
+        <:illustration>TEST1</:illustration>
+      </OSS::Popover>`);
+
+      assert.dom('.oss-popover__illustration').hasText('TEST1');
+    });
+
+    test('Contextual actions named-block content renders', async function (assert) {
+      await render(hbs`<OSS::Popover @title='Title test' @arrowplacement='top'>
+        <:contextual-actions>TEST2</:contextual-actions>
+      </OSS::Popover>`);
+
+      assert.dom('.oss-popover__contextualactions').hasText('TEST2');
+    });
+
+    test('Content named-block content renders', async function (assert) {
+      await render(hbs`<OSS::Popover @title='Title test' @arrowplacement='top'>
+        <:content>TEST3</:content>
+      </OSS::Popover>`);
+
+      assert.dom('.oss-popover__content').hasText('TEST3');
+    });
+  });
+
+  module('arrow position validation', () => {
+    test('When the @arrowPlacement param is "top", it renders with arrow on top', async function (assert) {
+      await render(hbs`<OSS::Popover @title='Title test' @arrowplacement='top' />`);
+
+      assert.dom('.oss-popover__arrow').hasClass('oss-popover__arrow--top');
+    });
+
+    test('When the @arrowPlacement param is "bottom", it renders with arrow on bottom', async function (assert) {
+      await render(hbs`<OSS::Popover @title='Title test' @arrowplacement='bottom' />`);
+
+      assert.dom('.oss-popover__arrow').hasClass('oss-popover__arrow--bottom');
+    });
+
+    test('When the @arrowPlacement param is "right", it renders with arrow on right', async function (assert) {
+      await render(hbs`<OSS::Popover @title='Title test' @arrowplacement='right' />`);
+
+      assert.dom('.oss-popover__arrow').hasClass('oss-popover__arrow--right');
+    });
+
+    test('When the @arrowPlacement param is "left", it renders with arrow on left', async function (assert) {
+      await render(hbs`<OSS::Popover @title='Title test' @arrowplacement='left' />`);
+
+      assert.dom('.oss-popover__arrow').hasClass('oss-popover__arrow--left');
+    });
+  });
+});

--- a/tests/integration/modifiers/attach-element-test.ts
+++ b/tests/integration/modifiers/attach-element-test.ts
@@ -1,0 +1,49 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { find, render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Modifiers | modifiers/attach-element', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('the attached element has no floating-related style when not using the modifier', async function (assert) {
+    await render(hbs`
+      <div class="reference-element">
+        I am the reference!
+      </div>
+
+      <div class="attached-element">
+        I am floaaaaaating !
+      </div>
+    `);
+
+    const attachedElement = find('.attached-element') as HTMLElement;
+    const attachedElementStyles = Object.fromEntries(attachedElement.attributeStyleMap.entries());
+
+    assert.deepEqual(Object.keys(attachedElementStyles), []);
+  });
+
+  test('attached element is properly rendered w/ the right floating-ui positioning style', async function (assert) {
+    await render(hbs`
+      <div class="reference-element">
+        I am the reference!
+      </div>
+
+      <div class="attached-element" {{attach-element to=".reference-element"}}>
+        I am floaaaaaating !
+      </div>
+    `);
+
+    const attachedElement = find('.attached-element') as HTMLElement;
+    const attachedElementStyles = Object.fromEntries(attachedElement.attributeStyleMap.entries());
+
+    assert.deepEqual(Object.keys(attachedElementStyles), [
+      'max-width',
+      'min-width',
+      'width',
+      'left',
+      'top',
+      'visibility'
+    ]);
+  });
+});


### PR DESCRIPTION
### What does this PR do?

This PR adds support for an `attach-element` modifier that uses FloatingUI (via the `attachDropdown` util function) to attach a given element to another.

Invoking it looks like:

```handlebars
<div class="reference-element">
  I am the reference!
</div>

<div class="attached-element" {{attach-element to=".reference-element"}}>
  <!-- This element should be in absolute position -->
  I am floaaaaaating !
</div>
```

It also promotes the OSS::Popover component from candidate (in ember-influencer) to global implementation.

### Good PR checklist
- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [x] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled
