### PR TITLE
New OSS::Carousel component

### DIFF
--- a/addon/components/o-s-s/carousel.hbs
+++ b/addon/components/o-s-s/carousel.hbs
@@ -1,0 +1,3 @@
+<div class="oss-carousel" {{did-insert this.initialize}}>
+  {{yield to="pages"}}
+</div>

--- a/addon/components/o-s-s/carousel.hbs
+++ b/addon/components/o-s-s/carousel.hbs
@@ -1,3 +1,22 @@
-<div class="oss-carousel" {{did-insert this.initialize}}>
-  {{yield to="pages"}}
+<div class="oss-carousel" {{did-insert this.initialize}} ...attributes>
+  {{#if this.showIndicators}}
+    <div class="fx-row">
+      {{#each this.pages as |page index|}}
+        <div class="page-btn" role="button" {{on "click" (fn this.displayPage page)}}>
+          <i class="{{this.buttonIcon}} {{if (eq index this.currentPageIndex) 'page-btn--active'}}"></i>
+        </div>
+      {{/each}}
+    </div>
+  {{/if}}
+  <div class="page-container {{if this.displaySidePadding 'page-container--side-padding'}}">
+    {{#if this.showControls}}
+      <div class="carousel-control carousel-control--left" {{on "click" this.previousPage}} role="button">
+        <i class="far fa-chevron-left"></i>
+      </div>
+      <div class="carousel-control carousel-control--right" {{on "click" this.nextPage}} role="button">
+        <i class="far fa-chevron-right"></i>
+      </div>
+    {{/if}}
+    {{yield to="pages"}}
+  </div>
 </div>

--- a/addon/components/o-s-s/carousel.stories.js
+++ b/addon/components/o-s-s/carousel.stories.js
@@ -1,0 +1,103 @@
+import { hbs } from 'ember-cli-htmlbars';
+
+export default {
+  title: 'Components/OSS::Carousel',
+  component: 'carousel',
+  argTypes: {
+    buttonIcon: {
+      description:
+        'Allows setting a custom icon for the button. The icon should be a FontAwesome icon, e.g. "fas fa-robot".',
+      table: {
+        type: {
+          summary: 'string'
+        },
+        defaultValue: { summary: 'fas fa-circle' }
+      },
+      control: { type: 'text' }
+    },
+    animationStyle: {
+      description: 'The style of the animation. Can be either shift or slide.',
+      table: {
+        type: {
+          summary: 'string'
+        },
+        defaultValue: { summary: 'shift' }
+      },
+      options: ['shift', 'slide'],
+      control: { type: 'select' }
+    },
+    showIndicators: {
+      description: 'Whether to show the indicators or not. The "indicators" are the bullet points above the carousel.',
+      table: {
+        type: {
+          summary: 'boolean'
+        },
+        defaultValue: { summary: 'true' }
+      },
+      control: { type: 'boolean' }
+    },
+    showControls: {
+      description:
+        'Whether to show the controls or not. The "controls" are the arrows/chevrons on the sides of the carousel. Overlay displays within the carousel, outside displays outside the carousel by adding padding around the pages.',
+      table: {
+        type: {
+          summary: 'text'
+        },
+        defaultValue: { summary: 'undefined' }
+      },
+      options: [undefined, 'overlay', 'outside'],
+      control: { type: 'select' }
+    },
+    autoPlay: {
+      description:
+        'Allows the carousel to automatically play through the slides. The parameter is the time in milliseconds between slides.',
+      table: {
+        type: {
+          summary: 'number'
+        },
+        defaultValue: { summary: 'undefined' }
+      },
+      control: { type: 'number' }
+    }
+  },
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'An OSS-components implementation of a Carousel component.<br/>The `:page` named-block should be use to yield the pages that will be displayed.<br/>Each page requires a `page` class.'
+      }
+    }
+  }
+};
+
+const defaultArgs = {
+  buttonIcon: undefined,
+  animationStyle: undefined,
+  showIndicators: undefined,
+  showControls: undefined,
+  autoPlay: undefined
+};
+
+const Template = (args) => ({
+  template: hbs`
+    <OSS::Carousel @showIndicators={{this.showIndicators}} @showControls={{this.showControls}}
+                   @animationStyle={{this.animationStyle}} @buttonIcon={{this.buttonIcon}}
+                   @autoPlay={{this.autoPlay}}>
+      <:pages>
+        <div class="page">
+          <OSS::Banner @icon="fas fa-image" @title="PAGE 1"/>
+        </div>
+        <div class="page">
+          <OSS::Banner @icon="fas fa-image" @title="PAGE 2"/>
+        </div>
+        <div class="page">
+          <OSS::Banner @icon="fas fa-image" @title="PAGE 1"/>
+        </div>
+      </:pages>
+    </OSS::Carousel>
+  `,
+  context: args
+});
+
+export const Default = Template.bind({});
+Default.args = defaultArgs;

--- a/addon/components/o-s-s/carousel.ts
+++ b/addon/components/o-s-s/carousel.ts
@@ -1,0 +1,27 @@
+import { action } from '@ember/object';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+
+interface OSSCarouselArgs {}
+
+export default class OSSCarousel extends Component<OSSCarouselArgs> {
+  @tracked declare element: HTMLElement;
+  @tracked declare pages: HTMLElement[];
+
+  // the number of dots is based on number of page divs
+  constructor(owner: unknown, args: OSSCarouselArgs) {
+    super(owner, args);
+  }
+
+  @action
+  initialize(element: HTMLElement) {
+    this.element = element;
+    this.pages = Array.from(this.element.querySelectorAll('.page'));
+    this.displayPage(this.pages[0]!);
+  }
+
+  private displayPage(page: HTMLElement) {
+    this.pages.forEach((p) => p.classList.remove('active'));
+    page.classList.add('page--active');
+  }
+}

--- a/addon/components/o-s-s/carousel.ts
+++ b/addon/components/o-s-s/carousel.ts
@@ -88,7 +88,7 @@ export default class OSSCarousel extends Component<OSSCarouselArgs> {
     this.currentPageIndex = this.pages.indexOf(page);
   }
 
-  willDestroy() {
+  willDestroy(): void {
     super.willDestroy();
     clearInterval(this.autoPlayInterval);
   }

--- a/addon/components/o-s-s/carousel.ts
+++ b/addon/components/o-s-s/carousel.ts
@@ -46,7 +46,6 @@ export default class OSSCarousel extends Component<OSSCarouselArgs> {
   initialize(element: HTMLElement): void {
     this.element = element;
     this.pages = Array.from(this.element.querySelectorAll('.page'));
-    // if this pages is empty, throw an error
     if (this.pages.length === 0) {
       throw new Error('[component][OSS::Carousel] No pages found in the carousel');
     }

--- a/addon/components/o-s-s/carousel.ts
+++ b/addon/components/o-s-s/carousel.ts
@@ -26,15 +26,15 @@ export default class OSSCarousel extends Component<OSSCarouselArgs> {
 
   private declare autoPlayInterval: number;
 
-  get buttonIcon() {
+  get buttonIcon(): string {
     return this.args.buttonIcon ?? DEFAULT_BUTTON_ICON;
   }
 
-  get showIndicators() {
+  get showIndicators(): boolean {
     return this.args.showIndicators ?? true;
   }
 
-  get showControls() {
+  get showControls(): boolean {
     return !!this.args.showControls ?? false;
   }
 

--- a/addon/components/o-s-s/carousel.ts
+++ b/addon/components/o-s-s/carousel.ts
@@ -2,26 +2,135 @@ import { action } from '@ember/object';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 
-interface OSSCarouselArgs {}
+interface OSSCarouselArgs {
+  buttonIcon?: string;
+  animationStyle?: 'shift' | 'slide';
+  showIndicators?: boolean;
+  showControls?: 'overlay' | 'outside';
+  autoPlay?: number;
+}
+
+const DEFAULT_BUTTON_ICON = 'fas fa-circle';
+const ANIMATION_TIME = 500;
+
+interface AnimationHandler {
+  (page: HTMLElement, executeAfterAnimation: (...args: any) => any): void;
+}
 
 export default class OSSCarousel extends Component<OSSCarouselArgs> {
   @tracked declare element: HTMLElement;
   @tracked declare pages: HTMLElement[];
+  @tracked declare currentPageIndex: number;
+  @tracked declare prevPageIndex: number;
+  @tracked ongoingAnimation = false;
 
-  // the number of dots is based on number of page divs
-  constructor(owner: unknown, args: OSSCarouselArgs) {
-    super(owner, args);
+  get buttonIcon() {
+    return this.args.buttonIcon ?? DEFAULT_BUTTON_ICON;
+  }
+
+  get showIndicators() {
+    return this.args.showIndicators ?? true;
+  }
+
+  get showControls() {
+    return !!this.args.showControls ?? false;
+  }
+
+  get displaySidePadding(): boolean {
+    return this.args.showControls === 'outside';
   }
 
   @action
-  initialize(element: HTMLElement) {
+  initialize(element: HTMLElement): void {
     this.element = element;
     this.pages = Array.from(this.element.querySelectorAll('.page'));
-    this.displayPage(this.pages[0]!);
+    this.pages[0]!.classList.add('page--active');
+    this.currentPageIndex = 0;
+    if (this.args.autoPlay) {
+      setInterval(() => {
+        this.nextPage();
+      }, this.args.autoPlay);
+    }
   }
 
-  private displayPage(page: HTMLElement) {
-    this.pages.forEach((p) => p.classList.remove('active'));
-    page.classList.add('page--active');
+  @action
+  previousPage(): void {
+    if (this.currentPageIndex === 0) {
+      this.displayPage(this.pages[this.pages.length - 1]!);
+      return;
+    }
+    this.displayPage(this.pages[this.currentPageIndex - 1]!);
   }
+
+  @action
+  nextPage(): void {
+    if (this.currentPageIndex === this.pages.length - 1) {
+      this.displayPage(this.pages[0]!);
+      return;
+    }
+    this.displayPage(this.pages[this.currentPageIndex + 1]!);
+  }
+
+  @action
+  displayPage(page: HTMLElement): void {
+    if (this.pages.indexOf(page) === this.currentPageIndex || this.ongoingAnimation) {
+      return;
+    }
+    this.ongoingAnimation = true;
+
+    if (this.animationStyle === 'slide') {
+      this.slideAnimationHandler(page, (classesToCleanup: string[]) => {
+        this.pages[this.prevPageIndex ?? 0]!.classList.remove('page--active');
+        this.pages.forEach((p) => p.classList.remove(...classesToCleanup));
+        this.ongoingAnimation = false;
+      });
+    } else if (this.animationStyle === 'shift') {
+      this.shiftAnimationHandler(page, () => {
+        this.ongoingAnimation = false;
+      });
+    }
+
+    page.classList.add('page--active');
+    this.prevPageIndex = this.currentPageIndex;
+    this.currentPageIndex = this.pages.indexOf(page);
+  }
+
+  private get animationStyle(): 'shift' | 'slide' {
+    return this.args.animationStyle ?? 'shift';
+  }
+
+  private slideAnimationHandler: AnimationHandler = (
+    page: HTMLElement,
+    executeAfterAnimation: (classesToCleanup: string[]) => any
+  ) => {
+    const classesToCleanup = [
+      'animate--slide-from-left',
+      'animate--slide-from-right',
+      'animate--slide-to-left',
+      'animate--slide-to-right'
+    ];
+
+    this.pages.forEach((p) => p.classList.remove(...classesToCleanup));
+    setTimeout(() => executeAfterAnimation(classesToCleanup), ANIMATION_TIME);
+
+    if (this.pages.indexOf(page) > this.currentPageIndex) {
+      this.pages[this.currentPageIndex ?? 0]!.classList.add('animate--slide-to-left');
+      page.classList.add('animate--slide-from-left');
+    } else {
+      this.pages[this.currentPageIndex ?? 0]!.classList.add('animate--slide-to-right');
+      page.classList.add('animate--slide-from-right');
+    }
+  };
+
+  private shiftAnimationHandler: AnimationHandler = (page: HTMLElement, executeAfterAnimation: () => any) => {
+    const classesToCleanup = ['animate--shift-from-left', 'animate--shift-from-right', 'page--active'];
+
+    this.pages.forEach((p) => p.classList.remove(...classesToCleanup));
+    if (this.pages.indexOf(page) > this.currentPageIndex) {
+      page.classList.add('animate--shift-from-left');
+    } else {
+      page.classList.add('animate--shift-from-right');
+    }
+    setTimeout(() => executeAfterAnimation(), ANIMATION_TIME);
+  };
 }

--- a/addon/components/o-s-s/carousel.ts
+++ b/addon/components/o-s-s/carousel.ts
@@ -82,19 +82,7 @@ export default class OSSCarousel extends Component<OSSCarouselArgs> {
       return;
     }
     this.ongoingAnimation = true;
-
-    if (this.animationStyle === 'slide') {
-      this.slideAnimationHandler(page, (classesToCleanup: string[]) => {
-        this.pages[this.prevPageIndex ?? 0]!.classList.remove('page--active');
-        this.pages.forEach((p) => p.classList.remove(...classesToCleanup));
-        this.ongoingAnimation = false;
-      });
-    } else if (this.animationStyle === 'shift') {
-      this.shiftAnimationHandler(page, () => {
-        this.ongoingAnimation = false;
-      });
-    }
-
+    this.triggerAnimation(page);
     page.classList.add('page--active');
     this.prevPageIndex = this.currentPageIndex;
     this.currentPageIndex = this.pages.indexOf(page);
@@ -107,6 +95,20 @@ export default class OSSCarousel extends Component<OSSCarouselArgs> {
 
   private get animationStyle(): 'shift' | 'slide' {
     return this.args.animationStyle ?? 'shift';
+  }
+
+  private triggerAnimation(page: HTMLElement): void {
+    if (this.animationStyle === 'slide') {
+      this.slideAnimationHandler(page, (classesToCleanup: string[]) => {
+        this.pages[this.prevPageIndex ?? 0]!.classList.remove('page--active');
+        this.pages.forEach((p) => p.classList.remove(...classesToCleanup));
+        this.ongoingAnimation = false;
+      });
+    } else if (this.animationStyle === 'shift') {
+      this.shiftAnimationHandler(page, () => {
+        this.ongoingAnimation = false;
+      });
+    }
   }
 
   private slideAnimationHandler: AnimationHandler = (

--- a/app/components/o-s-s/carousel.js
+++ b/app/components/o-s-s/carousel.js
@@ -1,0 +1,1 @@
+export { default } from '@upfluence/oss-components/components/o-s-s/carousel';

--- a/app/styles/organisms/carousel.less
+++ b/app/styles/organisms/carousel.less
@@ -1,0 +1,9 @@
+.oss-carousel {
+  .page {
+    display: none;
+
+    &--active {
+      display: block;
+    }
+  }
+}

--- a/app/styles/organisms/carousel.less
+++ b/app/styles/organisms/carousel.less
@@ -7,7 +7,7 @@
   position: relative;
 
   .page-btn {
-    padding: 3px;
+    padding: var(--spacing-px-3);
     color: var(--color-gray-200);
     font-size: 8px;
 
@@ -25,7 +25,7 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    width: 24px;
+    width: var(--spacing-px-24);
     padding: 0;
     color: var(--color-gray-500);
     text-align: center;

--- a/app/styles/organisms/carousel.less
+++ b/app/styles/organisms/carousel.less
@@ -9,7 +9,7 @@
   .page-btn {
     padding: var(--spacing-px-3);
     color: var(--color-gray-200);
-    font-size: 8px;
+    font-size: 6px;
 
     &:hover,
     &--active {

--- a/app/styles/organisms/carousel.less
+++ b/app/styles/organisms/carousel.less
@@ -1,9 +1,167 @@
 .oss-carousel {
-  .page {
-    display: none;
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--spacing-px-12);
+  position: relative;
 
+
+  .page-btn {
+    padding: 3px;
+    color: var(--color-gray-200);
+    font-size: 8px;
+
+    &:hover,
     &--active {
-      display: block;
+      color: var(--color-gray-500);
     }
+  }
+
+  .carousel-control {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    z-index: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 8%;
+    padding: 0;
+    color: var(--color-gray-500);
+    text-align: center;
+    transition: opacity .15s ease;
+
+    &--left {
+      left: 0;
+    }
+
+    &--right {
+      left: unset;
+      right: 0;
+    }
+  }
+
+  .page-container {
+    display: block;
+    position: relative;
+    overflow: hidden;
+    width: 100%;
+
+    .page {
+      width: 100%;
+      margin-right: -100%;
+      display: none;
+      float: left;
+      position: relative;
+      transition: transform .5s ease-in-out;
+
+      &--active {
+        display: block;
+      }
+    }
+
+    &--side-padding {
+      padding-left: 46px;
+      padding-right: 46px;
+    }
+  }
+
+  .animate {
+    &--shift-from-left {
+      animation: shift-from-left 0.5s forwards;
+    }
+
+    &--shift-from-right {
+      animation: shift-from-right 0.5s forwards;
+    }
+
+    &--slide-from-left {
+      animation: slide-from-left 0.5s forwards;
+    }
+
+    &--slide-from-right {
+      animation: slide-from-right 0.5s forwards;
+    }
+
+    &--slide-to-left {
+      animation: slide-to-left 0.5s forwards;
+    }
+
+    &--slide-to-right {
+      animation: slide-to-right 0.5s forwards;
+    }
+  }
+}
+
+@keyframes shift-from-left {
+  0% {
+    transform: translateX(100px);
+    opacity: 0;
+  }
+
+  100% {
+    transform: translateX(0px);
+    opacity: 1;
+  }
+}
+
+@keyframes shift-from-right {
+  0% {
+    transform: translateX(-100px);
+    opacity: 0;
+  }
+
+  100% {
+    transform: translateX(0px);
+    opacity: 1;
+  }
+}
+
+@keyframes slide-from-left {
+  0% {
+    transform: translateX(100%);
+    opacity: 0;
+  }
+
+  100% {
+    transform: translateX(0%);
+    opacity: 1;
+  }
+}
+
+@keyframes slide-from-right {
+  0% {
+    transform: translateX(-100%);
+    opacity: 0;
+  }
+
+  100% {
+    transform: translateX(0%);
+    opacity: 1;
+  }
+}
+
+@keyframes slide-to-left {
+  0% {
+    transform: translateX(0);
+    opacity: 1;
+  }
+
+  100% {
+    transform: translateX(-100%);
+    opacity: 0;
+  }
+}
+
+@keyframes slide-to-right {
+  0% {
+    transform: translateX(0);
+    opacity: 1;
+  }
+
+  100% {
+    transform: translateX(100%);
+    opacity: 0;
   }
 }

--- a/app/styles/organisms/carousel.less
+++ b/app/styles/organisms/carousel.less
@@ -29,7 +29,7 @@
     padding: 0;
     color: var(--color-gray-500);
     text-align: center;
-    transition: opacity .15s ease;
+    transition: opacity 0.5s ease;
 
     &--left {
       left: 0;
@@ -53,7 +53,7 @@
       display: none;
       float: left;
       position: relative;
-      transition: transform .5s ease-in-out;
+      transition: transform 0.5s ease-in-out;
 
       &--active {
         display: flex;

--- a/app/styles/organisms/carousel.less
+++ b/app/styles/organisms/carousel.less
@@ -6,7 +6,6 @@
   gap: var(--spacing-px-12);
   position: relative;
 
-
   .page-btn {
     padding: 3px;
     color: var(--color-gray-200);
@@ -26,7 +25,7 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    width: 8%;
+    width: 24px;
     padding: 0;
     color: var(--color-gray-500);
     text-align: center;
@@ -57,7 +56,8 @@
       transition: transform .5s ease-in-out;
 
       &--active {
-        display: block;
+        display: flex;
+        justify-content: center;
       }
     }
 

--- a/app/styles/oss-components.less
+++ b/app/styles/oss-components.less
@@ -62,3 +62,4 @@
 @import 'organisms/attributes-panel';
 @import 'organisms/side-panel';
 @import 'organisms/popover';
+@import 'organisms/carousel';

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -1,3 +1,82 @@
+<div class="fx-col fx-gap-px-10 margin-md">
+  <OSS::Button @label="Toggle carousel" {{on "click" (fn (mut this.displayCarousel) (not this.displayCarousel))}} />
+  <OSS::Carousel @buttonIcon="fas fa-robot" @animationStyle="shift" @showIndicators={{true}} @showControls="outside">
+    <:pages>
+      <div class="page">
+        <OSS::Banner
+          @icon="fas fa-box-open"
+          @title="Import creators inside your campaign"
+          @subtitle="Choose the creators you want to import from a list, emailing, stream, Live capture or upload an existing .CSV file."
+        />
+      </div>
+      <div class="page">
+        <OSS::Banner
+          @title="Banner without icon"
+          @subtitle="Choose the creators you want to import from a list, emailing, stream, Live capture or upload an existing .CSV file."
+        />
+      </div>
+      <div class="page">
+        <OSS::Banner
+          @icon="fas fa-box-open"
+          @title="Import creators inside your campaign"
+          @subtitle="Choose the creators you want to import from a list, emailing, stream, Live capture or upload an existing .CSV file."
+        />
+      </div>
+      <div class="page">
+        <OSS::Banner
+          @title="Banner without icon"
+          @subtitle="Choose the creators you want to import from a list, emailing, stream, Live capture or upload an existing .CSV file."
+        />
+      </div>
+      <div class="page">
+        <OSS::Banner
+          @icon="fas fa-box-open"
+          @title="Import creators inside your campaign"
+          @subtitle="Choose the creators you want to import from a list, emailing, stream, Live capture or upload an existing .CSV file."
+        />
+      </div>
+      <div class="page">
+        <OSS::Banner
+          @title="Banner without icon"
+          @subtitle="Choose the creators you want to import from a list, emailing, stream, Live capture or upload an existing .CSV file."
+        />
+      </div>
+      <div class="page">
+        <OSS::Banner
+          @icon="fas fa-box-open"
+          @title="Import creators inside your campaign"
+          @subtitle="Choose the creators you want to import from a list, emailing, stream, Live capture or upload an existing .CSV file."
+        />
+      </div>
+      <div class="page">
+        <OSS::Banner
+          @title="Banner without icon"
+          @subtitle="Choose the creators you want to import from a list, emailing, stream, Live capture or upload an existing .CSV file."
+        />
+      </div>
+    </:pages>
+  </OSS::Carousel>
+  <OSS::Carousel @buttonIcon="fas fa-robot" @animationStyle="shift" @showIndicators={{true}} @showControls="outside">
+    <:pages>
+      <div class="page">
+        <img
+          src="https://sm.pcmag.com/pcmag_au/how-to/c/consolidat/consolidate-your-data-how-to-combine-multiple-storage-drives_zvnz.jpg"
+        />
+      </div>
+      <div class="page">
+        <img
+          src="https://sm.pcmag.com/pcmag_au/how-to/c/consolidat/consolidate-your-data-how-to-combine-multiple-storage-drives_zvnz.jpg"
+        />
+      </div>
+      <div class="page">
+        <img
+          src="https://sm.pcmag.com/pcmag_au/how-to/c/consolidat/consolidate-your-data-how-to-combine-multiple-storage-drives_zvnz.jpg"
+        />
+      </div>
+    </:pages>
+  </OSS::Carousel>
+</div>
+
 <div class="fx-row fx-gap-px-10 margin-md">
   <OSS::Copy @value="I am the value copied" @inline={{true}} />
   <OSS::Copy @value="I am the value copied" />

--- a/tests/integration/components/o-s-s/carousel-test.ts
+++ b/tests/integration/components/o-s-s/carousel-test.ts
@@ -1,26 +1,124 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@ember/test-helpers';
+import { click, render, setupOnerror } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | o-s-s/carousel', function (hooks) {
   setupRenderingTest(hooks);
 
-  test('it renders', async function (assert) {
-    // Set any properties with this.set('myProperty', 'value');
-    // Handle any actions with this.set('myAction', function (val) { ... });
+  hooks.beforeEach(function () {
+    this.buttonIcon = undefined;
+    this.animationStyle = 'shift';
+    this.showIndicators = undefined;
+    this.showControls = undefined;
+    this.autoPlay = undefined;
+  });
 
-    await render(hbs`<OSS::Carousel />`);
-
-    assert.dom().hasText('');
-
-    // Template block usage:
+  async function renderCarousel() {
     await render(hbs`
-      <OSS::Carousel>
-        template block text
+      <OSS::Carousel @showIndicators={{this.showIndicators}} @showControls={{this.showControls}}
+                     @animationStyle={{this.animationStyle}} @buttonIcon={{this.buttonIcon}}
+                     @autoPlay={{this.autoPlay}}>
+        <:pages>
+          <div class="page">Page 1</div>
+          <div class="page">Page 2</div>
+          <div class="page">Page 3</div>
+        </:pages>
       </OSS::Carousel>
     `);
+  }
 
-    assert.dom().hasText('template block text');
+  test('it renders', async function (assert) {
+    await renderCarousel();
+    assert.dom('.oss-carousel').exists();
+  });
+
+  test('If no pages are yielded to the component, it throws an error', async function (assert) {
+    setupOnerror((error: Error) => {
+      assert.equal(error.message, '[component][OSS::Carousel] No pages found in the carousel');
+    });
+
+    await render(hbs`<OSS::Carousel />`);
+  });
+
+  test('it renders the pages', async function (assert) {
+    await renderCarousel();
+    assert.dom('.oss-carousel .page').exists({ count: 3 });
+  });
+
+  module('Indicators', () => {
+    test('By default, it renders the indicators', async function (assert) {
+      await renderCarousel();
+      assert.dom('.oss-carousel .page-btn').exists({ count: 3 });
+    });
+
+    test('When specified, it does not render the indicators if showIndicators is set to false', async function (assert) {
+      this.showIndicators = false;
+      await renderCarousel();
+      assert.dom('.oss-carousel .page-btn').doesNotExist();
+    });
+  });
+
+  module('Controls (chevrons)', () => {
+    test('By default, it does not render the controls', async function (assert) {
+      await renderCarousel();
+      assert.dom('.oss-carousel .carousel-control').doesNotExist();
+      assert.dom('.oss-carousel .carousel-control--left').doesNotExist();
+      assert.dom('.oss-carousel .carousel-control--right').doesNotExist();
+    });
+
+    test('When specified, it renders the controls if showControls is set to true', async function (assert) {
+      this.showControls = true;
+      await renderCarousel();
+      assert.dom('.oss-carousel .carousel-control').exists();
+      assert.dom('.oss-carousel .carousel-control--left').exists();
+      assert.dom('.oss-carousel .carousel-control--right').exists();
+    });
+
+    test('When specified, it renders the controls outside the carousel if showControls is set to outside', async function (assert) {
+      this.showControls = 'outside';
+      await renderCarousel();
+      assert.dom('.oss-carousel .carousel-control').exists();
+      assert.dom('.oss-carousel .carousel-control--left').exists();
+      assert.dom('.oss-carousel .carousel-control--right').exists();
+      assert.dom('.page-container--side-padding').exists();
+    });
+  });
+
+  module('Indicator button icon', () => {
+    test('By default, it renders the default button icon', async function (assert) {
+      await renderCarousel();
+      assert.dom('.oss-carousel .fas.fa-circle').exists({ count: 3 });
+    });
+
+    test('When specified, it renders the custom button icon', async function (assert) {
+      this.buttonIcon = 'fas fa-robot';
+      await renderCarousel();
+      assert.dom('.oss-carousel .fas.fa-robot').exists({ count: 3 });
+    });
+  });
+
+  module('Animation style', () => {
+    test('By default, it uses the shift animation style', async function (assert) {
+      await renderCarousel();
+      await click('.oss-carousel .page-btn:nth-child(2)');
+      assert.dom('.animate--shift-from-left').exists();
+    });
+
+    test('When specified, it uses the slide animation style', async function (assert) {
+      this.animationStyle = 'slide';
+      await renderCarousel();
+      await click('.oss-carousel .page-btn:nth-child(2)');
+      assert.dom('.animate--slide-from-left').exists();
+    });
+  });
+
+  module('Auto play', () => {
+    test('When specified, it automatically switches to the next page', async function (assert) {
+      this.autoPlay = 100;
+      await renderCarousel();
+      await new Promise((resolve) => setTimeout(resolve, 101));
+      assert.dom('.oss-carousel .page--active').hasText('Page 2');
+    });
   });
 });

--- a/tests/integration/components/o-s-s/carousel-test.ts
+++ b/tests/integration/components/o-s-s/carousel-test.ts
@@ -1,0 +1,26 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Component | o-s-s/carousel', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function (assert) {
+    // Set any properties with this.set('myProperty', 'value');
+    // Handle any actions with this.set('myAction', function (val) { ... });
+
+    await render(hbs`<OSS::Carousel />`);
+
+    assert.dom().hasText('');
+
+    // Template block usage:
+    await render(hbs`
+      <OSS::Carousel>
+        template block text
+      </OSS::Carousel>
+    `);
+
+    assert.dom().hasText('template block text');
+  });
+});


### PR DESCRIPTION
### What does this PR do?
New OSS::Carousel component

```
interface OSSCarouselArgs {
  buttonIcon?: string;
  animationStyle?: 'shift' | 'slide';
  showIndicators?: boolean;
  showControls?: 'overlay' | 'outside';
  autoPlay?: number;
}
```

Usage:
```handlebars
  <OSS::Carousel @showIndicators={{this.showIndicators}} @showControls={{this.showControls}}
                 @animationStyle={{this.animationStyle}} @buttonIcon={{this.buttonIcon}}
                 @autoPlay={{this.autoPlay}}>
    <:pages>
      <div class="page">
        <OSS::Banner @icon="fas fa-image" @title="PAGE 1"/>
      </div>
      <div class="page">
        <OSS::Banner @icon="fas fa-image" @title="PAGE 2"/>
      </div>
      <div class="page">
        <OSS::Banner @icon="fas fa-image" @title="PAGE 1"/>
      </div>
    </:pages>
  </OSS::Carousel>
```

## Examples

With controls, `outside`:
![Screenshot 2024-10-03 at 14 59 18](https://github.com/user-attachments/assets/35e14196-728f-4a97-85c7-34697a159714)

With controls, `overlay` (would be more useful with pictures for example):
![Screenshot 2024-10-03 at 14 59 54](https://github.com/user-attachments/assets/47162c22-70d5-41cb-b666-12648e130730)

Without `indicators`:
![Screenshot 2024-10-03 at 15 00 39](https://github.com/user-attachments/assets/4e1c505c-9c33-44b7-9255-4099ac554f88)

With custom `fas fa-robot` `indicators`:
![Screenshot 2024-10-03 at 15 01 22](https://github.com/user-attachments/assets/921a777b-391e-4407-83b9-a5844265e1a6)

## Video of animations

With default `shift` animation:
https://github.com/user-attachments/assets/645cf53a-ebc5-4558-8b70-95a639ef19b2

With `slide` animation:
https://github.com/user-attachments/assets/43372e49-f23d-4cfe-a20c-45bdbaea5d64


### Good PR checklist
- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [x] Added/updated documentation
- [x] Properly labeled