### PR TITLE
Add error skin for OSS::Dialog

### DIFF
--- a/addon/components/o-s-s/dialog.hbs
+++ b/addon/components/o-s-s/dialog.hbs
@@ -1,11 +1,11 @@
 <div class="oss-dialog__backdrop fx-row fx-malign-center fx-xalign-center" {{will-destroy this.onDestroy}}>
   <div class="oss-dialog fx-col" {{did-insert this.onInit}} ...attributes>
     <div class="oss-dialog__header">
-      <OSS::Badge @icon="fa-warning" @skin="alert" />
+      <OSS::Badge @icon="fa-warning" @skin={{this.skin}} />
       <span class="font-weight-semibold font-size-md">{{@title}}</span>
     </div>
     <div class="oss-dialog__footer">
-      <OSS::Button @skin="alert" @label={{@mainAction.label}} {{on "click" @mainAction.action}} />
+      <OSS::Button @skin={{this.skinBtn}} @label={{@mainAction.label}} {{on "click" @mainAction.action}} />
       <OSS::Button @label={{@secondaryAction.label}} {{on "click" @secondaryAction.action}} />
     </div>
   </div>

--- a/addon/components/o-s-s/dialog.stories.js
+++ b/addon/components/o-s-s/dialog.stories.js
@@ -1,11 +1,14 @@
 import { hbs } from 'ember-cli-htmlbars';
 import { action } from '@storybook/addon-actions';
 
+const SizeTypes = ['alert', 'error'];
+
 export default {
   title: 'Components/OSS::Dialog',
   component: 'dialog',
   argTypes: {
     title: {
+      type: { required: true },
       description: 'The dialog title',
       table: {
         type: {
@@ -15,26 +18,41 @@ export default {
       },
       control: { type: 'text' }
     },
+    skin: {
+      description: 'The dialog skin',
+      table: {
+        type: {
+          summary: SizeTypes.join('|')
+        },
+        defaultValue: { summary: 'alert' }
+      },
+      options: SizeTypes,
+      control: { type: 'select' }
+    },
     mainAction: {
+      type: { required: true },
       description: 'A hash with the main action button properties',
       table: {
         type: {
-          summary: '{ label: string, action: () => unknown }[]'
-        }
+          summary: '{ label: string, action: () => unknown }'
+        },
+        defaultValue: { summary: 'undefined' }
       },
       control: {
-        type: '{ label: string, action: () => unknown }[]'
+        type: 'object'
       }
     },
     secondaryAction: {
+      type: { required: true },
       description: 'A hash with the secondary action button properties',
       table: {
         type: {
-          summary: '{ label: string, action: () => unknown }[]'
-        }
+          summary: '{ label: string, action: () => unknown }'
+        },
+        defaultValue: { summary: 'undefined' }
       },
       control: {
-        type: '{ label: string, action: () => unknown }[]'
+        type: 'object'
       }
     }
   },
@@ -49,6 +67,7 @@ export default {
 
 const defaultArgs = {
   title: 'You are about to discard your changes',
+  skin: undefined,
   mainAction: {
     label: 'Discard',
     action: action('discard')
@@ -63,6 +82,7 @@ const BasicUsageTemplate = (args) => ({
   template: hbs`
     <OSS::Dialog
       @title={{this.title}}
+      @skin={{this.skin}}
       @mainAction={{this.mainAction}}
       @secondaryAction={{this.secondaryAction}} />
   `,

--- a/addon/components/o-s-s/dialog.ts
+++ b/addon/components/o-s-s/dialog.ts
@@ -2,11 +2,19 @@ import BaseModal, { type BaseModalArgs } from './private/base-modal';
 import { action } from '@ember/object';
 import { assert } from '@ember/debug';
 
+type Skin = 'alert' | 'error';
+
 export interface OSSDialogArgs extends BaseModalArgs {
   title: string;
+  skin?: Skin;
   mainAction: { label: string; action: () => unknown };
   secondaryAction: { label: string; action: () => unknown };
 }
+
+const BTN_STYLE_MATCHER: Record<Skin, string> = {
+  alert: 'alert',
+  error: 'destructive'
+};
 
 export default class OSSDialog extends BaseModal<OSSDialogArgs> {
   constructor(owner: unknown, args: OSSDialogArgs) {
@@ -18,6 +26,14 @@ export default class OSSDialog extends BaseModal<OSSDialogArgs> {
       '[component][OSS::Dialog] The secondaryAction parameter is mandatory',
       typeof args.secondaryAction === 'object'
     );
+  }
+
+  get skin(): Skin {
+    return this.args.skin ?? 'alert';
+  }
+
+  get skinBtn(): string {
+    return BTN_STYLE_MATCHER[this.skin];
   }
 
   @action

--- a/tests/integration/components/o-s-s/dialog-test.ts
+++ b/tests/integration/components/o-s-s/dialog-test.ts
@@ -19,7 +19,7 @@ module('Integration | Component | o-s-s/dialog', function (hooks) {
     };
   });
 
-  test('it renders', async function (assert) {
+  test('It renders', async function (assert) {
     await render(
       hbs`<OSS::Dialog @title={{this.title}} @mainAction={{this.mainAction}} @secondaryAction={{this.secondaryAction}} />`
     );
@@ -35,7 +35,36 @@ module('Integration | Component | o-s-s/dialog', function (hooks) {
     assert.dom('.oss-dialog__header').hasText(this.title);
   });
 
-  test('The dialog displays the main action button', async function (assert) {
+  module('For @skin', () => {
+    test('When the value is undefined, skins are correct', async function (assert) {
+      await render(
+        hbs`<OSS::Dialog @title={{this.title}} @mainAction={{this.mainAction}} @secondaryAction={{this.secondaryAction}} />`
+      );
+
+      assert.dom('.oss-dialog__footer .upf-btn--alert').exists();
+      assert.dom('.oss-dialog__header .upf-badge--alert').exists();
+    });
+
+    test('When the value is alert, skins are correct', async function (assert) {
+      await render(
+        hbs`<OSS::Dialog @title={{this.title}} @skin="alert" @mainAction={{this.mainAction}} @secondaryAction={{this.secondaryAction}} />`
+      );
+
+      assert.dom('.oss-dialog__footer .upf-btn--alert').exists();
+      assert.dom('.oss-dialog__header .upf-badge--alert').exists();
+    });
+
+    test('When the value is error, skins are correct', async function (assert) {
+      await render(
+        hbs`<OSS::Dialog @title={{this.title}} @skin="error" @mainAction={{this.mainAction}} @secondaryAction={{this.secondaryAction}} />`
+      );
+
+      assert.dom('.oss-dialog__footer .upf-btn--destructive').exists();
+      assert.dom('.oss-dialog__header .upf-badge--error').exists();
+    });
+  });
+
+  test('The main action button label is displayed', async function (assert) {
     await render(
       hbs`<OSS::Dialog @title={{this.title}} @mainAction={{this.mainAction}} @secondaryAction={{this.secondaryAction}} />`
     );
@@ -43,7 +72,7 @@ module('Integration | Component | o-s-s/dialog', function (hooks) {
     assert.dom('.oss-dialog__footer .upf-btn--alert').hasText(this.mainAction.label);
   });
 
-  test('The dialog displays the secondary action button', async function (assert) {
+  test('The secondary action button label is displayed', async function (assert) {
     await render(
       hbs`<OSS::Dialog @title={{this.title}} @mainAction={{this.mainAction}} @secondaryAction={{this.secondaryAction}} />`
     );


### PR DESCRIPTION
### What does this PR do?

Add error skin for OSS::Dialog

### What are the observable changes?
![Screenshot from 2024-09-02 12-12-38](https://github.com/user-attachments/assets/92e58d4f-d57b-426c-9ac0-79c766452f77)

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [x] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled
