### PR TITLE
OSS-Components - Edited: dialog component to include skin and icon args

### DIFF
--- a/addon/components/o-s-s/dialog.hbs
+++ b/addon/components/o-s-s/dialog.hbs
@@ -1,7 +1,7 @@
 <div class="oss-dialog__backdrop fx-row fx-malign-center fx-xalign-center" {{will-destroy this.onDestroy}}>
   <div class="oss-dialog fx-col" {{did-insert this.onInit}} ...attributes>
     <div class="oss-dialog__header">
-      <OSS::Badge @icon="fa-warning" @skin={{this.skin}} />
+      <OSS::Badge @icon={{this.icon}} @skin={{this.skin}} />
       <span class="font-weight-semibold font-size-md">{{@title}}</span>
     </div>
     <div class="oss-dialog__footer">

--- a/addon/components/o-s-s/dialog.stories.js
+++ b/addon/components/o-s-s/dialog.stories.js
@@ -1,7 +1,7 @@
 import { hbs } from 'ember-cli-htmlbars';
 import { action } from '@storybook/addon-actions';
 
-const SizeTypes = ['alert', 'error', 'primary'];
+const SkinTypes = ['alert', 'error', 'primary'];
 
 export default {
   title: 'Components/OSS::Dialog',
@@ -22,11 +22,11 @@ export default {
       description: 'The dialog skin',
       table: {
         type: {
-          summary: SizeTypes.join('|')
+          summary: SkinTypes.join('|')
         },
         defaultValue: { summary: 'alert' }
       },
-      options: SizeTypes,
+      options: SkinTypes,
       control: { type: 'select' }
     },
     icon: {

--- a/addon/components/o-s-s/dialog.stories.js
+++ b/addon/components/o-s-s/dialog.stories.js
@@ -1,7 +1,7 @@
 import { hbs } from 'ember-cli-htmlbars';
 import { action } from '@storybook/addon-actions';
 
-const SizeTypes = ['alert', 'error'];
+const SizeTypes = ['alert', 'error', 'primary'];
 
 export default {
   title: 'Components/OSS::Dialog',
@@ -28,6 +28,16 @@ export default {
       },
       options: SizeTypes,
       control: { type: 'select' }
+    },
+    icon: {
+      description: 'The dialog icon',
+      table: {
+        type: {
+          summary: 'string'
+        },
+        defaultValue: { summary: 'fa-warning' }
+      },
+      control: { type: 'text' }
     },
     mainAction: {
       type: { required: true },
@@ -68,6 +78,7 @@ export default {
 const defaultArgs = {
   title: 'You are about to discard your changes',
   skin: undefined,
+  icon: 'fa-warning',
   mainAction: {
     label: 'Discard',
     action: action('discard')
@@ -83,6 +94,7 @@ const BasicUsageTemplate = (args) => ({
     <OSS::Dialog
       @title={{this.title}}
       @skin={{this.skin}}
+      @icon={{this.icon}}
       @mainAction={{this.mainAction}}
       @secondaryAction={{this.secondaryAction}} />
   `,

--- a/addon/components/o-s-s/dialog.ts
+++ b/addon/components/o-s-s/dialog.ts
@@ -2,17 +2,19 @@ import BaseModal, { type BaseModalArgs } from './private/base-modal';
 import { action } from '@ember/object';
 import { assert } from '@ember/debug';
 
-type Skin = 'alert' | 'error';
+type Skin = 'alert' | 'primary' | 'error';
 
 export interface OSSDialogArgs extends BaseModalArgs {
   title: string;
   skin?: Skin;
+  icon?: string;
   mainAction: { label: string; action: () => unknown };
   secondaryAction: { label: string; action: () => unknown };
 }
 
 const BTN_STYLE_MATCHER: Record<Skin, string> = {
   alert: 'alert',
+  primary: 'primary',
   error: 'destructive'
 };
 
@@ -30,6 +32,10 @@ export default class OSSDialog extends BaseModal<OSSDialogArgs> {
 
   get skin(): Skin {
     return this.args.skin ?? 'alert';
+  }
+
+  get icon(): string {
+    return this.args.icon ?? 'fa-warning';
   }
 
   get skinBtn(): string {

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -1049,5 +1049,7 @@
     @title="You are about to discard your changes"
     @mainAction={{hash action=this.onMainAction label="Discard changes"}}
     @secondaryAction={{hash action=this.onSecondaryAction label="Keep editing"}}
+    @icon="fa-circle-info"
+    @skin="error"
   />
 {{/if}}

--- a/tests/integration/components/o-s-s/dialog-test.ts
+++ b/tests/integration/components/o-s-s/dialog-test.ts
@@ -62,6 +62,33 @@ module('Integration | Component | o-s-s/dialog', function (hooks) {
       assert.dom('.oss-dialog__footer .upf-btn--destructive').exists();
       assert.dom('.oss-dialog__header .upf-badge--error').exists();
     });
+
+    test('When the value is primary, skins are correct', async function (assert) {
+      await render(
+        hbs`<OSS::Dialog @title={{this.title}} @skin="primary" @mainAction={{this.mainAction}} @secondaryAction={{this.secondaryAction}} />`
+      );
+
+      assert.dom('.oss-dialog__footer .upf-btn--primary').exists();
+      assert.dom('.oss-dialog__header .upf-badge--primary').exists();
+    });
+  });
+
+  module('For @icon', () => {
+    test('When the value is undefined, icon is correct', async function (assert) {
+      await render(
+        hbs`<OSS::Dialog @title={{this.title}} @mainAction={{this.mainAction}} @secondaryAction={{this.secondaryAction}} />`
+      );
+
+      assert.dom('.oss-dialog__header .upf-badge--alert .fa-warning').exists();
+    });
+
+    test('When the value is defined, icon is correct', async function (assert) {
+      await render(
+        hbs`<OSS::Dialog @title={{this.title}} @icon="fa-otter" @mainAction={{this.mainAction}} @secondaryAction={{this.secondaryAction}} />`
+      );
+
+      assert.dom('.oss-dialog__header .upf-badge--alert .fa-otter').exists();
+    });
   });
 
   test('The main action button label is displayed', async function (assert) {

--- a/tests/integration/components/o-s-s/dialog-test.ts
+++ b/tests/integration/components/o-s-s/dialog-test.ts
@@ -27,7 +27,7 @@ module('Integration | Component | o-s-s/dialog', function (hooks) {
     assert.dom('.oss-dialog').exists();
   });
 
-  test('The dialog displays the title', async function (assert) {
+  test('The dialog title is correctly displayed', async function (assert) {
     await render(
       hbs`<OSS::Dialog @title={{this.title}} @mainAction={{this.mainAction}} @secondaryAction={{this.secondaryAction}} />`
     );
@@ -36,7 +36,7 @@ module('Integration | Component | o-s-s/dialog', function (hooks) {
   });
 
   module('For @skin', () => {
-    test('When the value is undefined, skins are correct', async function (assert) {
+    test('When the value is undefined, the default skin is displayed', async function (assert) {
       await render(
         hbs`<OSS::Dialog @title={{this.title}} @mainAction={{this.mainAction}} @secondaryAction={{this.secondaryAction}} />`
       );
@@ -45,7 +45,7 @@ module('Integration | Component | o-s-s/dialog', function (hooks) {
       assert.dom('.oss-dialog__header .upf-badge--alert').exists();
     });
 
-    test('When the value is alert, skins are correct', async function (assert) {
+    test('When the value is "alert", the corresponding skin is displayed', async function (assert) {
       await render(
         hbs`<OSS::Dialog @title={{this.title}} @skin="alert" @mainAction={{this.mainAction}} @secondaryAction={{this.secondaryAction}} />`
       );
@@ -54,7 +54,7 @@ module('Integration | Component | o-s-s/dialog', function (hooks) {
       assert.dom('.oss-dialog__header .upf-badge--alert').exists();
     });
 
-    test('When the value is error, skins are correct', async function (assert) {
+    test('When the value is "error", the corresponding skin is displayed', async function (assert) {
       await render(
         hbs`<OSS::Dialog @title={{this.title}} @skin="error" @mainAction={{this.mainAction}} @secondaryAction={{this.secondaryAction}} />`
       );
@@ -63,7 +63,7 @@ module('Integration | Component | o-s-s/dialog', function (hooks) {
       assert.dom('.oss-dialog__header .upf-badge--error').exists();
     });
 
-    test('When the value is primary, skins are correct', async function (assert) {
+    test('When the value is "primary", the corresponding skin is displayed', async function (assert) {
       await render(
         hbs`<OSS::Dialog @title={{this.title}} @skin="primary" @mainAction={{this.mainAction}} @secondaryAction={{this.secondaryAction}} />`
       );
@@ -74,7 +74,7 @@ module('Integration | Component | o-s-s/dialog', function (hooks) {
   });
 
   module('For @icon', () => {
-    test('When the value is undefined, icon is correct', async function (assert) {
+    test('When the value is undefined, the default icon is displayed', async function (assert) {
       await render(
         hbs`<OSS::Dialog @title={{this.title}} @mainAction={{this.mainAction}} @secondaryAction={{this.secondaryAction}} />`
       );
@@ -82,7 +82,7 @@ module('Integration | Component | o-s-s/dialog', function (hooks) {
       assert.dom('.oss-dialog__header .upf-badge--alert .fa-warning').exists();
     });
 
-    test('When the value is defined, icon is correct', async function (assert) {
+    test('When the value is defined, the corresponding icon is displayed', async function (assert) {
       await render(
         hbs`<OSS::Dialog @title={{this.title}} @icon="fa-otter" @mainAction={{this.mainAction}} @secondaryAction={{this.secondaryAction}} />`
       );
@@ -107,7 +107,7 @@ module('Integration | Component | o-s-s/dialog', function (hooks) {
     assert.dom('.oss-dialog__footer .upf-btn--default').hasText(this.secondaryAction.label);
   });
 
-  test('The dialog calls the main action when the main action button is clicked', async function (assert) {
+  test('When clicking on the main action button, the main action is called', async function (assert) {
     await render(
       hbs`<OSS::Dialog @title={{this.title}} @mainAction={{this.mainAction}} @secondaryAction={{this.secondaryAction}} />`
     );
@@ -116,7 +116,7 @@ module('Integration | Component | o-s-s/dialog', function (hooks) {
     assert.true(this.mainAction.action.calledOnce);
   });
 
-  test('The dialog calls the secondary action when the secondary action button is clicked', async function (assert) {
+  test('When clicking on the secondary action button, the secondary action is called', async function (assert) {
     await render(
       hbs`<OSS::Dialog @title={{this.title}} @mainAction={{this.mainAction}} @secondaryAction={{this.secondaryAction}} />`
     );


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the context of this pull request and its purpose. -->

Related to: #[DRA-1046](https://linear.app/upfluence/issue/DRA-1046/dialog-box-to-confirm-if-users-wants-to-define-default-account-email)

### What are the observable changes?
<!-- This question could be adequate with multiple use cases, for example: -->

<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->

### Good PR checklist
- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [x] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled
