### PR TITLE
Override flatpickrs style to match our branding(s)

### DIFF
--- a/app/styles/vendor/_all.less
+++ b/app/styles/vendor/_all.less
@@ -1,3 +1,4 @@
 @import '_modal';
 @import '_dropdowns';
 @import '_nav-tabs';
+@import '_flatpickr';

--- a/app/styles/vendor/_flatpickr.less
+++ b/app/styles/vendor/_flatpickr.less
@@ -2,19 +2,18 @@
   --flatpickr-padding: 0px;
   --flatpickr-day-size: 34px;
   --flatpickr-day-margin: 3px;
+  --flatpickr-width: calc(
+    var(--flatpickr-day-size) * 7 + var(--flatpickr-day-margin) * 14 + var(--flatpickr-padding) * 2 + 2px
+  );
 }
 
 .flatpickr-calendar,
 .flatpickr-rContainer,
 .flatpickr-rContainer .flatpickr-days,
 .flatpickr-rContainer .dayContainer {
-  width: calc(var(--flatpickr-day-size) * 7 + var(--flatpickr-day-margin) * 14 + var(--flatpickr-padding) * 2 + 2px);
-  max-width: calc(
-    var(--flatpickr-day-size) * 7 + var(--flatpickr-day-margin) * 14 + var(--flatpickr-padding) * 2 + 2px
-  );
-  min-width: calc(
-    var(--flatpickr-day-size) * 7 + var(--flatpickr-day-margin) * 14 + var(--flatpickr-padding) * 2 + 2px
-  );
+  width: var(--flatpickr-width);
+  max-width: var(--flatpickr-width);
+  min-width: var(--flatpickr-width);
 }
 
 .flatpickr-calendar {

--- a/app/styles/vendor/_flatpickr.less
+++ b/app/styles/vendor/_flatpickr.less
@@ -1,0 +1,183 @@
+:root {
+  --flatpickr-padding: 0px;
+  --flatpickr-day-size: 34px;
+  --flatpickr-day-margin: 3px;
+}
+
+.flatpickr-calendar,
+.flatpickr-rContainer,
+.flatpickr-rContainer .flatpickr-days,
+.flatpickr-rContainer .dayContainer {
+  width: calc(var(--flatpickr-day-size) * 7 + var(--flatpickr-day-margin) * 14 + var(--flatpickr-padding) * 2 + 2px);
+  max-width: calc(
+    var(--flatpickr-day-size) * 7 + var(--flatpickr-day-margin) * 14 + var(--flatpickr-padding) * 2 + 2px
+  );
+  min-width: calc(
+    var(--flatpickr-day-size) * 7 + var(--flatpickr-day-margin) * 14 + var(--flatpickr-padding) * 2 + 2px
+  );
+}
+
+.flatpickr-calendar {
+  .flatpickr-months {
+    .flatpickr-prev-month,
+    .flatpickr-next-month {
+      svg {
+        height: 12px;
+        width: 12px;
+        stroke: var(--color-gray-600);
+        transition: stroke 300ms ease-in-out;
+      }
+    }
+
+    .flatpickr-prev-month:hover svg,
+    .flatpickr-next-month:hover svg {
+      stroke: var(--color-gray-900);
+    }
+
+    .flatpickr-current-month {
+      padding-top: 10px;
+
+      select,
+      input.cur-year {
+        color: var(--color-gray-900);
+        font-size: var(--font-size-md);
+        font-weight: var(--font-weight-semibold);
+      }
+
+      select {
+        text-align: right;
+        margin-right: var(--spacing-px-12);
+
+        &:hover {
+          background: none;
+        }
+      }
+
+      .numInputWrapper {
+        border-radius: var(--border-radius-sm);
+
+        &:hover {
+          background: none;
+        }
+
+        input.cur-year {
+          height: 22px;
+
+          &:hover {
+            .input-state-hover;
+            border-radius: var(--border-radius-sm);
+            border-top-right-radius: 0;
+            border-bottom-right-radius: 0;
+          }
+
+          &:focus {
+            border-radius: var(--border-radius-sm);
+            .input-state-focus;
+          }
+        }
+      }
+    }
+  }
+
+  .flatpickr-weekdaycontainer {
+    span.flatpickr-weekday {
+      color: var(--color-gray-900);
+      font-size: var(--font-size-xs);
+      font-weight: normal;
+    }
+  }
+
+  .flatpickr-day {
+    border-width: 0px;
+    color: var(--color-gray-600);
+    font-size: var(--font-size-sm);
+    line-height: var(--flatpickr-day-size);
+
+    height: var(--flatpickr-day-size);
+    width: var(--flatpickr-day-size);
+    max-height: var(--flatpickr-day-size);
+    max-width: var(--flatpickr-day-size);
+
+    margin: var(--flatpickr-day-margin);
+
+    .rangeMode .flatpickr-day {
+      margin-top: unset;
+    }
+
+    &:not(.startRange):not(.endRange):not(.selected):not(.inRange):hover {
+      background-color: var(--color-gray-200);
+      border-radius: 50%;
+      color: var(--color-gray-600);
+    }
+
+    &.today:not(.startRange):not(.endRange):not(.selected):not(.inRange) {
+      border-width: 1px;
+      border-color: var(--color-border-default);
+      color: var(--color-primary-500);
+    }
+
+    &.nextMonthDay {
+      color: var(--color-gray-400);
+    }
+
+    &.startRange,
+    &.endRange {
+      background-color: var(--color-primary-500);
+      border-radius: 50%;
+      position: relative;
+      color: var(--color-white);
+    }
+
+    &.startRange:not(.endRange):before {
+      content: '';
+      height: 38px;
+      width: 41px;
+      position: absolute;
+      z-index: -1;
+      top: -2px;
+      left: -3px;
+      border-radius: 50% 0 0 50%;
+      background-color: var(--color-primary-100);
+    }
+
+    &.endRange:not(.startRange):hover:before,
+    &.endRange:not(.startRange):before {
+      content: '';
+      height: 38px;
+      width: 41px;
+      position: absolute;
+      z-index: -1;
+      top: -2px;
+      right: -3px;
+      border-radius: 0 50% 50% 0;
+      background-color: var(--color-primary-100);
+    }
+
+    &.inRange {
+      background-color: var(--color-primary-100);
+      box-shadow: none;
+      -webkit-box-shadow: none;
+      position: relative;
+      border: none;
+
+      &:before {
+        content: '';
+        background-color: red;
+        background-color: var(--color-primary-100);
+        position: absolute;
+        top: -2px;
+        left: -5px;
+        height: 38px;
+        width: 45px;
+        z-index: -1;
+      }
+    }
+  }
+
+  .flatpickr-day.selected.startRange + .endRange:not(:nth-child(7n + 1)),
+  .flatpickr-day.startRange.startRange + .endRange:not(:nth-child(7n + 1)),
+  .flatpickr-day.endRange.startRange + .endRange:not(:nth-child(7n + 1)) {
+    box-shadow: none;
+    -webkit-box-shadow: none;
+  }
+}


### PR DESCRIPTION
### What does this PR do?

Override flatpickrs style to match our branding

### What are the observable changes?

Before:

![Screenshot 2024-09-13 at 14 16 31](https://github.com/user-attachments/assets/476ff11e-d283-45ad-977c-2dc84ea91dbf)
![Screenshot 2024-09-13 at 14 16 25](https://github.com/user-attachments/assets/15f49e94-13d1-4a50-9913-6d97e4d90ffc)

After:

![Screenshot 2024-09-13 at 14 17 50](https://github.com/user-attachments/assets/b0b4d2f6-82b4-49d1-890f-48b281f53497)
![Screenshot 2024-09-13 at 14 17 41](https://github.com/user-attachments/assets/93b04987-84c9-4eb3-97b5-953e59a0e60b)


### Good PR checklist
- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled
