### PR TITLE
Add icon option for OSS::Copy

### DIFF
--- a/addon/components/o-s-s/copy.hbs
+++ b/addon/components/o-s-s/copy.hbs
@@ -1,7 +1,7 @@
 {{#if this.accessibleClipboard}}
   {{#if this.inline}}
     <OSS::Icon
-      @icon="fa-copy"
+      @icon={{this.icon}}
       class="oss-copy--inline"
       {{on "click" this.copy}}
       {{enable-tooltip placement="top" title=(t "oss-components.copy.tooltip") trigger="hover"}}
@@ -10,7 +10,7 @@
     />
   {{else}}
     <OSS::Button
-      @icon="far fa-copy"
+      @icon={{this.icon}}
       @square={{true}}
       @size="sm"
       {{on "click" this.copy}}

--- a/addon/components/o-s-s/copy.hbs
+++ b/addon/components/o-s-s/copy.hbs
@@ -4,7 +4,7 @@
       @icon={{this.icon}}
       class="oss-copy--inline"
       {{on "click" this.copy}}
-      {{enable-tooltip placement="top" title=(t "oss-components.copy.tooltip") trigger="hover"}}
+      {{enable-tooltip placement="top" title=this.tooltip trigger="hover"}}
       data-control-name="copy-content-button"
       ...attributes
     />
@@ -14,7 +14,7 @@
       @square={{true}}
       @size="sm"
       {{on "click" this.copy}}
-      {{enable-tooltip placement="top" title=(t "oss-components.copy.tooltip") trigger="hover"}}
+      {{enable-tooltip placement="top" title=this.tooltip trigger="hover"}}
       data-control-name="copy-content-button"
       ...attributes
     />

--- a/addon/components/o-s-s/copy.stories.js
+++ b/addon/components/o-s-s/copy.stories.js
@@ -36,6 +36,17 @@ export default {
         defaultValue: { summary: 'undefined' }
       },
       control: { type: 'text' }
+    },
+    tooltip: {
+      type: { name: 'string' },
+      description: 'Set the custom tooltip value',
+      table: {
+        type: {
+          summary: 'string'
+        },
+        defaultValue: { summary: 'undefined' }
+      },
+      control: { type: 'text' }
     }
   },
   parameters: {
@@ -51,11 +62,15 @@ export default {
 const defaultArgs = {
   value: 'Your copied value',
   inline: false,
-  icon: undefined
+  icon: undefined,
+  tooltip: undefined
 };
 
 const BasicUsageTemplate = (args) => ({
-  template: hbs`<div class="fx-col"><OSS::Copy @value={{this.value}} @inline={{this.inline}} @icon={{this.icon}}/></div>`,
+  template: hbs`
+    <div class="fx-col">
+      <OSS::Copy @value={{this.value}} @inline={{this.inline}} @icon={{this.icon}} @tooltip={{this.tooltip}} />
+    </div>`,
   context: args
 });
 

--- a/addon/components/o-s-s/copy.stories.js
+++ b/addon/components/o-s-s/copy.stories.js
@@ -33,7 +33,7 @@ export default {
         type: {
           summary: 'string'
         },
-        defaultValue: { summary: 'undefined' }
+        defaultValue: { summary: 'far fa-copy' }
       },
       control: { type: 'text' }
     },
@@ -44,7 +44,7 @@ export default {
         type: {
           summary: 'string'
         },
-        defaultValue: { summary: 'undefined' }
+        defaultValue: { summary: 'Copy' }
       },
       control: { type: 'text' }
     }

--- a/addon/components/o-s-s/copy.stories.js
+++ b/addon/components/o-s-s/copy.stories.js
@@ -25,6 +25,17 @@ export default {
         defaultValue: { summary: false }
       },
       control: { type: 'boolean' }
+    },
+    icon: {
+      type: { name: 'string' },
+      description: 'Set the custom icon',
+      table: {
+        type: {
+          summary: 'string'
+        },
+        defaultValue: { summary: 'undefined' }
+      },
+      control: { type: 'text' }
     }
   },
   parameters: {
@@ -39,11 +50,12 @@ export default {
 
 const defaultArgs = {
   value: 'Your copied value',
-  inline: false
+  inline: false,
+  icon: undefined
 };
 
 const BasicUsageTemplate = (args) => ({
-  template: hbs`<div class="fx-col"><OSS::Copy @value={{this.value}} @inline={{this.inline}}/></div>`,
+  template: hbs`<div class="fx-col"><OSS::Copy @value={{this.value}} @inline={{this.inline}} @icon={{this.icon}}/></div>`,
   context: args
 });
 

--- a/addon/components/o-s-s/copy.ts
+++ b/addon/components/o-s-s/copy.ts
@@ -11,6 +11,7 @@ interface OSSCopyArgs {
   value: string;
   inline?: boolean;
   icon?: string;
+  tooltip?: string;
 }
 
 export default class OSSCopy extends Component<OSSCopyArgs> {
@@ -38,6 +39,10 @@ export default class OSSCopy extends Component<OSSCopyArgs> {
 
   get icon(): string {
     return this.args.icon ?? 'far fa-copy';
+  }
+
+  get tooltip(): string {
+    return this.args.tooltip ?? this.intl.t('oss-components.copy.tooltip');
   }
 
   @action

--- a/addon/components/o-s-s/copy.ts
+++ b/addon/components/o-s-s/copy.ts
@@ -10,6 +10,7 @@ import type { IntlService } from 'ember-intl';
 interface OSSCopyArgs {
   value: string;
   inline?: boolean;
+  icon?: string;
 }
 
 export default class OSSCopy extends Component<OSSCopyArgs> {
@@ -33,6 +34,10 @@ export default class OSSCopy extends Component<OSSCopyArgs> {
         this.accessibleClipboard = state === 'granted';
       })
       .catch(() => {});
+  }
+
+  get icon(): string {
+    return this.args.icon ?? 'far fa-copy';
   }
 
   @action

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -29,17 +29,21 @@
   </OSS::Layout::Sidebar>
 
   <div style="width:100%; height:100vh; overflow: auto; background-color: var(--color-gray-50)">
-    <OSS::Slider @value={{10}} />
-    <div class="fx-col fx-gap-px-10 margin-md width-pc-20">
-      <OSS::Layout::Navbar::NavItem @icon="fa-cog" @label="First Label" />
-      <OSS::Layout::Navbar::NavItem @icon="fa-code-branch" @label="Second Label" @active={{true}} />
-      <OSS::Layout::Navbar::NavItem @icon="fa-code-branch" @label="Third Label" @active={{true}} />
+    <div class="fx-row fx-gap-px-10 margin-md">
+      <OSS::Copy @value="I am the value copied" @inline={{true}} />
+      <OSS::Copy @value="I am the value copied" />
+      <OSS::Copy @value="I am the value copied" @icon="far fa-jedi" />
+      <OSS::Copy @value="I am the value copied" @icon="fab fa-empire" @inline={{true}} />
+      <OSS::Slider @value={{10}} />
     </div>
 
-    <div class="fx-col fx-gap-px-10 margin-md width-pc-20">
+    <div class="fx-row fx-gap-px-10 margin-md">
       <OSS::Button @skin="primary" @label="Open Dialog" {{on "click" (fn (mut this.showDialog) true)}} />
       <OSS::Button @skin="primary" @label="Open Modal" {{on "click" (fn (mut this.showModal) true)}} />
       <OSS::Button @skin="primary" @label="Open Side Panel" {{on "click" this.openSidePanel}} />
+      <OSS::Layout::Navbar::NavItem @icon="fa-cog" @label="First Label" />
+      <OSS::Layout::Navbar::NavItem @icon="fa-code-branch" @label="Second Label" @active={{true}} />
+      <OSS::Layout::Navbar::NavItem @icon="fa-code-branch" @label="Third Label" @active={{true}} />
     </div>
 
     <OSS::SidePanel @onClose={{this.closeSidePanel}} @backdrop={{true}} @visible={{this.showSidePanel}}>

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -32,6 +32,7 @@
     <div class="fx-row fx-gap-px-10 margin-md">
       <OSS::Copy @value="I am the value copied" @inline={{true}} />
       <OSS::Copy @value="I am the value copied" />
+      <OSS::Copy @value="I am the value copied" @tooltip="Custom tooltip" />
       <OSS::Copy @value="I am the value copied" @icon="far fa-jedi" />
       <OSS::Copy @value="I am the value copied" @icon="fab fa-empire" @inline={{true}} />
       <OSS::Slider @value={{10}} />

--- a/tests/integration/components/o-s-s/avatar-test.ts
+++ b/tests/integration/components/o-s-s/avatar-test.ts
@@ -81,7 +81,7 @@ module('Integration | Component | o-s-s/avatar', function (hooks) {
     });
 
     test('it displays the initials when both initials and image are provided and the image fails to load', async function (assert) {
-      await render(hbs`<OSS::Avatar @image="http://foo.co/bar.p" @initials="TS" />`);
+      await render(hbs`<OSS::Avatar @image="/foo.co/bar.p" @initials="TS" />`);
       await waitFor('.upf-avatar span');
 
       assert.dom('.upf-avatar').exists();
@@ -90,7 +90,7 @@ module('Integration | Component | o-s-s/avatar', function (hooks) {
     });
 
     test('it displays the placeholder image when the image provided in parameters fails to load', async function (assert) {
-      await render(hbs`<OSS::Avatar @image="http://foo.co/bar.p" />`);
+      await render(hbs`<OSS::Avatar @image="/foo.co/bar.p" />`);
       await waitUntil(function () {
         return find('.upf-avatar img')?.getAttribute('src') === DEFAULT_IMAGE_URL;
       });

--- a/tests/integration/components/o-s-s/copy-test.ts
+++ b/tests/integration/components/o-s-s/copy-test.ts
@@ -23,6 +23,18 @@ module('Integration | Component | o-s-s/copy', function (hooks) {
     assert.dom('.oss-copy--inline').exists();
   });
 
+  module('for @icon', () => {
+    test('when value is undefined, it renders the default icon', async function (assert) {
+      await render(hbs`<OSS::Copy />`);
+      assert.dom('i.fa-copy').exists();
+    });
+
+    test('when value is defined, it renders the specified icon', async function (assert) {
+      await render(hbs`<OSS::Copy @icon="far fa-jedi" />`);
+      assert.dom('i.fa-jedi').exists();
+    });
+  });
+
   test('the tooltip has correct wording', async function (assert) {
     await render(hbs`<OSS::Copy />`);
 

--- a/tests/integration/components/o-s-s/copy-test.ts
+++ b/tests/integration/components/o-s-s/copy-test.ts
@@ -35,10 +35,17 @@ module('Integration | Component | o-s-s/copy', function (hooks) {
     });
   });
 
-  test('the tooltip has correct wording', async function (assert) {
-    await render(hbs`<OSS::Copy />`);
+  module('for @tooltip', () => {
+    test('when value is undefined, it renders the default', async function (assert) {
+      await render(hbs`<OSS::Copy />`);
+      await assert.tooltip('.upf-btn--default').hasTitle('Copy');
+    });
 
-    await assert.tooltip('.upf-btn--default').hasTitle('Copy');
+    test('when value is defined, it renders the specified tooltip', async function (assert) {
+      this.tooltip = 'Custom tooltip';
+      await render(hbs`<OSS::Copy @tooltip={{this.tooltip}} />`);
+      await assert.tooltip('.upf-btn--default').hasTitle(this.tooltip);
+    });
   });
 
   module('on non-Chrome browsers the button is always displayed', function (hooks) {


### PR DESCRIPTION
### What does this PR do?

Add icon option for OSS::Copy

### What are the observable changes?
![Screenshot from 2024-09-16 11-44-13](https://github.com/user-attachments/assets/b55c422a-750e-4447-9ad3-fae5035e31df)

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [x] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled
