### PR TITLE
na/DRA-1046 - Added: safe string acceptance on oss-dialog title

### DIFF
--- a/addon/components/o-s-s/dialog.stories.js
+++ b/addon/components/o-s-s/dialog.stories.js
@@ -12,7 +12,7 @@ export default {
       description: 'The dialog title',
       table: {
         type: {
-          summary: 'string'
+          summary: 'string | safeString'
         },
         defaultValue: { summary: 'undefined' }
       },

--- a/addon/components/o-s-s/dialog.stories.js
+++ b/addon/components/o-s-s/dialog.stories.js
@@ -12,7 +12,7 @@ export default {
       description: 'The dialog title',
       table: {
         type: {
-          summary: 'string | safeString'
+          summary: 'string | SafeString'
         },
         defaultValue: { summary: 'undefined' }
       },

--- a/addon/components/o-s-s/dialog.ts
+++ b/addon/components/o-s-s/dialog.ts
@@ -1,6 +1,7 @@
 import BaseModal, { type BaseModalArgs } from './private/base-modal';
 import { action } from '@ember/object';
 import { assert } from '@ember/debug';
+import { isEmpty } from '@ember/utils';
 
 type Skin = 'alert' | 'primary' | 'error';
 
@@ -22,7 +23,10 @@ export default class OSSDialog extends BaseModal<OSSDialogArgs> {
   constructor(owner: unknown, args: OSSDialogArgs) {
     super(owner, args);
 
-    assert('[component][OSS::Dialog] The title parameter is mandatory', typeof args.title === 'string');
+    assert(
+      '[component][OSS::Dialog] The title parameter is mandatory',
+      typeof args.title === 'string' || this.isSafeString(args.title)
+    );
     assert('[component][OSS::Dialog] The mainAction parameter is mandatory', typeof args.mainAction === 'object');
     assert(
       '[component][OSS::Dialog] The secondaryAction parameter is mandatory',
@@ -45,5 +49,9 @@ export default class OSSDialog extends BaseModal<OSSDialogArgs> {
   @action
   onInit(elem: HTMLElement): void {
     this.initialize(elem, false);
+  }
+
+  private isSafeString(data: any): boolean {
+    return typeof data === 'object' && !isEmpty(data.string);
   }
 }

--- a/addon/components/o-s-s/dialog.ts
+++ b/addon/components/o-s-s/dialog.ts
@@ -1,7 +1,7 @@
 import BaseModal, { type BaseModalArgs } from './private/base-modal';
 import { action } from '@ember/object';
 import { assert } from '@ember/debug';
-import { isEmpty } from '@ember/utils';
+import { htmlSafe } from '@ember/template';
 
 type Skin = 'alert' | 'primary' | 'error';
 
@@ -52,6 +52,6 @@ export default class OSSDialog extends BaseModal<OSSDialogArgs> {
   }
 
   private isSafeString(data: any): boolean {
-    return typeof data === 'object' && !isEmpty(data.string);
+    return data.constructor.name === 'SafeString';
   }
 }

--- a/addon/components/o-s-s/dialog.ts
+++ b/addon/components/o-s-s/dialog.ts
@@ -52,6 +52,6 @@ export default class OSSDialog extends BaseModal<OSSDialogArgs> {
   }
 
   private isSafeString(data: any): boolean {
-    return data.constructor.name === 'SafeString';
+    return data?.constructor?.name === 'SafeString';
   }
 }

--- a/tests/dummy/app/controllers/application.js
+++ b/tests/dummy/app/controllers/application.js
@@ -3,6 +3,8 @@ import Controller from '@ember/controller';
 import { action, set } from '@ember/object';
 import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
+import { htmlSafe } from '@ember/template';
+
 import { countries } from '@upfluence/oss-components/utils/country-codes';
 import BaseUploader from '@upfluence/oss-components/services/base-uploader';
 
@@ -241,6 +243,10 @@ export default class ApplicationController extends Controller {
     const owner = getOwner(this);
     owner.register('service:mock-uploader', MockUploader);
     this.mockUploader = owner.lookup('service:mock-uploader');
+  }
+
+  get translatedHTMLTitle() {
+    return htmlSafe('This title can take a <em>string</em> or a <em>safeString</em>');
   }
 
   @action

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -1051,7 +1051,7 @@
 
 {{#if this.showDialog}}
   <OSS::Dialog
-    @title={{t "oss-components.dialog.title" htmlSafe=true}}
+    @title={{this.translatedHTMLTitle}}
     @mainAction={{hash action=this.onMainAction label="Discard changes"}}
     @secondaryAction={{hash action=this.onSecondaryAction label="Keep editing"}}
     @icon="fa-circle-info"

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -1051,7 +1051,7 @@
 
 {{#if this.showDialog}}
   <OSS::Dialog
-    @title="You are about to discard your changes"
+    @title={{t "oss-components.dialog.title" htmlSafe=true}}
     @mainAction={{hash action=this.onMainAction label="Discard changes"}}
     @secondaryAction={{hash action=this.onSecondaryAction label="Keep editing"}}
     @icon="fa-circle-info"

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -72,5 +72,4 @@ oss-components:
       lock_tooltip: Reveal email
     removable_text:
       remove_tooltip: Remove
-  dialog:
-    title: This title can take a <em>string</em> or a <em>safeString</em>
+

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -72,3 +72,5 @@ oss-components:
       lock_tooltip: Reveal email
     removable_text:
       remove_tooltip: Remove
+  dialog:
+    title: This title can take a <em>string</em> or a <em>safeString</em>


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the context of this pull request and its purpose. -->

Added the option to pass a safe string to the title of the OSS::Dialog component.

Necessary for: #[DRA-1046](https://linear.app/upfluence/issue/DRA-1046/dialog-box-to-confirm-if-users-wants-to-define-default-account-email)

### What are the observable changes?
<!-- This question could be adequate with multiple use cases, for example: -->

<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->

### Good PR checklist
- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [ ] Added/updated tests
- [x] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled
