### PR TITLE
Fixed corners for Panel::row & added disabled to panel::row

### DIFF
--- a/addon/components/o-s-s/panel.hbs
+++ b/addon/components/o-s-s/panel.hbs
@@ -1,4 +1,4 @@
-<div class="oss-panel">
+<div class="oss-panel" ...attributes>
   {{#if (has-block "header")}}
     <div class="oss-panel--header width-pc-100">
       {{yield to="header"}}

--- a/addon/components/o-s-s/panel.stories.js
+++ b/addon/components/o-s-s/panel.stories.js
@@ -17,13 +17,13 @@ const Template = (args) => ({
     <OSS::Panel
     >
       <:header>
-        <span>Header named-block</span>
+        <OSS::Panel::Row @label="Header named-block" @icon="fa-cog" />
       </:header>
       <:content>
-        <span>Content named-block</span>
+        <OSS::Panel::Row @label="Content named-block" @icon="fa-search" />
       </:content>
       <:footer>
-        <span>Footer named-block</span>
+        <OSS::Panel::Row @label="Footer named-block" @icon="fa-sign-out" @disabled={{true}} />
       </:footer>
     </OSS::Panel>
   `,

--- a/addon/components/o-s-s/panel/row.hbs
+++ b/addon/components/o-s-s/panel/row.hbs
@@ -1,10 +1,10 @@
-<div class="oss-panel-content--row" ...attributes>
+<div class="oss-panel-content--row {{if @disabled 'oss-panel-content--row-disabled'}}" ...attributes>
   {{#if @icon}}
     <div class="oss-panel-content--row--icon-wrapper">
       <OSS::Icon @icon={{@icon}} />
     </div>
   {{/if}}
-  <span class="font-color-gray-500">
+  <span class="font-color-gray-500 oss-panel-content--row--text">
     {{@label}}
   </span>
 </div>

--- a/app/styles/organisms/panel.less
+++ b/app/styles/organisms/panel.less
@@ -8,6 +8,7 @@
   width: 200px;
   flex-direction: column;
   align-items: flex-start;
+  overflow: hidden;
 
   .oss-panel-content--row {
     display: inline-flex;
@@ -20,6 +21,25 @@
     gap: var(--spacing-px-9);
     flex-shrink: 0;
     background: var(--color-white);
+
+    &-disabled {
+      cursor: not-allowed;
+
+      &:hover {
+        background-color: var(--color-gray-50);
+        transition: background-color 0.3s ease;
+
+        .oss-panel-content--row--icon-wrapper i,
+        .oss-panel-content--row--text {
+          color: var(--color-gray-400);
+        }
+      }
+
+      .oss-panel-content--row--icon-wrapper i,
+      .oss-panel-content--row--text {
+        color: var(--color-gray-400);
+      }
+    }
 
     .far {
       color: var(--color-gray-400);

--- a/tests/integration/components/o-s-s/panel-row-test.ts
+++ b/tests/integration/components/o-s-s/panel-row-test.ts
@@ -20,4 +20,9 @@ module('Integration | Component | o-s-s/panel-row', function (hooks) {
     await render(hbs`<OSS::Panel::Row @icon={{"fa-cog"}} @label={{'Your Label'l}} />`);
     assert.dom('span').hasText('Your Label');
   });
+
+  test('it renders as disabled when @disabled is provided', async function (assert) {
+    await render(hbs`<OSS::Panel::Row @icon={{"fa-cog"}} @label={{'Your Label'l}} @disabled={{true}}/>`);
+    assert.dom('.oss-panel-content--row-disabled').exists();
+  });
 });


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the context of this pull request and its purpose. -->

Related to: #<!-- enter issue number here -->

### What are the observable changes?
<!-- This question could be adequate with multiple use cases, for example: -->

This is the user links panel in the sidebar, the corners are messed up , 
<img width="819" alt="Capture d’écran 2024-09-30 à 16 45 36" src="https://github.com/user-attachments/assets/8f148d40-38c9-4d99-89fb-f68e2cc7d8b6">

With my changes to the overflow, this is fixed. Also added a disabled param to Panel::Row for later uses

<img width="688" alt="Capture d’écran 2024-09-30 à 16 45 51" src="https://github.com/user-attachments/assets/290162ef-8aa7-49da-a732-7aeadfb0cbcd">

<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->


### Good PR checklist
- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled
