### PR TITLE
Add plain to chat-gpt tag skin

### DIFF
--- a/app/styles/base/_tags.less
+++ b/app/styles/base/_tags.less
@@ -143,6 +143,23 @@
     i {
       .font-color-smart-gradient;
     }
+
+    &.upf-tag--plain {
+      background: var(--color-smart-gradient-500);
+
+      div,
+      i {
+        background: var(--color-white);
+        background-clip: text;
+        -webkit-text-fill-color: transparent;
+        -webkit-background-clip: text;
+      }
+    }
+  }
+
+  &--smart-colors {
+    background: var(--color-smart-gradient-500);
+    color: var(--color-white);
   }
 
   &--xs {

--- a/app/styles/base/_tags.less
+++ b/app/styles/base/_tags.less
@@ -157,11 +157,6 @@
     }
   }
 
-  &--smart-colors {
-    background: var(--color-smart-gradient-500);
-    color: var(--color-white);
-  }
-
   &--xs {
     padding: 0 var(--spacing-px-6);
     height: var(--spacing-px-18);

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -671,6 +671,7 @@
   <OSS::Tag @label="Tag" @skin="xtd-blue" />
   <OSS::Tag @label="Tag" @skin="xtd-violet" />
   <OSS::Tag @label="Tag" @skin="xtd-lime" />
+  <OSS::Tag @label="Tag" @skin="chat-gpt" />
   <OSS::Tag @label="Test with a huge label sentence" @skin="danger" @icon="far fa-thumbs-up" />
   <OSS::Tag
     @label="Test with a huge label sentence"
@@ -696,6 +697,7 @@
   <OSS::Tag @label="Tag" @skin="xtd-blue" @plain={{true}} />
   <OSS::Tag @label="Tag" @skin="xtd-violet" @plain={{true}} />
   <OSS::Tag @label="Tag" @skin="xtd-lime" @plain={{true}} />
+  <OSS::Tag @label="Tag" @skin="chat-gpt" @plain={{true}} />
   <OSS::Tag @label="Test with a huge label sentence" @skin="danger" @icon="far fa-thumbs-up" @plain={{true}} />
   <OSS::Tag
     @label="Test with a huge label sentence"


### PR DESCRIPTION
### What does this PR do?
This PR adds a plain mode to the chat-gpt skin for the OSS::Tag component

![image](https://github.com/user-attachments/assets/a7cecd7e-20fa-40d6-a97b-be2097d1ea4e)


### Good PR checklist
- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled
