### PR TITLE
Added: plain option for scrollable panel component

### DIFF
--- a/addon/components/o-s-s/scrollable-panel.hbs
+++ b/addon/components/o-s-s/scrollable-panel.hbs
@@ -1,4 +1,4 @@
-<div class="oss-scrollable-panel-container" ...attributes>
+<div class="oss-scrollable-panel-container {{if @plain 'oss-scrollable-panel-container--plain'}}" ...attributes>
   {{#if this.shadowTopVisible}}
     <div class="oss-scrollable-panel--shadow oss-scrollable-panel--shadow__top"></div>
   {{/if}}

--- a/addon/components/o-s-s/scrollable-panel.stories.js
+++ b/addon/components/o-s-s/scrollable-panel.stories.js
@@ -3,7 +3,18 @@ import { hbs } from 'ember-cli-htmlbars';
 export default {
   title: 'Components/OSS::ScrollablePanel',
   component: 'scrollable-panel',
-  argTypes: {},
+  argTypes: {
+    plain: {
+      description: 'When plain is true, the top and bottom shadows are displayed in white, otherwise in grey',
+      table: {
+        type: { summary: 'boolean' },
+        defaultValue: { summary: 'false' }
+      },
+      control: {
+        type: 'boolean'
+      }
+    }
+  },
   parameters: {
     docs: {
       description: {
@@ -13,12 +24,14 @@ export default {
   }
 };
 
-const defaultArgs = {};
+const defaultArgs = {
+  plain: false
+};
 
 const Template = (args) => ({
   template: hbs`
       <div style="height:200px; width: 300px; background-color: white; " >
-        <OSS::ScrollablePanel>
+        <OSS::ScrollablePanel @plain={{this.plain}}>
           <div class="fx-col fx-gap-px-12 padding-px-12">
             <div class="background-color-gray-200" style="height: 50px; width: 100%;" />
             <div class="background-color-gray-200" style="height: 50px; width: 100%;" />

--- a/addon/components/o-s-s/scrollable-panel.ts
+++ b/addon/components/o-s-s/scrollable-panel.ts
@@ -2,7 +2,9 @@ import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 
-interface OSSScrollablePanelComponentSignature {}
+interface OSSScrollablePanelComponentSignature {
+  plain?: boolean;
+}
 
 export default class OSSScrollablePanelComponent extends Component<OSSScrollablePanelComponentSignature> {
   @tracked declare parentElement: HTMLElement;
@@ -19,6 +21,7 @@ export default class OSSScrollablePanelComponent extends Component<OSSScrollable
   @action
   willDestroy(): void {
     this.parentElement.removeEventListener('scroll', this.scrollListener.bind(this));
+    super.willDestroy();
   }
 
   private scrollListener(): void {

--- a/app/styles/organisms/scrollable-panel.less
+++ b/app/styles/organisms/scrollable-panel.less
@@ -26,4 +26,16 @@
       background: linear-gradient(to top, var(--color-gray-50), transparent 40px);
     }
   }
+
+  &--plain {
+    .oss-scrollable-panel--shadow {
+      &__top {
+        background: linear-gradient(to bottom, var(--color-white), transparent 40px);
+      }
+
+      &__bottom {
+        background: linear-gradient(to top, var(--color-white), transparent 40px);
+      }
+    }
+  }
 }


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the context of this pull request and its purpose. -->

Added "plain" optional argument on OSS::ScrollablePanel to allow for choosing between grey or white shadows.

Related to: #[DRA-1560](https://linear.app/upfluence/issue/DRA-1560/[identity-web]-user-roles-and-permissions-make-the-user-management)

### What are the observable changes?
<!-- This question could be adequate with multiple use cases, for example: -->

<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->

### Good PR checklist
- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled
