### PR TITLE
Removed: bootstrap's col-xs usage from InputWrapper

### DIFF
--- a/app/styles/base/_inputs.less
+++ b/app/styles/base/_inputs.less
@@ -192,7 +192,6 @@ label {
 
   .upf-input-feedback {
     position: relative;
-    min-height: 1px;
     padding-right: var(--spacing-px-12);
     padding-left: var(--spacing-px-12);
     float: left;

--- a/app/styles/base/_inputs.less
+++ b/app/styles/base/_inputs.less
@@ -191,6 +191,13 @@ label {
   position: relative;
 
   .upf-input-feedback {
+    position: relative;
+    min-height: 1px;
+    padding-right: var(--spacing-px-12);
+    padding-left: var(--spacing-px-12);
+    float: left;
+    width: 100%;
+
     i {
       display: block;
       font-size: 1.5em;

--- a/app/templates/components/input-wrapper.hbs
+++ b/app/templates/components/input-wrapper.hbs
@@ -1,11 +1,11 @@
 {{yield}}
 
 {{#if this.error}}
-  <span class="col-xs-12 upf-input-feedback upf-input-feedback--error">
+  <span class="upf-input-feedback upf-input-feedback--error">
     <OSS::Icon @icon="fa-exclamation-circle" aria-label={{this.error}} />
   </span>
 {{else if this.help}}
-  <span class="col-xs-12 upf-input-feedback upf-input-feedback--help">
+  <span class="upf-input-feedback upf-input-feedback--help">
     <OSS::Icon @icon="fa-question-circle" aria-label={{this.help}} />
   </span>
 {{/if}}


### PR DESCRIPTION
### What does this PR do?
Removes the `col-xs` bootstrap class from the soon to be deprecated `InputWrapper` component

### Good PR checklist
- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled