### PR TITLE
Remove event.stopPropagation in select toggle for OSS::ToggleButtons

### DIFF
--- a/addon/components/o-s-s/toggle-buttons.ts
+++ b/addon/components/o-s-s/toggle-buttons.ts
@@ -41,8 +41,7 @@ export default class OSSToggleButtons extends Component<OSSToggleButtonsArgs> {
   }
 
   @action
-  onSelectToggle(selectedToggle: string, event: PointerEvent): void {
-    event.stopPropagation();
+  onSelectToggle(selectedToggle: string): void {
     if (this.args.disabled) return;
     if (this.args.selectedToggle !== selectedToggle) {
       this.args.onSelection(selectedToggle);


### PR DESCRIPTION
### What does this PR do?

Remove event.stopPropagation in select toggle for OSS::ToggleButtons. I check in all OSS::ToggleButtons, it is not intriduce any issue. In some cases, this leads to UX inconsistencies on dropdown closures.

### What are the observable changes?

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled
