### PR TITLE
Updated: OSS::Dialog with optional @subtitle param and logic to handle loading state on main action button

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ clear:
 install: ## Install dependencies
 	@echo 'Installing dependencies'
 	pnpm install
-	@echo ""; echo "\n-------------------------------\n"; echo ""
+	@echo ""; echo "-------------------------------"; echo ""
 
 echo:
 	@echo Starting OSS-Components

--- a/addon/components/o-s-s/dialog.hbs
+++ b/addon/components/o-s-s/dialog.hbs
@@ -2,11 +2,26 @@
   <div class="oss-dialog fx-col" {{did-insert this.onInit}} ...attributes>
     <div class="oss-dialog__header">
       <OSS::Badge @icon={{this.icon}} @skin={{this.skin}} />
-      <span class="font-weight-semibold font-size-md">{{@title}}</span>
+      <div class="fx-col fx-gap-px-3">
+        <span class="font-weight-semibold font-size-md">{{@title}}</span>
+        {{#if @subtitle}}
+          <span class="font-color-gray-900 font-size-sm">{{@subtitle}}</span>
+        {{/if}}
+      </div>
     </div>
     <div class="oss-dialog__footer">
-      <OSS::Button @skin={{this.skinBtn}} @label={{@mainAction.label}} {{on "click" @mainAction.action}} />
-      <OSS::Button @label={{@secondaryAction.label}} {{on "click" @secondaryAction.action}} />
+      <OSS::Button
+        @skin={{this.skinBtn}}
+        @label={{@mainAction.label}}
+        {{on "click" @mainAction.action}}
+        @loading={{@mainAction.loading}}
+        data-control-name="dialog-primary-action-button"
+      />
+      <OSS::Button
+        @label={{@secondaryAction.label}}
+        {{on "click" @secondaryAction.action}}
+        data-control-name="dialog-secondary-action-button"
+      />
     </div>
   </div>
 </div>

--- a/addon/components/o-s-s/dialog.stories.js
+++ b/addon/components/o-s-s/dialog.stories.js
@@ -18,6 +18,17 @@ export default {
       },
       control: { type: 'text' }
     },
+    subtitle: {
+      type: { required: false },
+      description: 'An optional subtitle that will be displayed below the title',
+      table: {
+        type: {
+          summary: 'string | SafeString'
+        },
+        defaultValue: { summary: 'undefined' }
+      },
+      control: { type: 'text' }
+    },
     skin: {
       description: 'The dialog skin',
       table: {
@@ -44,7 +55,7 @@ export default {
       description: 'A hash with the main action button properties',
       table: {
         type: {
-          summary: '{ label: string, action: () => unknown }'
+          summary: '{ label: string, action: () => unknown; loading?: boolean }'
         },
         defaultValue: { summary: 'undefined' }
       },
@@ -81,7 +92,8 @@ const defaultArgs = {
   icon: 'fa-warning',
   mainAction: {
     label: 'Discard',
-    action: action('discard')
+    action: action('discard'),
+    loading: false
   },
   secondaryAction: {
     label: 'Cancel',

--- a/addon/components/o-s-s/dialog.ts
+++ b/addon/components/o-s-s/dialog.ts
@@ -5,12 +5,15 @@ import { htmlSafe } from '@ember/template';
 
 type Skin = 'alert' | 'primary' | 'error';
 
+export type ButtonDefinition = { label: string; action: () => unknown; loading?: boolean };
+
 export interface OSSDialogArgs extends BaseModalArgs {
   title: string;
+  subtitle?: string;
   skin?: Skin;
   icon?: string;
-  mainAction: { label: string; action: () => unknown };
-  secondaryAction: { label: string; action: () => unknown };
+  mainAction: ButtonDefinition;
+  secondaryAction: ButtonDefinition;
 }
 
 const BTN_STYLE_MATCHER: Record<Skin, string> = {

--- a/tests/integration/components/o-s-s/dialog-test.ts
+++ b/tests/integration/components/o-s-s/dialog-test.ts
@@ -35,6 +35,16 @@ module('Integration | Component | o-s-s/dialog', function (hooks) {
     assert.dom('.oss-dialog__header').hasText(this.title);
   });
 
+  test('If a @subtitle is passed, it is displayed', async function (assert) {
+    this.subtitle = 'This is a subtitle';
+
+    await render(
+      hbs`<OSS::Dialog @title={{this.title}} @subtitle={{this.subtitle}} @mainAction={{this.mainAction}} @secondaryAction={{this.secondaryAction}} />`
+    );
+
+    assert.dom('.font-color-gray-900.font-size-sm').hasText(`${this.subtitle}`);
+  });
+
   module('For @skin', () => {
     test('When the value is undefined, the default skin is displayed', async function (assert) {
       await render(
@@ -97,6 +107,15 @@ module('Integration | Component | o-s-s/dialog', function (hooks) {
     );
 
     assert.dom('.oss-dialog__footer .upf-btn--alert').hasText(this.mainAction.label);
+  });
+
+  test('When the main action button has the loading property set to true, the button shows a spinner', async function (assert) {
+    this.mainAction.loading = true;
+
+    await render(
+      hbs`<OSS::Dialog @title={{this.title}} @mainAction={{this.mainAction}} @secondaryAction={{this.secondaryAction}} />`
+    );
+    assert.dom('[data-control-name="dialog-primary-action-button"] .fa-circle-notch').exists();
   });
 
   test('The secondary action button label is displayed', async function (assert) {


### PR DESCRIPTION
### What does this PR do?
Updates to OSS::Dialog

1) Adds an optional paramater for a subtitle
2) Adds logic so that we can set the mainAction button in a loading state from the parent
3) Exports typing for Typescript users
![Untitled](https://github.com/user-attachments/assets/a4a0e4fd-7c0a-424e-8fc8-388c9768d735)
![Screenshot 2024-11-25 at 16 46 55](https://github.com/user-attachments/assets/e5764ade-55bc-4cc4-9ee4-c07e30b9a13b)


### Good PR checklist
- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [x] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled