### PR TITLE
OSS::Button: Add support for `@loadingOptions` arg

### DIFF
--- a/addon/components/o-s-s/button.hbs
+++ b/addon/components/o-s-s/button.hbs
@@ -1,14 +1,24 @@
 {{! template-lint-disable u-template-lint/no-bare-button}}
-<button type="button" class={{this.computedClass}} {{did-insert this.didInsert}} {{on "click" this.onclick}} ...attributes>
+<button
+  type="button"
+  class={{this.computedClass}}
+  {{did-insert this.didInsert}}
+  {{on "click" this.onclick}}
+  ...attributes
+>
   {{#if this.intervalState}}
     {{t "oss-components.button.cancel_message" time=this.counterTimeLeftSecond}}
   {{else if this.loadingState}}
     <OSS::Icon @style="solid" @icon="fa-circle-notch fa-spin" />
+
+    {{#if (and @label @loadingOptions.showLabel)}}
+      <span class="margin-left-px-6">{{@label}}</span>
+    {{/if}}
   {{else}}
     {{#if @icon}}
       <OSS::Icon @style={{fa-icon-style @icon}} @icon={{fa-icon-value @icon}} />
     {{else if @iconUrl}}
-      <img src={{@iconUrl}} alt='icon' />
+      <img src={{@iconUrl}} alt="icon" />
     {{/if}}
 
     {{#if @label}}

--- a/addon/components/o-s-s/button.stories.js
+++ b/addon/components/o-s-s/button.stories.js
@@ -57,6 +57,16 @@ export default {
       },
       control: { type: 'boolean' }
     },
+    loadingOptions: {
+      description: 'Options to configure the loading state',
+      table: {
+        type: {
+          summary: '{ showLabel?: boolean }'
+        },
+        defaultValue: { summary: 'undefined' }
+      },
+      control: { type: 'object' }
+    },
     label: {
       description: 'Text content of the button',
       table: {
@@ -141,6 +151,7 @@ const defaultArgs = {
   theme: 'light',
   square: false,
   countDown: undefined,
+  loadingOptions: undefined,
   iconUrl: undefined
 };
 
@@ -148,8 +159,8 @@ const Template = (args) => ({
   template: hbs`
     <OSS::Button
       @skin={{this.skin}} @size={{this.size}} @loading={{this.loading}} @label={{this.label}} @icon={{this.icon}}
-      @theme={{this.theme}} @square={{this.square}} @countDown={{this.countDown}} @theme={{this.theme}} 
-      @iconUrl={{this.iconUrl}}/>
+      @theme={{this.theme}} @square={{this.square}} @countDown={{this.countDown}}
+      @iconUrl={{this.iconUrl}} @loadingOptions={{this.loadingOptions}} />
   `,
   context: args
 });

--- a/addon/components/o-s-s/button.ts
+++ b/addon/components/o-s-s/button.ts
@@ -74,7 +74,6 @@ interface ButtonArgs {
   skin?: string;
   size?: string;
   loading?: boolean;
-  showLabelOnLoad?: boolean;
   loadingOptions?: LoadingOptions;
   icon?: string;
   iconUrl?: string;

--- a/addon/components/o-s-s/button.ts
+++ b/addon/components/o-s-s/button.ts
@@ -148,7 +148,7 @@ export default class OSSButton extends Component<ButtonArgs> {
       return false;
     }
 
-    if (this.args.loading && !this.args.loadingOptions.showLabel) {
+    if (this.args.loading && !this.args.loadingOptions?.showLabel) {
       this.DOMElement.style.width = `${this.DOMElement?.offsetWidth}px`;
     } else {
       this.DOMElement.style.removeProperty('width');

--- a/addon/components/o-s-s/button.ts
+++ b/addon/components/o-s-s/button.ts
@@ -34,6 +34,7 @@ type ThemeType = 'light' | 'dark';
 type ThemeDefType = {
   [key in ThemeType]?: string;
 };
+type LoadingOptions = { showLabel?: boolean };
 
 const SkinDefinition: SkinDefType = {
   default: 'default',
@@ -73,6 +74,8 @@ interface ButtonArgs {
   skin?: string;
   size?: string;
   loading?: boolean;
+  showLabelOnLoad?: boolean;
+  loadingOptions?: LoadingOptions;
   icon?: string;
   iconUrl?: string;
   label?: string;
@@ -145,7 +148,7 @@ export default class OSSButton extends Component<ButtonArgs> {
       return false;
     }
 
-    if (this.args.loading) {
+    if (this.args.loading && !this.args.loadingOptions.showLabel) {
       this.DOMElement.style.width = `${this.DOMElement?.offsetWidth}px`;
     } else {
       this.DOMElement.style.removeProperty('width');

--- a/tests/integration/components/o-s-s/button-test.ts
+++ b/tests/integration/components/o-s-s/button-test.ts
@@ -134,10 +134,22 @@ module('Integration | Component | o-s-s/button', function (hooks) {
 
   module('it renders with loading state', function () {
     test('when using default loading', async function (assert) {
-      await render(hbs`<OSS::Button @size="sm" @loading="true" @label="Test" />`);
+      await render(hbs`<OSS::Button @size="sm" @loading={{true}} @label="Test" />`);
       assert.dom('.upf-btn i.fas').exists();
       assert.dom('.upf-btn i.fas').hasClass('fa-circle-notch');
       assert.dom('.upf-btn i.fas').hasClass('fa-spin');
+      assert.dom('.upf-btn span.margin-left-px-6').doesNotExist();
+    });
+
+    test('when loading and the showLabel loading option is truthy, the label is displayed', async function (assert) {
+      await render(
+        hbs`<OSS::Button @size="sm" @loading={{true}} @label="Test" @loadingOptions={{hash showLabel=true}} />`
+      );
+      assert.dom('.upf-btn i.fas').exists();
+      assert.dom('.upf-btn i.fas').hasClass('fa-circle-notch');
+      assert.dom('.upf-btn i.fas').hasClass('fa-spin');
+      assert.dom('.upf-btn span.margin-left-px-6').exists();
+      assert.dom('.upf-btn span.margin-left-px-6').hasText('Test');
     });
   });
 


### PR DESCRIPTION
### What does this PR do?

This PR introduces a `loadingOptions` optional arg on the `OSS::Button` component to allow us to fine tune it. This is because we now have a case where we want to display the button's label even when loading.

### What are the observable changes?
<!-- This question could be adequate with multiple use cases, for example: -->

<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->

### Good PR checklist
- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [x] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled
