### PR TITLE
Remove Bootstrap imports we are sure we are not using across the apps

### DIFF
--- a/app/styles/shims/bootstrap.less
+++ b/app/styles/shims/bootstrap.less
@@ -11,7 +11,6 @@
 // Reset and dependencies
 @import 'bootstrap/less/normalize.less';
 @import 'bootstrap/less/print.less';
-@import 'bootstrap/less/glyphicons.less';
 
 // Core CSS
 @import 'bootstrap/less/scaffolding.less';
@@ -27,29 +26,13 @@
 @import 'bootstrap/less/dropdowns.less';
 @import 'bootstrap/less/button-groups.less';
 @import 'bootstrap/less/input-groups.less';
-@import 'bootstrap/less/navs.less';
-@import 'bootstrap/less/navbar.less';
-@import 'bootstrap/less/breadcrumbs.less';
-@import 'bootstrap/less/pagination.less';
-@import 'bootstrap/less/pager.less';
 @import 'bootstrap/less/labels.less';
-@import 'bootstrap/less/badges.less';
-@import 'bootstrap/less/jumbotron.less';
-@import 'bootstrap/less/thumbnails.less';
-@import 'bootstrap/less/alerts.less';
-@import 'bootstrap/less/progress-bars.less';
 @import 'bootstrap/less/media.less';
-@import 'bootstrap/less/list-group.less';
-@import 'bootstrap/less/panels.less';
 @import 'bootstrap/less/responsive-embed.less';
-@import 'bootstrap/less/wells.less';
 @import 'bootstrap/less/close.less';
 
 // Components w/ JavaScript
-@import 'bootstrap/less/modals.less';
-@import 'bootstrap/less/tooltip.less';
 @import 'bootstrap/less/popovers.less';
-@import 'bootstrap/less/carousel.less';
 
 // Utility classes
 @import 'bootstrap/less/utilities.less';


### PR DESCRIPTION
### What does this PR do?

Remove Bootstrap imports we are sure we are not using across the apps. This needs to be merged after: https://github.com/upfluence/uedit/pull/76.

### What are the observable changes?
<!-- This question could be adequate with multiple use cases, for example: -->

<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->

### Good PR checklist
- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled
