### PR TITLE
Define all @upfluence template linting rules in our plugin to be extended by others

### DIFF
--- a/linters/handlebars/index.js
+++ b/linters/handlebars/index.js
@@ -5,5 +5,25 @@ module.exports = {
 
   rules: {
     'u-template-lint/no-bare-button': NoBareHTMLButton
+  },
+
+  configurations: {
+    recommended: {
+      extends: 'recommended',
+      rules: {
+        'require-valid-alt-text': false,
+        'simple-unless': false,
+        'no-curly-component-invocation': false,
+        'no-inline-styles': false,
+        'require-iframe-title': false,
+        'require-input-label': false,
+        'no-down-event-binding': false,
+        'no-invalid-interactive': false,
+        'no-action': false,
+        'no-nested-interactive': false,
+        'no-yield-only': false,
+        'no-bare-strings': false
+      }
+    }
   }
 };


### PR DESCRIPTION
### What does this PR do?

This PR updates the internal handlebars linter w/ all rules that are turned-off as we start properly linting our templates. The idea is to gradually enable again the turned-off rules and add custom ones in the future.

### What are the observable changes?
<!-- This question could be adequate with multiple use cases, for example: -->

<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->

### Good PR checklist
- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled
