### PR TITLE
[VEL-3663] OSS::UploadArea: add support onDryRun action support

### DIFF
--- a/addon/components/o-s-s/upload-area.stories.js
+++ b/addon/components/o-s-s/upload-area.stories.js
@@ -165,6 +165,15 @@ export default {
           summary: 'onHandleFileUpload(): void'
         }
       }
+    },
+    onDryRun: {
+      description: 'Action allowing the user to stop just before the actual upload and get the file directly.',
+      table: {
+        category: 'Actions',
+        type: {
+          summary: 'onDryRun?(): void'
+        }
+      }
     }
   },
   parameters: {

--- a/addon/components/o-s-s/upload-area.ts
+++ b/addon/components/o-s-s/upload-area.ts
@@ -26,14 +26,13 @@ interface OSSUploadAreaArgs {
   size?: 'lg' | 'md';
   multiple?: boolean;
   displayPreview?: boolean;
-  dryRun?: boolean;
 
   onUploadSuccess(artifact: FileArtifact): void;
   onUploadFailure?(error: FailedUploadResponse): void;
   onVerificationFailure?(): void;
   onHandleFileUpload?(): void;
   onFileDeletion?(): void;
-  onFileSelected?(file: File): void;
+  onDryRun?(file: File): void;
 
   // In multiple mode
   onUploadSuccess(index: number, artifact: FileArtifact): void;
@@ -228,8 +227,8 @@ export default class OSSUploadArea extends Component<OSSUploadAreaArgs> {
   private _handleFileUpload(file: File): void {
     this.args.onHandleFileUpload?.();
     if (this._validateFile(file)) {
-      if (this.args.dryRun && this.args.onFileSelected) {
-        this.args.onFileSelected(file);
+      if (this.args.onDryRun) {
+        this.args.onDryRun(file);
         return;
       }
 

--- a/addon/components/o-s-s/upload-area.ts
+++ b/addon/components/o-s-s/upload-area.ts
@@ -26,12 +26,14 @@ interface OSSUploadAreaArgs {
   size?: 'lg' | 'md';
   multiple?: boolean;
   displayPreview?: boolean;
+  dryRun?: boolean;
 
   onUploadSuccess(artifact: FileArtifact): void;
   onUploadFailure?(error: FailedUploadResponse): void;
   onVerificationFailure?(): void;
   onHandleFileUpload?(): void;
   onFileDeletion?(): void;
+  onFileSelected?(file: File): void;
 
   // In multiple mode
   onUploadSuccess(index: number, artifact: FileArtifact): void;
@@ -226,6 +228,11 @@ export default class OSSUploadArea extends Component<OSSUploadAreaArgs> {
   private _handleFileUpload(file: File): void {
     this.args.onHandleFileUpload?.();
     if (this._validateFile(file)) {
+      if (this.args.dryRun && this.args.onFileSelected) {
+        this.args.onFileSelected(file);
+        return;
+      }
+
       if (this.editingFileIndex !== undefined) {
         this.selectedFiles[this.editingFileIndex] = file;
         this.selectedFiles = this.selectedFiles;

--- a/tests/integration/components/o-s-s/upload-area-test.ts
+++ b/tests/integration/components/o-s-s/upload-area-test.ts
@@ -235,6 +235,23 @@ module('Integration | Component | o-s-s/upload-area', function (hooks) {
         );
       });
 
+      test('if onDryRun is passed, the uploaded file is passed to it if validated and no upload item is displayed', async function (assert) {
+        this.onDryRun = sinon.stub();
+
+        await render(hbs`
+          <OSS::UploadArea
+            @uploader={{this.mockUploader}} @rules={{this.validationRules}} @size={{this.size}}
+            @subtitle={{this.subtitle}} @onUploadSuccess={{this.onUploadSuccess}} @onDryRun={{this.onDryRun}} />
+        `);
+        await triggerEvent('.oss-upload-area', 'drop', {
+          dataTransfer: { files: [this.file] }
+        });
+
+        assert.dom('.oss-upload-item').doesNotExist();
+        assert.dom('.oss-upload-area').exists();
+        assert.ok(this.onDryRun.calledOnceWithExactly(sinon.match((file: unknown) => file instanceof File)));
+      });
+
       test('the uploaded file is displayed if the dropped file passes the validation', async function (assert) {
         await render(hbs`
           <OSS::UploadArea


### PR DESCRIPTION
### What does this PR do?

OSS::UploadArea: add support `onDryRun` allowing the parent to stop after the file validation and get the File to deal w/ it.

### What are the observable changes?
<!-- This question could be adequate with multiple use cases, for example: -->

<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->

### Good PR checklist
- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [x] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled
