### PR TITLE
OSS::Dialog: add support for icons on the action buttons

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -15,7 +15,7 @@ module.exports = {
     '../addon/modifiers/**/*.stories.@(js|jsx|ts|tsx)',
     '../addon/helpers/**/*.stories.mdx',
     '../addon/helpers/**/*.stories.@(js|jsx|ts|tsx)',
-    '../addon-test-support/custom-assertions/**/*.stories.mdx',
+    '../addon-test-support/**/*.stories.mdx',
     '../app/styles/**/*.stories.mdx'
   ],
 

--- a/addon-test-support/index.ts
+++ b/addon-test-support/index.ts
@@ -1,1 +1,2 @@
 export { default as setupClipboard } from './setup-clipboard';
+export { default as setupToast } from './setup-toast';

--- a/addon-test-support/setup-toast.ts
+++ b/addon-test-support/setup-toast.ts
@@ -1,0 +1,12 @@
+import type { TestContext } from '@ember/test-helpers';
+import sinon from 'sinon';
+
+export default function setupToast(hooks: NestedHooks) {
+  hooks.beforeEach(function (this: TestContext) {
+    this.toastService = this.owner.lookup('service:toast');
+    this.toastSuccessStub = sinon.stub(this.toastService, 'success');
+    this.toastErrorStub = sinon.stub(this.toastService, 'error');
+    this.toastInfoStub = sinon.stub(this.toastService, 'info');
+    this.toastWarningStub = sinon.stub(this.toastService, 'warning');
+  });
+}

--- a/addon-test-support/test-helpers.stories.mdx
+++ b/addon-test-support/test-helpers.stories.mdx
@@ -1,0 +1,44 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+
+<Meta
+  title="Testing/Test helpers"
+  parameters={{
+    viewMode: 'docs',
+    previewTabs: { canvas: { hidden: true } }
+  }}
+/>
+
+# Test helpers
+
+`@upfluence/oss-components` provides a few test helpers, so that you can check
+easily setup frequently used stubs in a few lines of code.
+
+## setupToast
+
+This test helper allows you to setup the Toast service and its various methods
+so you can easily spy on them in your tests. It defines a `this.toastService`
+property that is available in your tests as well as the following stubs:
+
+- `this.toastSuccessStub`
+- `this.toastErrorStub`
+- `this.toastInfoStub`
+- `this.toastWarningStub`
+
+All the stubbing is done using
+[`Sinon`](https://sinonjs.org/releases/v19/stubs/) if you want to know more
+about the methods available on them.
+
+Usage:
+
+```typescript
+module('Integration | Component | o-s-s/my-component', function (hooks) {
+  setupRenderingTest(hooks);
+  setupToast(hooks);
+
+  test('it renders a toast when clicked', function(assert) {
+    await render(hbs`<OSS::MyComponent />`)
+    await click('.button-that-triggers-a-toast')
+    assert.ok(this.toastSuccessStub.calledOnce);
+  })
+});
+```

--- a/addon/components/o-s-s/dialog.hbs
+++ b/addon/components/o-s-s/dialog.hbs
@@ -11,16 +11,18 @@
     </div>
     <div class="oss-dialog__footer">
       <OSS::Button
+        @icon={{@mainAction.icon}}
         @skin={{this.skinBtn}}
         @label={{@mainAction.label}}
-        {{on "click" @mainAction.action}}
         @loading={{@mainAction.loading}}
         data-control-name="dialog-primary-action-button"
+        {{on "click" @mainAction.action}}
       />
       <OSS::Button
+        @icon={{@secondaryAction.icon}}
         @label={{@secondaryAction.label}}
-        {{on "click" @secondaryAction.action}}
         data-control-name="dialog-secondary-action-button"
+        {{on "click" @secondaryAction.action}}
       />
     </div>
   </div>

--- a/addon/components/o-s-s/dialog.stories.js
+++ b/addon/components/o-s-s/dialog.stories.js
@@ -55,7 +55,7 @@ export default {
       description: 'A hash with the main action button properties',
       table: {
         type: {
-          summary: '{ label: string, action: () => unknown; loading?: boolean }'
+          summary: '{ label: string, action: () => unknown; loading?: boolean; icon?: string }'
         },
         defaultValue: { summary: 'undefined' }
       },
@@ -68,7 +68,7 @@ export default {
       description: 'A hash with the secondary action button properties',
       table: {
         type: {
-          summary: '{ label: string, action: () => unknown }'
+          summary: '{ label: string, action: () => unknown; icon?: string }'
         },
         defaultValue: { summary: 'undefined' }
       },
@@ -93,11 +93,13 @@ const defaultArgs = {
   mainAction: {
     label: 'Discard',
     action: action('discard'),
-    loading: false
+    loading: false,
+    icon: null
   },
   secondaryAction: {
     label: 'Cancel',
-    action: action('cancel')
+    action: action('cancel'),
+    icon: null
   }
 };
 

--- a/addon/components/o-s-s/dialog.ts
+++ b/addon/components/o-s-s/dialog.ts
@@ -2,7 +2,7 @@ import BaseModal, { type BaseModalArgs } from './private/base-modal';
 import { action } from '@ember/object';
 import { assert } from '@ember/debug';
 
-type Skin = 'alert' | 'primary' | 'error';
+export type Skin = 'alert' | 'primary' | 'error';
 
 export type ButtonDefinition = { label: string; action: () => unknown; loading?: boolean; icon?: string };
 

--- a/addon/components/o-s-s/dialog.ts
+++ b/addon/components/o-s-s/dialog.ts
@@ -1,11 +1,10 @@
 import BaseModal, { type BaseModalArgs } from './private/base-modal';
 import { action } from '@ember/object';
 import { assert } from '@ember/debug';
-import { htmlSafe } from '@ember/template';
 
 type Skin = 'alert' | 'primary' | 'error';
 
-export type ButtonDefinition = { label: string; action: () => unknown; loading?: boolean };
+export type ButtonDefinition = { label: string; action: () => unknown; loading?: boolean; icon?: string };
 
 export interface OSSDialogArgs extends BaseModalArgs {
   title: string;

--- a/addon/components/o-s-s/dialog.ts
+++ b/addon/components/o-s-s/dialog.ts
@@ -3,7 +3,6 @@ import { action } from '@ember/object';
 import { assert } from '@ember/debug';
 
 export type Skin = 'alert' | 'primary' | 'error';
-
 export type ButtonDefinition = { label: string; action: () => unknown; loading?: boolean; icon?: string };
 
 export interface OSSDialogArgs extends BaseModalArgs {

--- a/tests/integration/components/o-s-s/code-block-test.ts
+++ b/tests/integration/components/o-s-s/code-block-test.ts
@@ -5,9 +5,12 @@ import { setupIntl } from 'ember-intl/test-support';
 import { click, findAll, render } from '@ember/test-helpers';
 import sinon from 'sinon';
 
+import { setupToast } from '@upfluence/oss-components/test-support';
+
 module('Integration | Component | o-s-s/code-block', function (hooks) {
   setupRenderingTest(hooks);
   setupIntl(hooks);
+  setupToast(hooks);
 
   hooks.beforeEach(function () {
     this.codeBlock = codeExample;
@@ -48,9 +51,8 @@ module('Integration | Component | o-s-s/code-block', function (hooks) {
   test('if onCopyMessage is set, it shows a toast message when the code is copied', async function (assert) {
     sinon.stub(navigator.clipboard, 'writeText');
     await render(hbs`<OSS::CodeBlock @content={{this.codeBlock}} @copyable={{true}} @onCopyMessage={{'Copied!'}} />`);
-    const stubToast = sinon.stub(this.owner.lookup('service:toast'), 'success');
     await click('.code-block .floating-copy-btn .upf-btn');
-    assert.ok(stubToast.calledOnceWithExactly('Copied!', ''));
+    assert.ok(this.toastSuccessStub.calledOnceWithExactly('Copied!', ''));
     sinon.restore();
   });
 

--- a/tests/integration/components/o-s-s/copy-test.ts
+++ b/tests/integration/components/o-s-s/copy-test.ts
@@ -5,12 +5,13 @@ import { setupIntl } from 'ember-intl/test-support';
 import { render, click } from '@ember/test-helpers';
 import sinon from 'sinon';
 
-import { setupClipboard } from '@upfluence/oss-components/test-support';
+import { setupClipboard, setupToast } from '@upfluence/oss-components/test-support';
 
 module('Integration | Component | o-s-s/copy', function (hooks) {
   setupRenderingTest(hooks);
   setupIntl(hooks);
   setupClipboard(hooks);
+  setupToast(hooks);
 
   test('it renders', async function (assert) {
     await render(hbs`<OSS::Copy />`);
@@ -77,37 +78,35 @@ module('Integration | Component | o-s-s/copy', function (hooks) {
   });
 
   module('when clicking', function (hooks) {
-    hooks.beforeEach(function () {
-      this.toastService = this.owner.lookup('service:toast');
-    });
-
     hooks.afterEach(function () {
       sinon.restore();
     });
 
     test('the info toast is rendered', async function (assert) {
       sinon.stub(navigator.clipboard, 'writeText').resolves();
-      const toastInfoStub = sinon.stub(this.toastService, 'info').resolves();
 
       await render(hbs`<OSS::Copy @value="test" />`);
       await click('.upf-btn--default');
 
-      assert.true(toastInfoStub.calledOnceWithExactly('Successfully copied to your clipboard.', 'Copied to clipboard'));
+      assert.true(
+        this.toastInfoStub.calledOnceWithExactly('Successfully copied to your clipboard.', 'Copied to clipboard')
+      );
     });
 
     test('the error toast is rendered', async function (assert) {
       sinon.stub(navigator.clipboard, 'writeText').rejects();
-      const toastErrorStub = sinon.stub(this.toastService, 'error').resolves();
 
       await render(hbs`<OSS::Copy @value="test" />`);
       await click('.upf-btn--default');
 
-      assert.true(toastErrorStub.calledOnceWithExactly('Failed to copy to your clipboard. Please try again.', 'Error'));
+      assert.true(
+        this.toastErrorStub.calledOnceWithExactly('Failed to copy to your clipboard. Please try again.', 'Error')
+      );
     });
 
     test('the clipboard writeText method is called', async function (assert) {
       const writeTextStub = sinon.stub(navigator.clipboard, 'writeText').resolves();
-      sinon.stub(this.toastService, 'info').resolves();
+      this.toastInfoStub.resolves();
       this.textForCopy = 'test';
 
       await render(hbs`<OSS::Copy @value={{this.textForCopy}} />`);

--- a/tests/integration/components/o-s-s/dialog-test.ts
+++ b/tests/integration/components/o-s-s/dialog-test.ts
@@ -118,12 +118,30 @@ module('Integration | Component | o-s-s/dialog', function (hooks) {
     assert.dom('[data-control-name="dialog-primary-action-button"] .fa-circle-notch').exists();
   });
 
+  test('When the main action button has the icon property provided, the button shows it', async function (assert) {
+    this.mainAction.icon = 'far fa-robot';
+
+    await render(
+      hbs`<OSS::Dialog @title={{this.title}} @mainAction={{this.mainAction}} @secondaryAction={{this.secondaryAction}} />`
+    );
+    assert.dom('[data-control-name="dialog-primary-action-button"] .fa-robot').exists();
+  });
+
   test('The secondary action button label is displayed', async function (assert) {
     await render(
       hbs`<OSS::Dialog @title={{this.title}} @mainAction={{this.mainAction}} @secondaryAction={{this.secondaryAction}} />`
     );
 
     assert.dom('.oss-dialog__footer .upf-btn--default').hasText(this.secondaryAction.label);
+  });
+
+  test('When the secondary action button has the icon property provided, the button shows it', async function (assert) {
+    this.secondaryAction.icon = 'far fa-robot';
+
+    await render(
+      hbs`<OSS::Dialog @title={{this.title}} @mainAction={{this.mainAction}} @secondaryAction={{this.secondaryAction}} />`
+    );
+    assert.dom('[data-control-name="dialog-secondary-action-button"] .fa-robot').exists();
   });
 
   test('When clicking on the main action button, the main action is called', async function (assert) {

--- a/tests/integration/components/o-s-s/upload-area-test.ts
+++ b/tests/integration/components/o-s-s/upload-area-test.ts
@@ -6,6 +6,7 @@ import { setupIntl } from 'ember-intl/test-support';
 import sinon from 'sinon';
 
 import MockUploader from '@upfluence/oss-components/test-support/services/uploader';
+import { setupToast } from '@upfluence/oss-components/test-support';
 
 const file = new File(
   [new Blob(['iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=='])],
@@ -16,6 +17,7 @@ const file = new File(
 module('Integration | Component | o-s-s/upload-area', function (hooks) {
   setupRenderingTest(hooks);
   setupIntl(hooks);
+  setupToast(hooks);
 
   hooks.beforeEach(function () {
     this.owner.register('service:uploader', MockUploader);
@@ -209,8 +211,6 @@ module('Integration | Component | o-s-s/upload-area', function (hooks) {
           { type: 'filetype', value: ['pdf'] }
         ];
 
-        const toastStub = sinon.stub(this.owner.lookup('service:toast'), 'error');
-
         await render(hbs`
           <OSS::UploadArea
             @uploader={{this.mockUploader}} @rules={{this.validationRules}} @size={{this.size}}
@@ -221,14 +221,14 @@ module('Integration | Component | o-s-s/upload-area', function (hooks) {
         });
 
         assert.ok(
-          toastStub.calledWith(
+          this.toastErrorStub.calledWith(
             this.intl.t(`oss-components.upload-area.errors.filetype.description`),
             this.intl.t(`oss-components.upload-area.errors.filetype.title`)
           )
         );
 
         assert.ok(
-          toastStub.calledWith(
+          this.toastErrorStub.calledWith(
             this.intl.t('oss-components.upload-area.errors.filesize.description', { max_filesize: '1B' }),
             this.intl.t('oss-components.upload-area.errors.filesize.title')
           )


### PR DESCRIPTION
### What does this PR do?

- OSS::Dialog: add support for icons on the action buttons
- Add a `setupToast` test util fn for setting up toast stubbing

### What are the observable changes?
<!-- This question could be adequate with multiple use cases, for example: -->

<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->

### Good PR checklist
- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [x] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled
