### PR TITLE
Fix deprecation: Get rid of hash helper usage

### DIFF
--- a/tests/dummy/app/controllers/input.ts
+++ b/tests/dummy/app/controllers/input.ts
@@ -25,6 +25,10 @@ export default class Input extends Controller {
   @tracked currencyValue: number = 42.13;
   @tracked currencyOnly: string = '';
 
+  @tracked successFeedbackMessage: Object = { type: 'success', value: 'This is a success message !' };
+  @tracked warningFeedbackMessage: Object = { type: 'warning', value: 'This is a warning message !' };
+  @tracked errorFeedbackMessage: Object = { type: 'error', value: 'This is a error message !' };
+
   countries: CountryData[] = countries;
   allowedCurrencies: { code: string; symbol: string }[] = [
     { code: 'USD', symbol: '$' },

--- a/tests/dummy/app/controllers/overlay.ts
+++ b/tests/dummy/app/controllers/overlay.ts
@@ -11,6 +11,9 @@ export default class Overlay extends Controller {
   @tracked showSplitModal: boolean = false;
   @tracked showSidePanel: boolean = false;
 
+  @tracked overlayMainAction: Object = { action: this.onDialogMainAction, label: 'Discard changes' };
+  @tracked overlaySecondaryAction: Object = { action: this.onDialogSecondaryAction, label: 'Keep editing' };
+
   get translatedHTMLTitle(): SafeString {
     return htmlSafe('This title can take a <em>string</em> or a <em>safeString</em>');
   }

--- a/tests/dummy/app/controllers/visual.ts
+++ b/tests/dummy/app/controllers/visual.ts
@@ -81,6 +81,9 @@ export default class Visual extends Controller {
     }
   ];
 
+  @tracked countdownAction: { callback: Function } = { callback: this.countDownAction };
+  @tracked sliderInputOptions: { min: number; max: number } = { min: 0, max: 200 };
+
   @action
   redirectTo(route: string): void {
     console.log('Redirect to', route);

--- a/tests/dummy/app/templates/input.hbs
+++ b/tests/dummy/app/templates/input.hbs
@@ -65,8 +65,14 @@
       Infinite select
     </div>
     <div class="fx-row fx-gap-px-24 fx-xalign-start">
-        <OSS::InfiniteSelect
-        @items={{this.items}} @searchEnabled={{true}} @onSearch={{this.onInfiniteSelectSearch}} @searchPlaceholder="Enter a keyword" @onSelect={{this.onInfiniteSelectChange}}  style="position: relative; margin: 0"/>
+      <OSS::InfiniteSelect
+        @items={{this.items}}
+        @searchEnabled={{true}}
+        @onSearch={{this.onInfiniteSelectSearch}}
+        @searchPlaceholder="Enter a keyword"
+        @onSelect={{this.onInfiniteSelectChange}}
+        style="position: relative; margin: 0"
+      />
     </div>
   </div>
 
@@ -170,17 +176,17 @@
         <OSS::InputContainer
           @placeholder="Success !"
           @value={{this.shopUrl}}
-          @feedbackMessage={{hash type="success" value="This is a success message !"}}
+          @feedbackMessage={{this.successFeedbackMessage}}
         />
         <OSS::InputContainer
           @placeholder="Warning !"
           @value={{this.shopUrl}}
-          @feedbackMessage={{hash type="warning" value="This is an warning message !"}}
+          @feedbackMessage={{this.warningFeedbackMessage}}
         />
         <OSS::InputContainer
           @placeholder="Error !"
           @value={{this.shopUrl}}
-          @feedbackMessage={{hash type="error" value="This is also an error message !"}}
+          @feedbackMessage={{this.errorFeedbackMessage}}
         />
       </div>
     </div>

--- a/tests/dummy/app/templates/overlay.hbs
+++ b/tests/dummy/app/templates/overlay.hbs
@@ -16,8 +16,8 @@
       {{#if this.showDialog}}
         <OSS::Dialog
           @title={{this.translatedHTMLTitle}}
-          @mainAction={{hash action=this.onDialogMainAction label="Discard changes"}}
-          @secondaryAction={{hash action=this.onDialogSecondaryAction label="Keep editing"}}
+          @mainAction={{this.overlayMainAction}}
+          @secondaryAction={{this.overlaySecondaryAction}}
           @icon="fa-circle-info"
           @skin="error"
         />

--- a/tests/dummy/app/templates/visual.hbs
+++ b/tests/dummy/app/templates/visual.hbs
@@ -78,7 +78,7 @@
           @label="Count down"
           @icon="far fa-hourglass"
           @size="md"
-          @countDown={{hash callback=this.countDownAction}}
+          @countDown={{this.countdownAction}}
         />
       </div>
     </div>
@@ -546,7 +546,7 @@
       <div class="fx-row fx-gap-px-10">
         <OSS::Slider
           @value={{this.sliderValue3}}
-          @inputOptions={{hash min=0 max=999}}
+          @inputOptions={{this.sliderInputOptions}}
           @min={{0}}
           @max={{200}}
           @step={{10}}

--- a/tests/integration/components/o-s-s/button-test.ts
+++ b/tests/integration/components/o-s-s/button-test.ts
@@ -142,8 +142,9 @@ module('Integration | Component | o-s-s/button', function (hooks) {
     });
 
     test('when loading and the showLabel loading option is truthy, the label is displayed', async function (assert) {
+      this.loadingOptions = { showLabel: true };
       await render(
-        hbs`<OSS::Button @size="sm" @loading={{true}} @label="Test" @loadingOptions={{hash showLabel=true}} />`
+        hbs`<OSS::Button @size="sm" @loading={{true}} @label="Test" @loadingOptions={{this.loadingOptions}} />`
       );
       assert.dom('.upf-btn i.fas').exists();
       assert.dom('.upf-btn i.fas').hasClass('fa-circle-notch');
@@ -176,7 +177,8 @@ module('Integration | Component | o-s-s/button', function (hooks) {
 
     test('when clicking, it trigger the countdown', async function (assert) {
       this.callback = () => {};
-      await render(hbs`<OSS::Button @label="Test" @countDown={{hash callback=this.callback}} />`);
+      this.countDown = { callback: this.callback };
+      await render(hbs`<OSS::Button @label="Test" @countDown={{this.countDown}} />`);
       await click('.upf-btn--default');
 
       assert.dom('.upf-btn--default').hasText(this.intlService.t('oss-components.button.cancel_message', { time: 5 }));
@@ -184,7 +186,9 @@ module('Integration | Component | o-s-s/button', function (hooks) {
 
     test('when clicking, it executes callback at the end of the countdown', async function (assert) {
       this.callback = sinon.stub().callsFake(() => {});
-      await render(hbs`<OSS::Button @label="Test" @countDown={{hash callback=this.callback time=50 step=10}} />`);
+      this.countDown = { callback: this.callback, time: 50, step: 10 };
+
+      await render(hbs`<OSS::Button @label="Test" @countDown={{this.countDown}} />`);
       await click('.upf-btn--default');
 
       await waitUntil(
@@ -199,7 +203,8 @@ module('Integration | Component | o-s-s/button', function (hooks) {
 
     test('when clicking again, it cancels the countdown', async function (assert) {
       this.callback = () => {};
-      await render(hbs`<OSS::Button @label="Test" @countDown={{hash callback=this.callback}} />`);
+      this.countDown = { callback: this.callback };
+      await render(hbs`<OSS::Button @label="Test" @countDown={{this.countDown}} />`);
       await click('.upf-btn--default');
       await click('.upf-btn--default');
 
@@ -227,7 +232,9 @@ module('Integration | Component | o-s-s/button', function (hooks) {
         );
       });
 
-      await render(hbs`<OSS::Button @label="Test" @countDown={{hash time=1000}} />`);
+      this.countDown = { time: 1000 };
+
+      await render(hbs`<OSS::Button @label="Test" @countDown={{this.countDown}} />`);
     });
   });
 });

--- a/tests/integration/components/o-s-s/input-container-test.js
+++ b/tests/integration/components/o-s-s/input-container-test.js
@@ -81,35 +81,31 @@ module('Integration | Component | o-s-s/input-container', function (hooks) {
 
   module('feedback messages', () => {
     test('Passing success as @feedbackMessage.type displays the success message and sets the border to green', async function (assert) {
-      await render(
-        hbs`<OSS::InputContainer @feedbackMessage={{hash type="success" value="This is a success message"}} />`
-      );
+      this.feedbackMessage = { type: 'success', value: 'This is a success message' };
+      await render(hbs`<OSS::InputContainer @feedbackMessage={{this.feedbackMessage}} />`);
       assert.dom('.oss-input-container').hasClass('oss-input-container--success');
       assert.dom('i.far').hasClass('fa-check-circle');
       assert.dom('.font-color-success-500').hasText('This is a success message');
     });
 
     test('Passing warning as @feedbackMessage.type displays the warning message and sets the border to yellow', async function (assert) {
-      await render(
-        hbs`<OSS::InputContainer @feedbackMessage={{hash type="warning" value="This is a warning message"}} />`
-      );
+      this.feedbackMessage = { type: 'warning', value: 'This is a warning message' };
+      await render(hbs`<OSS::InputContainer @feedbackMessage={{this.feedbackMessage}} />`);
       assert.dom('.oss-input-container').hasClass('oss-input-container--warning');
       assert.dom('i.far').hasClass('fa-exclamation-circle');
       assert.dom('.font-color-warning-500').hasText('This is a warning message');
     });
 
     test('Passing error as @feedbackMessage.type displays the error message and sets the border to red', async function (assert) {
-      await render(
-        hbs`<OSS::InputContainer @feedbackMessage={{hash type="error" value="This is an error message"}} />`
-      );
+      this.feedbackMessage = { type: 'error', value: 'This is an error message' };
+      await render(hbs`<OSS::InputContainer @feedbackMessage={{this.feedbackMessage}} />`);
       assert.dom('.oss-input-container').hasClass('oss-input-container--error');
       assert.dom('.font-color-error-500').hasText('This is an error message');
     });
 
     test("Passing an invalid feedbackMessage type doesn't display any message", async function (assert) {
-      await render(
-        hbs`<OSS::InputContainer @feedbackMessage={{hash type="invalid" value="This is an invalid message"}} />`
-      );
+      this.feedbackMessage = { type: 'invalid', value: 'This is an invalid message' };
+      await render(hbs`<OSS::InputContainer @feedbackMessage={{this.feedbackMessage}} />`);
       assert.dom('.upf-input').exists();
       assert.dom('.font-color-success-500').doesNotExist();
       assert.dom('.font-color-warning-500').doesNotExist();

--- a/tests/integration/components/o-s-s/link-test.ts
+++ b/tests/integration/components/o-s-s/link-test.ts
@@ -30,10 +30,10 @@ module('Integration | Component | o-s-s/link', function (hooks) {
 
   test('it opens link with href and target', async function (assert: Assert) {
     let windowOpenStub = sinon.stub(window, 'open');
-
+    this.link = { href: 'https://www.google.fr', target: '_blank' };
     await render(hbs`
       <OSS::Link @icon="fab fa-facebook" @label="Facebook"
-                 @link={{hash href="https://www.google.fr" target="_blank"}} />
+                 @link={{this.link}} />
     `);
 
     await click('.upf-link');

--- a/tests/integration/components/o-s-s/modal-test.js
+++ b/tests/integration/components/o-s-s/modal-test.js
@@ -25,8 +25,9 @@ module('Integration | Component | o-s-s/modal', function (hooks) {
   module('available options', function () {
     module('centered', function () {
       test('it should set the centered class on the modal dialog', async function (assert) {
+        this.modalOptions = { centered: true };
         await render(hbs`
-          <OSS::Modal @title="Test Modal" @options={{hash centered=true}}>
+          <OSS::Modal @title="Test Modal" @options={{this.modalOptions}}>
             <div class="modal-body">
               Foo
             </div>
@@ -43,8 +44,9 @@ module('Integration | Component | o-s-s/modal', function (hooks) {
 
     module('additional classes on the modal-dialog', function () {
       test('it should add the passed class on the modal dialog', async function (assert) {
+        this.modalOptions = { modalClass: 'foobar' };
         await render(hbs`
-          <OSS::Modal @title="Test Modal" @options={{hash modalClass="foobar"}}>
+          <OSS::Modal @title="Test Modal" @options={{this.modalOptions}}>
             <div class="modal-body">
               Foo
             </div>
@@ -61,8 +63,9 @@ module('Integration | Component | o-s-s/modal', function (hooks) {
 
     module('borderless header', function () {
       test('it should add the good class on the modal dialog', async function (assert) {
+        this.modalOptions = { borderlessHeader: true };
         await render(hbs`
-          <OSS::Modal @title="Test Modal" @options={{hash borderlessHeader=true}}>
+          <OSS::Modal @title="Test Modal" @options={{this.modalOptions}}>
             <div class="modal-body">
               Foo
             </div>
@@ -79,8 +82,9 @@ module('Integration | Component | o-s-s/modal', function (hooks) {
 
     module('no header', function () {
       test('no header container is present', async function (assert) {
+        this.modalOptions = { header: false };
         await render(hbs`
-          <OSS::Modal @options={{hash header=false}}>
+          <OSS::Modal @options={{this.modalOptions}}>
             <div class="modal-body">
               Foo
             </div>

--- a/tests/integration/components/o-s-s/slider-test.ts
+++ b/tests/integration/components/o-s-s/slider-test.ts
@@ -54,7 +54,7 @@ module('Integration | Component | o-s-s/slider', function (hooks) {
       );
       const element = this.element.querySelector('.oss-slider__range');
       assert.dom(element).exists();
-      assert.strictEqual(element.style.getPropertyValue('--range-percentage'), '10%');
+      assert.strictEqual(element.style.getPropertyValue('--range-percentage').trim(), '10%');
     });
 
     module('with @step', () => {
@@ -65,7 +65,7 @@ module('Integration | Component | o-s-s/slider', function (hooks) {
         );
         const element = this.element.querySelector('.oss-slider__range');
         assert.dom(element).exists();
-        assert.strictEqual(element.style.getPropertyValue('--range-percentage'), '10%');
+        assert.strictEqual(element.style.getPropertyValue('--range-percentage').trim(), '10%');
       });
 
       test('it renders it properly with the value rounded up', async function (assert) {
@@ -75,7 +75,7 @@ module('Integration | Component | o-s-s/slider', function (hooks) {
         );
         const element = this.element.querySelector('.oss-slider__range');
         assert.dom(element).exists();
-        assert.strictEqual(element.style.getPropertyValue('--range-percentage'), '20%');
+        assert.strictEqual(element.style.getPropertyValue('--range-percentage').trim(), '20%');
       });
     });
   });
@@ -167,7 +167,7 @@ module('Integration | Component | o-s-s/slider', function (hooks) {
       assert.dom('.oss-slider__number-input').exists().hasText('');
       const element = this.element.querySelector('.oss-slider__range');
       assert.dom(element).exists();
-      assert.strictEqual(element.style.getPropertyValue('--range-percentage'), '0%');
+      assert.strictEqual(element.style.getPropertyValue('--range-percentage').trim(), '0%');
     });
 
     test('it does not render the number input when @displayInputValue is falsy', async function (assert) {
@@ -212,7 +212,7 @@ module('Integration | Component | o-s-s/slider', function (hooks) {
 
       assert.equal(this.min, this.value);
       const element = this.element.querySelector('.oss-slider__range');
-      assert.strictEqual(element.style.getPropertyValue('--range-percentage'), '0%');
+      assert.strictEqual(element.style.getPropertyValue('--range-percentage').trim(), '0%');
     });
 
     test('it renders the slider with a maximum value when @min is provided', async function (assert) {
@@ -223,7 +223,7 @@ module('Integration | Component | o-s-s/slider', function (hooks) {
 
       await fillIn('.oss-slider__number-input input', '1000');
       const element = this.element.querySelector('.oss-slider__range');
-      assert.strictEqual(element.style.getPropertyValue('--range-percentage'), '100%');
+      assert.strictEqual(element.style.getPropertyValue('--range-percentage').trim(), '100%');
     });
   });
 });


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the context of this pull request and its purpose. -->

Related to: #[VEL-4505](https://linear.app/upfluence/issue/VEL-4505/httpsdeprecationsemberjscomv3xtoc-setting-on-hash)

### What are the observable changes?
<!-- This question could be adequate with multiple use cases, for example: -->

<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->

### Good PR checklist
- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled
