### PR TITLE
Added fix to avoid showing style on focus when hover behavior is…

### DIFF
--- a/addon/components/o-s-s/infinite-select.hbs
+++ b/addon/components/o-s-s/infinite-select.hbs
@@ -35,8 +35,19 @@
       {{#if (and @loading (not @loadingMore))}}
         <OSS::Skeleton @width="100%" @height="18" @multiple={{5}} @direction="col" />
       {{else}}
-        {{#each this.items as |item|}}
-          <li class="upf-infinite-select__item" role="button" {{on "click" (fn this.didSelectItem item)}} tabindex="0">
+        {{#each this.items as |item index|}}
+          <li
+            class="upf-infinite-select__item
+              {{if
+                (and (eq index this._focusElement) this.focusStylesDisabled)
+                ' upf-infinite-select__item--disabled-focus'
+              }}"
+            role="button"
+            {{on "mouseenter" (fn this.handleItemHover index)}}
+            {{on "mouseleave" this.clearHoverState}}
+            {{on "click" (fn this.didSelectItem item)}}
+            tabindex="0"
+          >
             {{#if (has-block "option")}}
               {{yield item to="option"}}
             {{else}}

--- a/addon/components/o-s-s/infinite-select.ts
+++ b/addon/components/o-s-s/infinite-select.ts
@@ -150,7 +150,7 @@ export default class OSSInfiniteSelect extends Component<InfiniteSelectArgs> {
   }
 
   @action
-  handleItemHover(index: number) {
+  handleItemHover(index: number): void {
     this._focusElementAt(index);
     this._focusElement = index;
     console.log(this._focusElement, index);

--- a/addon/components/o-s-s/infinite-select.ts
+++ b/addon/components/o-s-s/infinite-select.ts
@@ -110,12 +110,15 @@ export default class OSSInfiniteSelect extends Component<InfiniteSelectArgs> {
 
   @action
   handleKeyEventInput(e: KeyboardEvent): void {
-    if (this.focusStylesDisabled === true) {
+    if (!this.searchEnabled && this.enableKeyboard) {
+      if (this.focusStylesDisabled === true) {
+        this.focusStylesDisabled = false;
+        return;
+      }
+
       this.focusStylesDisabled = false;
-      return;
     }
 
-    this.focusStylesDisabled = false;
     const actionsForKeys: Record<string, (self: any, e: KeyboardEvent) => void> = {
       ArrowDown: this.focusFirstItem,
       Enter: this.focusFirstItem,
@@ -129,7 +132,10 @@ export default class OSSInfiniteSelect extends Component<InfiniteSelectArgs> {
 
   @action
   handleKeyEvent(e: KeyboardEvent): void {
-    this.focusStylesDisabled = false;
+    if (!this.searchEnabled && this.enableKeyboard) {
+      this.focusStylesDisabled = false;
+    }
+
     const actionsForKeys: Record<string, (self: any, e: KeyboardEvent) => void> = {
       ArrowDown: this.handleArrowDown,
       ArrowUp: this.handleArrowUp,
@@ -146,6 +152,8 @@ export default class OSSInfiniteSelect extends Component<InfiniteSelectArgs> {
   @action
   handleItemHover(index: number) {
     this._focusElementAt(index);
+    this._focusElement = index;
+    console.log(this._focusElement, index);
     this.focusStylesDisabled = this._focusElement === index ? false : true;
   }
 

--- a/addon/components/o-s-s/infinite-select.ts
+++ b/addon/components/o-s-s/infinite-select.ts
@@ -31,6 +31,7 @@ const DEFAULT_ITEM_LABEL = 'name';
 export default class OSSInfiniteSelect extends Component<InfiniteSelectArgs> {
   @tracked _searchKeyword: string = '';
   @tracked _focusElement: number = 0;
+  @tracked focusStylesDisabled: boolean = true;
 
   @tracked elementId: string = guidFor(this);
 
@@ -109,6 +110,12 @@ export default class OSSInfiniteSelect extends Component<InfiniteSelectArgs> {
 
   @action
   handleKeyEventInput(e: KeyboardEvent): void {
+    if (this.focusStylesDisabled === true) {
+      this.focusStylesDisabled = false;
+      return;
+    }
+
+    this.focusStylesDisabled = false;
     const actionsForKeys: Record<string, (self: any, e: KeyboardEvent) => void> = {
       ArrowDown: this.focusFirstItem,
       Enter: this.focusFirstItem,
@@ -122,6 +129,7 @@ export default class OSSInfiniteSelect extends Component<InfiniteSelectArgs> {
 
   @action
   handleKeyEvent(e: KeyboardEvent): void {
+    this.focusStylesDisabled = false;
     const actionsForKeys: Record<string, (self: any, e: KeyboardEvent) => void> = {
       ArrowDown: this.handleArrowDown,
       ArrowUp: this.handleArrowUp,
@@ -133,6 +141,17 @@ export default class OSSInfiniteSelect extends Component<InfiniteSelectArgs> {
     if (this.enableKeyboard) {
       actionsForKeys[e.key]?.(this, e);
     }
+  }
+
+  @action
+  handleItemHover(index: number) {
+    this._focusElementAt(index);
+    this.focusStylesDisabled = this._focusElement === index ? false : true;
+  }
+
+  @action
+  clearHoverState(): void {
+    this.focusStylesDisabled = false;
   }
 
   private _focusElementAt(index: number): void {

--- a/addon/components/o-s-s/infinite-select.ts
+++ b/addon/components/o-s-s/infinite-select.ts
@@ -153,7 +153,6 @@ export default class OSSInfiniteSelect extends Component<InfiniteSelectArgs> {
   handleItemHover(index: number): void {
     this._focusElementAt(index);
     this._focusElement = index;
-    console.log(this._focusElement, index);
     this.focusStylesDisabled = this._focusElement === index ? false : true;
   }
 

--- a/app/styles/base/_infinite-select.less
+++ b/app/styles/base/_infinite-select.less
@@ -43,12 +43,8 @@
 }
 
 .upf-infinite-select__item--disabled-focus {
-  &:hover {
-    background-color: var(--color-gray-100);
-  }
-
   &:focus {
     outline: none;
-    background-color: white;
+    background-color: var(--color-white);
   }
 }

--- a/app/styles/base/_infinite-select.less
+++ b/app/styles/base/_infinite-select.less
@@ -41,3 +41,14 @@
     outline: none;
   }
 }
+
+.upf-infinite-select__item--disabled-focus {
+  &:hover {
+    background-color: var(--color-gray-100);
+  }
+
+  &:focus {
+    outline: none;
+    background-color: white;
+  }
+}

--- a/app/styles/molecules/select.less
+++ b/app/styles/molecules/select.less
@@ -85,10 +85,6 @@
     .item-wrapper {
       padding: var(--spacing-px-6) var(--spacing-px-6);
       border-radius: var(--border-radius-sm);
-
-      &.selected {
-        background-color: var(--color-gray-100);
-      }
     }
   }
 }


### PR DESCRIPTION
Description: 


https://www.loom.com/share/2b8370d959224143b6cb4c0b6c7c9439?sid=beefde54-cce9-47ab-9f99-127d0b81a0a9

Currently, when opening the infinite-select, the first element is focused and keeps its focus even when hovering over an element, making it where 3 elements can have a background grey at the same time.

Now, on opening the select, the first element is no longer focused. Selected item no longer has a grey background either.

When we hover, background styles from hover take over the keyboard navigation styles.

When we navigate with the keyboard, keyboard background styles take over the hover background styles.

### What does this PR do?
<!-- A brief description of the context of this pull request and its purpose. -->

Related to: #<!-- enter issue number here -->

### What are the observable changes?
<!-- This question could be adequate with multiple use cases, for example: -->

<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->

### Good PR checklist
- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [ ] Properly labeled
