### PR TITLE
Updated: OSS::PhoneNumber input with new error management parameters

### DIFF
--- a/addon/components/o-s-s/attribute/phone-number.stories.js
+++ b/addon/components/o-s-s/attribute/phone-number.stories.js
@@ -25,6 +25,27 @@ export default {
         defaultValue: { summary: 'undefined' }
       },
       control: { type: 'text' }
+    },
+    errorMessage: {
+      description: 'An error message that will be displayed below the input-group.',
+      table: {
+        type: {
+          summary: 'string'
+        },
+        defaultValue: { summary: 'undefined' }
+      },
+      control: { type: 'text' }
+    },
+    hasError: {
+      description:
+        'Allows setting the error style on the input without showing an error message. Useful for form validation.',
+      table: {
+        type: {
+          summary: 'boolean'
+        },
+        defaultValue: { summary: 'undefined' }
+      },
+      control: { type: 'boolean' }
     }
   },
   parameters: {
@@ -40,13 +61,16 @@ export default {
 const defaultArgs = {
   countryCode: 'FR',
   prefix: '+33',
-  number: '6 12 34 56 78'
+  number: '612345678',
+  hasError: false,
+  errorMessage: ''
 };
 
 const Template = (args) => ({
   template: hbs`
     <div style="padding: 12px; background: white">
-      <OSS::Attribute::PhoneNumber @countryCode={{this.countryCode}} @prefix={{this.prefix}} @number={{this.number}} />
+      <OSS::Attribute::PhoneNumber @countryCode={{this.countryCode}} @prefix={{this.prefix}} @number={{this.number}}
+                                   @hasError={{this.hasError}} @errorMessage={{this.errorMessage}} />
     </div>
   `,
   context: args

--- a/addon/components/o-s-s/phone-number-input.hbs
+++ b/addon/components/o-s-s/phone-number-input.hbs
@@ -1,28 +1,42 @@
 <div class="phone-number-container fx-1" ...attributes>
-  <div class="phone-number-input {{if this.countrySelectorShown 'phone-number-input--active'}} fx-row fx-1 fx-xalign-center">
+  <div class="phone-number-input fx-row fx-1 fx-xalign-center {{this.interactiveClasses}}">
     <div class="country-selector fx-row" role="button" {{on "click" this.toggleCountrySelector}}>
       <div class="fflag fflag-{{this.selectedCountry.id}} ff-sm ff-round"></div>
       <OSS::Icon @icon="fa-chevron-{{if this.countrySelectorShown 'up' 'down'}}" />
     </div>
     <div class="fx-1 fx-row upf-input" {{on "click" this.focusInput}}>
       <span class="fx-row fx-xalign-center phone-prefix">{{@prefix}}</span>
-      <Input class="fx-1" type="tel" @value={{@number}} placeholder={{this.placeholder}}
-             {{on "keydown" this.onlyNumeric}} {{on "blur" this.onlyNumeric}} {{did-insert this.registerInputElement}} />
+      <Input
+        @value={{@number}}
+        class="fx-1"
+        type="tel"
+        name="telephone"
+        placeholder={{this.placeholder}}
+        {{on "keydown" this.onlyNumeric}}
+        {{on "blur" this.onlyNumeric}}
+        {{did-insert this.registerInputElement}}
+      />
     </div>
-
   </div>
 
   {{#if this.invalidInputError}}
     <div class="font-color-error-500 margin-top-px-6">
       {{this.invalidInputError}}
     </div>
+  {{else if @errorMessage}}
+    <div class="font-color-error-500 margin-top-px-6">
+      {{@errorMessage}}
+    </div>
   {{/if}}
 
   {{#if this.countrySelectorShown}}
-    <OSS::InfiniteSelect @items={{this.filteredCountries}} @onSearch={{this.onSearch}}
-                         @onSelect={{this.onSelect}}
-                         @searchPlaceholder="Search"
-                         {{on-click-outside this.hideCountrySelector}}>
+    <OSS::InfiniteSelect
+      @items={{this.filteredCountries}}
+      @onSearch={{this.onSearch}}
+      @onSelect={{this.onSelect}}
+      @searchPlaceholder="Search"
+      {{on-click-outside this.hideCountrySelector}}
+    >
       <:option as |country|>
         <div class="fx-row fx-xalign-center {{if (eq this.selectedCountry country) 'row-selected'}}">
           <div class="fflag fflag-{{country.id}} ff-sm ff-rounded"></div>

--- a/addon/components/o-s-s/phone-number-input.ts
+++ b/addon/components/o-s-s/phone-number-input.ts
@@ -1,6 +1,7 @@
 import { assert } from '@ember/debug';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
+import { isBlank } from '@ember/utils';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { countries, type CountryData } from '@upfluence/oss-components/utils/country-codes';
@@ -10,6 +11,8 @@ interface OSSPhoneNumberInputArgs {
   prefix: string;
   number: string;
   placeholder?: string;
+  errorMessage?: string;
+  hasError?: boolean;
   onChange(prefix: string, number: string): void;
   validates?(isPassing: boolean): void;
 }
@@ -43,27 +46,23 @@ export default class OSSPhoneNumberInput extends Component<OSSPhoneNumberInputAr
     );
 
     this.selectedCountry = this._countries[0]!;
-    this._loadExistingNumber();
+    this.loadExistingNumber();
   }
 
-  private _loadExistingNumber(): void {
-    if (this.args.prefix) {
-      const purePrefix = this.args.prefix.replace(/\D/g, '');
-      this.selectedCountry =
-        this._countries.find((country: CountryData) => country.countryCallingCodes[0] === purePrefix) ||
-        this._countries[0]!;
-    }
+  get displayErrorBorder(): boolean {
+    return this.args.hasError || !isBlank(this.args.errorMessage);
   }
 
-  private validateInput(): void {
-    this.invalidInputError = '';
+  get interactiveClasses(): string {
+    let classArray: string[] = [];
 
-    if (this.args.number.startsWith('+')) {
-      this.invalidInputError = this.intl.t('oss-components.phone-input.invalid_input');
-      this.args.validates?.(false);
-    } else {
-      this.args.validates?.(true);
+    if (this.countrySelectorShown) {
+      classArray.push('phone-number-input--active');
     }
+    if (this.displayErrorBorder) {
+      classArray.push('phone-number-input--error');
+    }
+    return classArray.join(' ');
   }
 
   @action
@@ -120,5 +119,25 @@ export default class OSSPhoneNumberInput extends Component<OSSPhoneNumberInputAr
   @action
   registerInputElement(el: HTMLElement): void {
     this.inputElement = el;
+  }
+
+  private validateInput(): void {
+    this.invalidInputError = '';
+
+    if (this.args.number.startsWith('+')) {
+      this.invalidInputError = this.intl.t('oss-components.phone-input.invalid_input');
+      this.args.validates?.(false);
+    } else {
+      this.args.validates?.(true);
+    }
+  }
+
+  private loadExistingNumber(): void {
+    if (this.args.prefix) {
+      const purePrefix = this.args.prefix.replace(/\D/g, '');
+      this.selectedCountry =
+        this._countries.find((country: CountryData) => country.countryCallingCodes[0] === purePrefix) ||
+        this._countries[0]!;
+    }
   }
 }

--- a/app/styles/phone-number-input.less
+++ b/app/styles/phone-number-input.less
@@ -24,7 +24,7 @@
 
     height: 36px;
 
-    & > div {
+    &>div {
       height: 100%;
     }
 
@@ -75,6 +75,10 @@
 
     &:hover {
       .input-state-hover;
+    }
+
+    &--error {
+      border-color: var(--color-error-500);
     }
 
     &:active,

--- a/tests/dummy/app/templates/input.hbs
+++ b/tests/dummy/app/templates/input.hbs
@@ -65,8 +65,14 @@
       Infinite select
     </div>
     <div class="fx-row fx-gap-px-24 fx-xalign-start">
-        <OSS::InfiniteSelect
-        @items={{this.items}} @searchEnabled={{true}} @onSearch={{this.onInfiniteSelectSearch}} @searchPlaceholder="Enter a keyword" @onSelect={{this.onInfiniteSelectChange}}  style="position: relative; margin: 0"/>
+      <OSS::InfiniteSelect
+        @items={{this.items}}
+        @searchEnabled={{true}}
+        @onSearch={{this.onInfiniteSelectSearch}}
+        @searchPlaceholder="Enter a keyword"
+        @onSelect={{this.onInfiniteSelectChange}}
+        style="position: relative; margin: 0"
+      />
     </div>
   </div>
 
@@ -339,6 +345,23 @@
         @prefix={{this.phonePrefix}}
         @number={{this.phoneNumber}}
         @onChange={{this.onPhoneNumberChange}}
+      />
+    </div>
+    <div class="fx-row fx-gap-px-24 fx-xalign-start">
+      <OSS::PhoneNumberInput
+        @prefix={{this.phonePrefix}}
+        @number={{this.phoneNumber}}
+        @onChange={{this.onPhoneNumberChange}}
+        @errorMessage="This is an error message"
+      />
+    </div>
+    <div class="fx-row fx-gap-px-24 fx-xalign-start">
+      <OSS::PhoneNumberInput
+        @prefix={{this.phonePrefix}}
+        @number={{this.phoneNumber}}
+        @onChange={{this.onPhoneNumberChange}}
+        @errorMessage=""
+        @hasError={{true}}
       />
     </div>
   </div>

--- a/tests/integration/components/o-s-s/phone-number-input-test.ts
+++ b/tests/integration/components/o-s-s/phone-number-input-test.ts
@@ -11,22 +11,23 @@ import settled from '@ember/test-helpers/settled';
 module('Integration | Component | o-s-s/phone-number', function (hooks) {
   setupRenderingTest(hooks);
 
+  hooks.beforeEach(function () {
+    this.onChange = sinon.stub();
+  });
+
   test('it renders', async function (assert) {
-    this.onChange = () => {};
     await render(hbs`<OSS::PhoneNumberInput @prefix="" @number="" @onChange={{this.onChange}} />`);
 
     assert.dom('.phone-number-container').exists();
   });
 
   test('The passed @number parameter is properly displayed in the input', async function (assert) {
-    this.onChange = () => {};
     await render(hbs`<OSS::PhoneNumberInput @prefix="" @number="12341234" @onChange={{this.onChange}} />`);
 
     assert.dom('input').hasValue('12341234');
   });
 
   test('It properly loads the correct country when the @prefix parameter is defined', async function (assert) {
-    this.onChange = () => {};
     await render(hbs`<OSS::PhoneNumberInput @prefix="+33" @number="" @onChange={{this.onChange}} />`);
 
     assert.dom('.country-selector .fflag.fflag-FR').exists();
@@ -34,7 +35,6 @@ module('Integration | Component | o-s-s/phone-number', function (hooks) {
 
   module('Country selector', () => {
     test('Clicking on the Flag button opens the country selector', async function (assert) {
-      this.onChange = () => {};
       await render(hbs`<OSS::PhoneNumberInput @prefix="" @number="" @onChange={{this.onChange}} />`);
 
       await click('.country-selector');
@@ -42,7 +42,6 @@ module('Integration | Component | o-s-s/phone-number', function (hooks) {
     });
 
     test('Selecting a new country in the Country selector triggers the onChange method', async function (assert) {
-      this.onChange = sinon.spy();
       await render(hbs`<OSS::PhoneNumberInput @prefix="" @number="" @onChange={{this.onChange}} />`);
 
       await click('.country-selector');
@@ -52,7 +51,6 @@ module('Integration | Component | o-s-s/phone-number', function (hooks) {
     });
 
     test('Typing in the search input filters the results', async function (assert) {
-      this.onChange = sinon.spy();
       await render(hbs`<OSS::PhoneNumberInput @prefix="" @number="" @onChange={{this.onChange}} />`);
 
       await click('.country-selector');
@@ -64,7 +62,6 @@ module('Integration | Component | o-s-s/phone-number', function (hooks) {
     });
 
     test('Searching by Country Code Prefix works', async function (assert) {
-      this.onChange = sinon.spy();
       await render(hbs`<OSS::PhoneNumberInput @prefix="" @number="" @onChange={{this.onChange}} />`);
 
       await click('.country-selector');
@@ -76,10 +73,12 @@ module('Integration | Component | o-s-s/phone-number', function (hooks) {
     });
   });
 
-  module('Phone Number Input', () => {
+  module('Phone Number Input', (hooks) => {
+    hooks.beforeEach(function () {
+      this.onValidation = sinon.stub();
+    });
+
     test('Typing numbers in the Phone input triggers the onChange method', async function (assert) {
-      this.onChange = sinon.spy();
-      this.onValidation = sinon.spy();
       await render(
         hbs`<OSS::PhoneNumberInput @prefix="" @number="" @onChange={{this.onChange}} @validates={{this.onValidation}} />`
       );
@@ -90,8 +89,6 @@ module('Integration | Component | o-s-s/phone-number', function (hooks) {
     });
 
     test('Typing non-numeric characters does not apply changes', async function (assert) {
-      this.onChange = sinon.spy();
-      this.onValidation = sinon.spy();
       await render(
         hbs`<OSS::PhoneNumberInput @prefix="" @number="" @onChange={{this.onChange}} @validates={{this.onValidation}} />`
       );
@@ -107,12 +104,6 @@ module('Integration | Component | o-s-s/phone-number', function (hooks) {
       this.prefix = '+1';
       this.number = '';
 
-      this.onChange = (prefix: string, number: number) => {
-        this.set('prefix', prefix);
-        this.set('number', number);
-      };
-      this.onValidation = sinon.spy();
-
       await render(
         hbs`<OSS::PhoneNumberInput @prefix={{this.prefix}} @number={{this.number}} @onChange={{this.onChange}} @validates={{this.onValidation}} />`
       );
@@ -121,6 +112,38 @@ module('Integration | Component | o-s-s/phone-number', function (hooks) {
 
       assert.ok(this.onValidation.calledWithExactly(false));
       assert.dom('.font-color-error-500').exists();
+    });
+  });
+
+  module('@hasError parameter', () => {
+    test('A red border is displayed if the parameter is true', async function (assert) {
+      await render(hbs`<OSS::PhoneNumberInput @prefix="" @number="" @hasError={{true}}
+                                              @onChange={{this.onChange}} />`);
+      assert.dom('.phone-number-input').hasClass('phone-number-input--error');
+    });
+
+    test('No border is displayed if the parameter is not passed', async function (assert) {
+      await render(hbs`<OSS::PhoneNumberInput @prefix="" @number="" @onChange={{this.onChange}} />`);
+      assert.dom('.phone-number-input').doesNotHaveClass('phone-number-input--error');
+    });
+  });
+
+  module('@errorMessage parameter', () => {
+    test('It displays the error message if the parameter is passed', async function (assert) {
+      await render(hbs`<OSS::PhoneNumberInput @prefix="" @number="" @errorMessage="This is an error"
+                                              @onChange={{this.onChange}} />`);
+      assert.dom('.font-color-error-500').hasText('This is an error');
+    });
+
+    test('A red border is displayed if the parameter is true', async function (assert) {
+      await render(hbs`<OSS::PhoneNumberInput @prefix="" @number="" @errorMessage="This is an error"
+                                              @onChange={{this.onChange}} />`);
+      assert.dom('.phone-number-input').hasClass('phone-number-input--error');
+    });
+
+    test('It does not display the error message if the parameter is not passed', async function (assert) {
+      await render(hbs`<OSS::PhoneNumberInput @prefix="" @number="" @onChange={{this.onChange}} />`);
+      assert.dom('.font-color-error-500').doesNotExist();
     });
   });
 


### PR DESCRIPTION
### What does this PR do?
Adds two new parameters to OSS::PhoneNumberInput :
- @hasError : allows to mark the input as containing errors without the need of an error message
- @errorMessage: allows passing a custom error message to the input ; displays it in red along with a red border around the input

![Screenshot 2025-02-03 at 14 59 34](https://github.com/user-attachments/assets/fddbfcd6-d1d0-46b9-8cd6-1194419edfc6)

### Good PR checklist
- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [x] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled