### PR TITLE
Added ModeSwitch component to OSS

### DIFF
--- a/addon/components/o-s-s/mode-switch.hbs
+++ b/addon/components/o-s-s/mode-switch.hbs
@@ -1,0 +1,32 @@
+<div class={{this.computedClass}} {{did-insert this.registerContainerDiv}} style={{this.computedStyles}} ...attributes>
+  {{#each @options as |option|}}
+    <input
+      type="radio"
+      name={{this.guid}}
+      id={{concat this.guid "-" option.key}}
+      checked={{eq this.selectedOptionKey option.key}}
+      {{on "change" (fn @onSelect option.key)}}
+      data-control-name={{concat option.key "-input"}}
+    />
+    <label
+      for={{concat this.guid "-" option.key}}
+      tabindex="0"
+      {{on "keydown" (fn this.onKeyDown option.key)}}
+      data-control-name={{concat option.key "-label"}}
+    >
+      {{#if option.icon}}
+        <OSS::Icon @style={{fa-icon-style option.icon}} @icon={{fa-icon-value option.icon}} />
+      {{/if}}
+      {{option.label}}
+      {{#if option.tag}}
+        <OSS::Tag
+          @skin={{option.tag.skin}}
+          @plain={{option.tag.plain}}
+          @label={{option.tag.label}}
+          @size={{option.tag.size}}
+        />
+      {{/if}}
+    </label>
+  {{/each}}
+  <div class="mode-switch__background" {{did-insert this.registerBackgroundElement}} />
+</div>

--- a/addon/components/o-s-s/mode-switch.stories.js
+++ b/addon/components/o-s-s/mode-switch.stories.js
@@ -9,9 +9,9 @@ export default {
       description: 'The options of the switch',
       table: {
         type: {
-          summary: ''
+          summary: 'object'
         },
-        defaultValue: { summary: '' }
+        defaultValue: { summary: 'undefined' }
       },
       options: '',
       control: { type: 'object' }
@@ -49,11 +49,11 @@ export default {
       description: 'Changes the size of the switch',
       table: {
         type: {
-          summary: 'string'
+          summary: 'xs' | null
         },
-        defaultValue: { summary: 'sm' }
+        defaultValue: { summary: 'undefined' }
       },
-      options: 'xs' | 'sm',
+      options: ['xs', null],
       control: { type: 'select' }
     }
   }
@@ -73,29 +73,4 @@ Default.args = {
   selected: 'option1',
   plain: false,
   size: undefined
-};
-
-export const Plain = Template.bind({});
-Plain.args = {
-  ...Default.args,
-  plain: true
-};
-
-export const Small = Template.bind({});
-Small.args = {
-  ...Default.args,
-  size: 'xs'
-};
-
-export const DifferentSkins = Template.bind({});
-DifferentSkins.args = {
-  options: [
-    { key: 'blue', label: 'Blue', skin: 'xtd-blue' },
-    { key: 'cyan', label: 'Cyan', skin: 'xtd-cyan' },
-    { key: 'lime', label: 'Lime', skin: 'xtd-lime' },
-    { key: 'orange', label: 'Orange', skin: 'xtd-orange' },
-    { key: 'violet', label: 'Violet', skin: 'xtd-violet' },
-    { key: 'yellow', label: 'Yellow', skin: 'xtd-yellow' }
-  ],
-  selected: 'blue'
 };

--- a/addon/components/o-s-s/mode-switch.stories.js
+++ b/addon/components/o-s-s/mode-switch.stories.js
@@ -1,0 +1,101 @@
+import { hbs } from 'ember-cli-htmlbars';
+import { action } from '@storybook/addon-actions';
+
+export default {
+  title: 'Components/OSS::ModeSwitch',
+  component: 'ModeSwitch',
+  argTypes: {
+    options: {
+      description: 'The options of the switch',
+      table: {
+        type: {
+          summary: ''
+        },
+        defaultValue: { summary: '' }
+      },
+      options: '',
+      control: { type: 'object' }
+    },
+    selected: {
+      description: 'The selected option',
+      table: {
+        type: {
+          summary: 'string'
+        },
+        defaultValue: { summary: 'undefined' }
+      },
+      control: { type: 'text' }
+    },
+    onSelect: {
+      description: 'A callback triggered when an option is clicked',
+      table: {
+        category: 'Actions',
+        type: {
+          summary: 'onSelect():void'
+        }
+      }
+    },
+    plain: {
+      description: 'Display the switch with a grey background',
+      table: {
+        type: {
+          summary: 'boolean'
+        },
+        defaultValue: { summary: 'false' }
+      },
+      control: { type: 'boolean' }
+    },
+    size: {
+      description: 'Changes the size of the switch',
+      table: {
+        type: {
+          summary: 'string'
+        },
+        defaultValue: { summary: 'sm' }
+      },
+      options: 'xs' | 'sm',
+      control: { type: 'select' }
+    }
+  }
+};
+
+const Template = (args) => ({
+  template: hbs`<ModeSwitch @options={{this.options}} @selected={{this.selected}} @plain={{this.plain}} @size={{this.size}} @onSelect={{this.onSelect}} />`,
+  context: { ...args, onSelect: action('onSelect') }
+});
+
+export const Default = Template.bind({});
+Default.args = {
+  options: [
+    { key: 'option1', label: 'Option 1', icon: 'check', skin: 'primary' },
+    { key: 'option2', label: 'Option 2', tag: { label: 'New', skin: 'primary' }, skin: 'xtd-blue' }
+  ],
+  selected: 'option1',
+  plain: false,
+  size: undefined
+};
+
+export const Plain = Template.bind({});
+Plain.args = {
+  ...Default.args,
+  plain: true
+};
+
+export const Small = Template.bind({});
+Small.args = {
+  ...Default.args,
+  size: 'xs'
+};
+
+export const DifferentSkins = Template.bind({});
+DifferentSkins.args = {
+  options: [
+    { key: 'blue', label: 'Blue', skin: 'xtd-blue' },
+    { key: 'cyan', label: 'Cyan', skin: 'xtd-cyan' },
+    { key: 'lime', label: 'Lime', skin: 'xtd-lime' },
+    { key: 'orange', label: 'Orange', skin: 'xtd-orange' },
+    { key: 'violet', label: 'Violet', skin: 'xtd-violet' },
+    { key: 'yellow', label: 'Yellow', skin: 'xtd-yellow' }
+  ],
+  selected: 'blue'
+};

--- a/addon/components/o-s-s/mode-switch.ts
+++ b/addon/components/o-s-s/mode-switch.ts
@@ -1,0 +1,130 @@
+import { action } from '@ember/object';
+import { guidFor } from '@ember/object/internals';
+import { scheduleOnce } from '@ember/runloop';
+import Component from '@glimmer/component';
+import type { OSSTagArgs } from '@upfluence/oss-components/components/o-s-s/tag';
+
+type Skin = 'primary' | 'xtd-blue' | 'xtd-cyan' | 'xtd-lime' | 'xtd-orange' | 'xtd-violet' | 'xtd-yellow';
+
+export type ModeSwitchOption = {
+  key: string;
+  label: string;
+  skin?: Skin;
+  tag?: OSSTagArgs;
+  icon?: string;
+};
+
+interface ModeSwitchComponentArgs {
+  options: ModeSwitchOption[];
+  selected?: string;
+  onSelect(key: string): void;
+  plain?: boolean;
+  size?: 'xs';
+}
+
+const DEFAULT_SKIN = 'primary';
+
+export default class ModeSwitchComponent extends Component<ModeSwitchComponentArgs> {
+  containerDiv: HTMLElement = document.createElement('div');
+  containerStyles: CSSStyleDeclaration = getComputedStyle(this.containerDiv);
+  backgroundElement: HTMLElement = document.createElement('div');
+
+  guid: string = guidFor(this);
+
+  constructor(owner: unknown, args: ModeSwitchComponentArgs) {
+    super(owner, args);
+
+    scheduleOnce('afterRender', this, () => {
+      this.initComponent();
+    });
+  }
+
+  get selectedOptionKey(): string {
+    return this.args.selected ?? this.args.options[0]!.key;
+  }
+
+  @action
+  registerContainerDiv(container: HTMLElement): void {
+    this.containerDiv = container;
+    this.containerStyles = getComputedStyle(this.containerDiv);
+  }
+
+  @action
+  registerBackgroundElement(backgroundDiv: HTMLElement): void {
+    this.backgroundElement = backgroundDiv;
+  }
+
+  @action
+  onKeyDown(inputId: string, event: KeyboardEvent): void {
+    if (event.key !== 'Enter' && event.key !== ' ') return;
+    event.preventDefault();
+    const inputElement = document.getElementById(`${this.guid}-${inputId}`) as HTMLInputElement;
+    inputElement?.click();
+  }
+
+  get computedClass(): string {
+    const classes = ['mode-switch'];
+
+    if (this.args.plain) {
+      classes.push('mode-switch--plain');
+    }
+
+    if (this.args.size === 'xs') {
+      classes.push('mode-switch--xs');
+    }
+
+    return classes.join(' ');
+  }
+
+  get computedStyles(): string {
+    this.moveBackgroundElement();
+
+    const colorPath = this.getColorPath();
+    if (!this.containerStyles) return '';
+    return [
+      `--mode-switch__selected-color:${this.containerStyles?.getPropertyValue(`--color-${colorPath}-500`)}`,
+      `--mode-switch__selected-background-color:${this.containerStyles?.getPropertyValue(`--color-${colorPath}-50`)}`
+    ].join(';');
+  }
+
+  private moveBackgroundElement(): void {
+    const destinationLabelDivRect = document
+      .querySelector(`label[for='${this.guid}-${this.selectedOptionKey}']`)
+      ?.getBoundingClientRect();
+    if (!this.backgroundElement || !destinationLabelDivRect) return;
+    this.backgroundElement.style.width = destinationLabelDivRect.width + 'px';
+    this.backgroundElement.style.left =
+      destinationLabelDivRect.left - this.containerDiv.getBoundingClientRect().left + 'px';
+  }
+
+  private getColorPath(): string | undefined {
+    const option = this.args.options.find((option) => option.key === this.selectedOptionKey);
+    if (!option) return;
+    const skin = option.skin ?? DEFAULT_SKIN;
+    return skin.startsWith('xtd-') ? skin.split('-')[1] : skin;
+  }
+
+  private initComponent(): void {
+    this.moveBackgroundElement();
+
+    const colorPath = this.getColorPath();
+    this.containerDiv.style.setProperty(
+      '--mode-switch__selected-color',
+      this.containerStyles.getPropertyValue(`--color-${colorPath}-500`)
+    );
+    this.containerDiv.style.setProperty(
+      '--mode-switch__selected-background-color',
+      this.containerStyles.getPropertyValue(`--color-${colorPath}-50`)
+    );
+
+    this.addTransitionsStyle();
+  }
+
+  private addTransitionsStyle(): void {
+    this.backgroundElement.style.setProperty(
+      'transition',
+      'left 0.25s ease, width 0.25s ease, background-color 0.25s ease'
+    );
+    this.containerDiv.style.setProperty('transition', 'font-weight 0.25s ease, color 0.25s ease');
+  }
+}

--- a/app/components/o-s-s/mode-switch.js
+++ b/app/components/o-s-s/mode-switch.js
@@ -1,0 +1,1 @@
+export { default } from '@upfluence/oss-components/components/o-s-s/mode-switch';

--- a/app/styles/mode-switch.less
+++ b/app/styles/mode-switch.less
@@ -1,0 +1,77 @@
+:root {
+  --mode-switch__border-radius: 20px;
+  --mode-switch__default-label-width: 80px;
+  --mode-switch__smart-label-width: 140px;
+  --mode-switch__selected-color: var(--color-primary-500);
+  --mode-switch__selected-background-color: var(--color-primary-50);
+}
+
+.mode-switch {
+  position: relative;
+  z-index: 0;
+  height: 40px;
+  padding: var(--spacing-px-3);
+  background-color: var(--color-white);
+  border-radius: var(--mode-switch__border-radius);
+  display: flex;
+  gap: var(--spacing-px-6);
+
+  input {
+    visibility: hidden;
+    position: absolute;
+    top: 0;
+  }
+
+  label {
+    padding: 0 var(--spacing-px-12);
+    margin: 0;
+    text-align: center;
+    cursor: pointer;
+    color: var(--color-gray-600);
+    font-size: var(--font-size-sm);
+    font-weight: 400;
+    display: flex;
+    gap: var(--spacing-px-6);
+    justify-content: space-evenly;
+    align-items: center;
+
+    &:focus-visible {
+      outline: 2px solid var(--color-primary-100);
+      border-radius: var(--mode-switch__border-radius);
+    }
+  }
+
+  input[type='radio']:checked + label {
+    font-weight: var(--font-weight-semibold);
+    color: var(--mode-switch__selected-color);
+  }
+
+  &--xs {
+    height: 28px;
+
+    label {
+      font-size: var(--font-size-xs);
+      padding: 0 var(--spacing-px-6);
+    }
+
+    .mode-switch__background {
+      height: 22px;
+    }
+  }
+
+  &.mode-switch--plain {
+    background-color: var(--color-gray-50);
+  }
+}
+
+.mode-switch__background {
+  height: 34px;
+  position: absolute;
+  top: 0;
+  left: 0;
+  margin-top: var(--spacing-px-3);
+  border-radius: var(--mode-switch__border-radius);
+  background-color: var(--mode-switch__selected-background-color);
+  box-shadow: var(--box-shadow-xs);
+  z-index: -1;
+}

--- a/app/styles/oss-components.less
+++ b/app/styles/oss-components.less
@@ -25,6 +25,7 @@
 @import 'currency-input';
 @import 'alert';
 @import 'country-selector';
+@import 'mode-switch';
 
 @import 'atoms/attribute';
 @import 'atoms/button';

--- a/tests/dummy/app/controllers/visual.ts
+++ b/tests/dummy/app/controllers/visual.ts
@@ -1,6 +1,7 @@
 import Controller from '@ember/controller';
 import { tracked } from '@glimmer/tracking';
 import { action, set } from '@ember/object';
+import type { ModeSwitchOption } from '@upfluence/oss-components/components/o-s-s/mode-switch';
 
 export default class Visual extends Controller {
   @tracked toggleValue: boolean = false;
@@ -81,6 +82,30 @@ export default class Visual extends Controller {
     }
   ];
 
+  modeSwitchOptions1: ModeSwitchOption[] = [
+    {
+      key: 'default',
+      label: 'Default',
+      icon: 'fa-exclamation-circle'
+    },
+    {
+      key: 'smart_results_v1',
+      label: 'Smart results',
+      tag: {
+        label: 'Tag',
+        skin: 'chat-gpt',
+        plain: true,
+        size: 'xs'
+      }
+    }
+  ];
+  @tracked modeSwitchSelected1: string = 'default';
+  modeSwitchOptions2: ModeSwitchOption[] = [
+    { key: 'or', label: 'OR', skin: 'xtd-blue' },
+    { key: 'and', label: 'AND', skin: 'xtd-violet', icon: 'fa-exclamation-circle' }
+  ];
+  @tracked modeSwitchSelected2: string = 'or';
+
   @action
   redirectTo(route: string): void {
     console.log('Redirect to', route);
@@ -135,5 +160,12 @@ export default class Visual extends Controller {
   @action
   countDownAction(): void {
     console.log('countDownAction');
+  }
+
+  @action onChangeMode1(selectedMode: string): void {
+    this.modeSwitchSelected1 = selectedMode;
+  }
+  @action onChangeMode2(selectedMode: string): void {
+    this.modeSwitchSelected2 = selectedMode;
   }
 }

--- a/tests/dummy/app/templates/visual.hbs
+++ b/tests/dummy/app/templates/visual.hbs
@@ -558,4 +558,28 @@
     </div>
   </div>
 
+  <div
+    class="fx-col fx-1 background-color-white border border-color-default border-radius-md padding-px-12 fx-gap-px-12"
+  >
+    <div class="font-size-md font-weight-semibold">
+      Mode switch
+    </div>
+    <div class="fx-row fx-gap-px-24 fx-xalign-center">
+      <div class="fx-row fx-gap-px-10">
+        <OSS::ModeSwitch
+          @options={{this.modeSwitchOptions1}}
+          @selected={{this.modeSwitchSelected1}}
+          @onSelect={{this.onChangeMode1}}
+        />
+        <OSS::ModeSwitch
+          @options={{this.modeSwitchOptions2}}
+          @selected={{this.modeSwitchSelected2}}
+          @onSelect={{this.onChangeMode2}}
+          @plain={{true}}
+          @size="xs"
+        />
+      </div>
+    </div>
+  </div>
+
 </div>

--- a/tests/integration/components/o-s-s/mode-switch-test.ts
+++ b/tests/integration/components/o-s-s/mode-switch-test.ts
@@ -1,0 +1,131 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { click, render, triggerEvent } from '@ember/test-helpers';
+import type { TestContext } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import sinon from 'sinon';
+
+module('Integration | Component | o-s-s/mode-switch', function (hooks) {
+  setupRenderingTest(hooks);
+
+  hooks.beforeEach(function (this: TestContext) {
+    this.onSelect = sinon.stub();
+    this.options = [
+      {
+        key: 'option1',
+        label: 'Option one'
+      },
+      {
+        key: 'option2',
+        label: 'Option two'
+      }
+    ];
+  });
+
+  test('it renders with the correct wording', async function (assert) {
+    await render(hbs`<OSS::ModeSwitch @options={{this.options}} @onSelect={{this.onSelect}} />`);
+
+    assert.dom('[data-control-name="option1-input"]').exists();
+    assert.dom('[data-control-name="option2-input"]').exists();
+    assert.dom('[data-control-name="option1-label"]').hasText('Option one');
+    assert.dom('[data-control-name="option2-label"]').hasText('Option two');
+  });
+
+  test('it renders with the first option selected by default', async function (assert) {
+    await render(hbs`<OSS::ModeSwitch @options={{this.options}} @onSelect={{this.onSelect}} />`);
+
+    assert.dom('[data-control-name="option1-input"]').isChecked();
+    assert.dom('[data-control-name="option2-input"]').isNotChecked();
+  });
+
+  module('selected option parameter', function (hooks) {
+    test('it renders with option 1 as selected parameter', async function (assert) {
+      await render(hbs`<OSS::ModeSwitch @options={{this.options}} @selected='option1' @onSelect={{this.onSelect}} />`);
+
+      assert.dom('[data-control-name="option1-input"]').isChecked();
+      assert.dom('[data-control-name="option2-input"]').isNotChecked();
+    });
+
+    test('it renders with option 2 as selected parameter', async function (assert) {
+      await render(hbs`<OSS::ModeSwitch @options={{this.options}} @selected='option2' @onSelect={{this.onSelect}} />`);
+
+      assert.dom('[data-control-name="option1-input"]').isNotChecked();
+      assert.dom('[data-control-name="option2-input"]').isChecked();
+    });
+  });
+
+  test('it renders with a tag', async function (this: TestContext, assert) {
+    this.options = [
+      {
+        key: 'option1',
+        label: 'Option one'
+      },
+      {
+        key: 'option2',
+        label: 'Option two',
+        tag: {
+          label: 'Tag'
+        }
+      }
+    ];
+
+    await render(hbs`<OSS::ModeSwitch @options={{this.options}} @onSelect={{this.onSelect}} />`);
+
+    assert.dom('[data-control-name="option1-input"]').exists();
+    assert.dom('[data-control-name="option2-input"]').exists();
+    assert.dom('[data-control-name="option1-label"] .upf-tag').doesNotExist();
+    assert.dom('[data-control-name="option2-label"] .upf-tag').exists();
+    assert.dom('[data-control-name="option2-label"] .upf-tag').hasText('Tag');
+  });
+
+  test('it renders with an icon', async function (this: TestContext, assert) {
+    this.options = [
+      {
+        key: 'option1',
+        label: 'Option one'
+      },
+      {
+        key: 'option2',
+        label: 'Option two',
+        icon: 'fa-exclamation-circle'
+      }
+    ];
+
+    await render(hbs`<OSS::ModeSwitch @options={{this.options}} @onSelect={{this.onSelect}} />`);
+
+    assert.dom('[data-control-name="option1-input"]').exists();
+    assert.dom('[data-control-name="option2-input"]').exists();
+    assert.dom('[data-control-name="option1-label"] i').doesNotExist();
+    assert.dom('[data-control-name="option2-label"] i').exists();
+    assert.dom('[data-control-name="option2-label"] i').hasClass('fa-exclamation-circle');
+  });
+
+  test('clicking a radio button changes the selection option and calls the onselect function', async function (this: TestContext, assert) {
+    await render(hbs`<OSS::ModeSwitch @options={{this.options}} @onSelect={{this.onSelect}} />`);
+
+    await click('[data-control-name="option2-label"]');
+    assert.ok(this.onSelect.calledWith('option2'));
+    assert.dom('[data-control-name="option1-input"]').isNotChecked();
+    assert.dom('[data-control-name="option2-input"]').isChecked();
+
+    await click('[data-control-name="option1-label"]');
+    assert.ok(this.onSelect.calledWith('option1'));
+    assert.dom('[data-control-name="option1-input"]').isChecked();
+    assert.dom('[data-control-name="option1-input"]').isChecked();
+    assert.dom('[data-control-name="option2-input"]').isNotChecked();
+  });
+
+  test('keyboard interaction on label triggers click on input', async function (this: TestContext, assert) {
+    await render(hbs`<OSS::ModeSwitch @options={{this.options}} @onSelect={{this.onSelect}} />`);
+
+    await triggerEvent('[data-control-name="option2-label"]', 'keydown', { key: 'Enter' });
+    assert.ok(this.onSelect.calledWith('option2'));
+    assert.dom('[data-control-name="option1-input"]').isNotChecked();
+    assert.dom('[data-control-name="option2-input"]').isChecked();
+
+    await triggerEvent('[data-control-name="option1-label"]', 'keydown', { key: ' ' });
+    assert.ok(this.onSelect.calledWith('option1'));
+    assert.dom('[data-control-name="option1-input"]').isChecked();
+    assert.dom('[data-control-name="option2-input"]').isNotChecked();
+  });
+});


### PR DESCRIPTION
### What does this PR do?
This PR move the BehaviourSwitch from Facade-Web to OSSComponents, renaming it ModeSwitch

Related to: #<!-- enter issue number here -->

### What are the observable changes?
![image](https://github.com/user-attachments/assets/5f34ef7f-3561-4eea-b8e6-fd090a0a746b)

### Good PR checklist
- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled
