### PR TITLE
Updated: PhoneNumberInput component now handles paste events

### DIFF
--- a/addon/components/o-s-s/currency-input.ts
+++ b/addon/components/o-s-s/currency-input.ts
@@ -22,7 +22,7 @@ interface OSSCurrencyInputArgs {
 }
 
 const NUMERIC_ONLY = /^\d$/i;
-const NOT_NUMERIC_FLOAT = /[^0-9,.]/g;
+export const NOT_NUMERIC_FLOAT = /[^\d,.]/g;
 export const PLATFORM_CURRENCIES: Currency[] = [
   { code: 'USD', symbol: '$' },
   { code: 'EUR', symbol: '€' },

--- a/addon/components/o-s-s/phone-number-input.hbs
+++ b/addon/components/o-s-s/phone-number-input.hbs
@@ -13,6 +13,7 @@
         name="telephone"
         placeholder={{this.placeholder}}
         {{on "keydown" this.onlyNumeric}}
+        {{on "paste" this.handlePaste}}
         {{on "blur" this.onlyNumeric}}
         {{did-insert this.registerInputElement}}
       />

--- a/tests/integration/components/o-s-s/phone-number-input-test.ts
+++ b/tests/integration/components/o-s-s/phone-number-input-test.ts
@@ -1,14 +1,14 @@
 import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, setupOnerror, triggerKeyEvent } from '@ember/test-helpers';
+import { render, setupOnerror, triggerEvent, triggerKeyEvent } from '@ember/test-helpers';
 import click from '@ember/test-helpers/dom/click';
 import sinon from 'sinon';
 import findAll from '@ember/test-helpers/dom/find-all';
 import typeIn from '@ember/test-helpers/dom/type-in';
 import settled from '@ember/test-helpers/settled';
 
-module('Integration | Component | o-s-s/phone-number', function (hooks) {
+module('Integration | Component | o-s-s/phone-number-input', function (hooks) {
   setupRenderingTest(hooks);
 
   hooks.beforeEach(function () {
@@ -112,6 +112,58 @@ module('Integration | Component | o-s-s/phone-number', function (hooks) {
 
       assert.ok(this.onValidation.calledWithExactly(false));
       assert.dom('.font-color-error-500').exists();
+    });
+  });
+
+  module('When the paste event is received', function (hooks) {
+    hooks.beforeEach(function () {
+      this.onChange = () => {};
+      this.onValidation = sinon.spy();
+      this.number = '1234567890';
+    });
+
+    test('The value stored in the clipboard is inserted in the input', async function (assert) {
+      await render(
+        hbs`<OSS::PhoneNumberInput @prefix="" @number={{this.number}} @onChange={{this.onChange}} @validates={{this.onValidation}} />`
+      );
+      assert.dom('input').hasValue('1234567890');
+      await triggerEvent('input', 'paste', {
+        clipboardData: {
+          getData: sinon.stub().returns('123')
+        }
+      });
+
+      assert.dom('input').hasValue('1234567890123');
+    });
+
+    test('The non-numeric characters are escaped', async function (assert) {
+      await render(
+        hbs`<OSS::PhoneNumberInput @prefix="" @number={{this.number}} @onChange={{this.onChange}} @validates={{this.onValidation}} />`
+      );
+      assert.dom('input').hasValue('1234567890');
+      await triggerEvent('input', 'paste', {
+        clipboardData: {
+          getData: sinon.stub().returns('1withletter0')
+        }
+      });
+
+      assert.dom('input').hasValue('123456789010');
+    });
+
+    test('When selection is applied, it replaces the selection', async function (assert) {
+      await render(
+        hbs`<OSS::PhoneNumberInput @prefix="" @number={{this.number}} @onChange={{this.onChange}} @validates={{this.onValidation}} />`
+      );
+      assert.dom('input').hasValue('1234567890');
+      let input = document.querySelector('input.ember-text-field') as HTMLInputElement;
+      input.setSelectionRange(4, 6);
+      await triggerEvent('input', 'paste', {
+        clipboardData: {
+          getData: sinon.stub().returns('0')
+        }
+      });
+
+      assert.dom('input').hasValue('123407890');
     });
   });
 


### PR DESCRIPTION
### What does this PR do?

OSS::PhoneNumberInput component updated to properly handle paste events.
On paste, from keyboard shortcuts or click action (right click + paste) the cliboard data is parsed to keep only numeric characters.

### Good PR checklist
- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled