### PR TITLE
Togglable section: Add new actions named block

### DIFF
--- a/addon/components/o-s-s/togglable-section.hbs
+++ b/addon/components/o-s-s/togglable-section.hbs
@@ -12,6 +12,9 @@
       <span class="font-weight-semibold font-size-md font-color-gray-900">{{@title}}</span>
       <span class="font-color-gray-500">{{@subtitle}}</span>
     </div>
+    {{#if (and (has-block "actions"))}}
+      {{yield to="actions"}}
+    {{/if}}
     <OSS::ToggleSwitch @value={{@toggled}} @onChange={{this.noop}} @disabled={{@disabled}} />
   </div>
   {{#if (and (has-block "contents") @toggled)}}

--- a/addon/components/o-s-s/togglable-section.hbs
+++ b/addon/components/o-s-s/togglable-section.hbs
@@ -12,8 +12,8 @@
       <span class="font-weight-semibold font-size-md font-color-gray-900">{{@title}}</span>
       <span class="font-color-gray-500">{{@subtitle}}</span>
     </div>
-    {{#if (and (has-block "actions"))}}
-      {{yield to="actions"}}
+    {{#if (and (has-block "header-actions"))}}
+      {{yield to="header-actions"}}
     {{/if}}
     <OSS::ToggleSwitch @value={{@toggled}} @onChange={{this.noop}} @disabled={{@disabled}} />
   </div>

--- a/addon/components/o-s-s/togglable-section.stories.js
+++ b/addon/components/o-s-s/togglable-section.stories.js
@@ -132,5 +132,25 @@ const Template = (args) => ({
   context: args
 });
 
+const WithActionsNamedBlockTemplate = (args) => ({
+  template: hbs`
+    <OSS::TogglableSection
+      @title={{this.title}} @subtitle={{this.subtitle}} @toggled={{this.toggled}} @iconUrl={{this.iconUrl}}
+      @badgeIcon={{this.badgeIcon}} @icon={{this.icon}} @onChange={{this.onChange}}
+      @disabled={{this.disabled}} @size={{this.size}}>
+      <:contents>
+        Setting content
+      </:contents>
+      <:actions>
+        actions ...
+      </:actions>
+    </OSS::TogglableSection>
+  `,
+  context: args
+});
+
 export const Default = Template.bind({});
 Default.args = defaultArgs;
+
+export const WithActionsNamedBlock = WithActionsNamedBlockTemplate.bind({});
+WithActionsNamedBlock.args = defaultArgs;

--- a/addon/components/o-s-s/togglable-section.stories.js
+++ b/addon/components/o-s-s/togglable-section.stories.js
@@ -141,9 +141,9 @@ const WithActionsNamedBlockTemplate = (args) => ({
       <:contents>
         Setting content
       </:contents>
-      <:actions>
+      <:header-actions>
         actions ...
-      </:actions>
+      </:header-actions>
     </OSS::TogglableSection>
   `,
   context: args

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -139,9 +139,9 @@
           @toggled={{this.toggled}}
           @onChange={{this.onToggle}}
         >
-          <:actions>
+          <:header-actions>
             <OSS::Tag @label="optional" />
-          </:actions>
+          </:header-actions>
           <:contents>
             <span>This is a Contents named block</span>
           </:contents>

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -131,7 +131,7 @@
       Togglable section
     </div>
     <div class="fx-row fx-gap-px-36 fx-xalign-start">
-      <div class="fx-row fx-gap-px-24">
+      <div class="fx-row fx-gap-px-24 fx-1">
         <OSS::TogglableSection
           @title="This is a title"
           @subtitle="This is a subtitle"
@@ -139,6 +139,9 @@
           @toggled={{this.toggled}}
           @onChange={{this.onToggle}}
         >
+          <:actions>
+            <OSS::Tag @label="optional" />
+          </:actions>
           <:contents>
             <span>This is a Contents named block</span>
           </:contents>

--- a/tests/integration/components/o-s-s/togglable-section-test.ts
+++ b/tests/integration/components/o-s-s/togglable-section-test.ts
@@ -176,12 +176,12 @@ module('Integration | Component | o-s-s/togglable-section', function (hooks) {
     });
   });
 
-  test('When `actions` named block is passed, the content is rendered in the header', async function (assert) {
+  test('When `header-actions` named block is passed, the content is rendered in the header', async function (assert) {
     await render(
       hbs`<OSS::TogglableSection @title={{this.title}} @toggled={{this.toggled}} @onChange={{this.onChange}} @disabled={{true}} >
-            <:actions>
+            <:header-actions>
               <div data-control-name="action-named-block-content" />
-            </:actions>
+            </:header-actions>
           </OSS::TogglableSection>`
     );
     assert.dom('.togglable-section .header-block [data-control-name="action-named-block-content"]').exists();

--- a/tests/integration/components/o-s-s/togglable-section-test.ts
+++ b/tests/integration/components/o-s-s/togglable-section-test.ts
@@ -175,4 +175,15 @@ module('Integration | Component | o-s-s/togglable-section', function (hooks) {
       assert.dom('.upf-toggle').hasClass('upf-toggle--toggled');
     });
   });
+
+  test('When `actions` named block is passed, the content is rendered in the header', async function (assert) {
+    await render(
+      hbs`<OSS::TogglableSection @title={{this.title}} @toggled={{this.toggled}} @onChange={{this.onChange}} @disabled={{true}} >
+            <:actions>
+              <div data-control-name="action-named-block-content" />
+            </:actions>
+          </OSS::TogglableSection>`
+    );
+    assert.dom('.togglable-section .header-block [data-control-name="action-named-block-content"]').exists();
+  });
 });


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the context of this pull request and its purpose. -->

Related to: #[DRA-2652](https://linear.app/upfluence/issue/DRA-2652/[publishr-admin-web]-add-application-received-tag-to-marketplace)

Adding an `actions` named block to the `<OSS::TogglableSection/>` component. 
This name block should allow us to overwrite the component behavior by adding content directly in the header of the `TogglableSection` between the title & the toggle when needed

### What are the observable changes?
<!-- This question could be adequate with multiple use cases, for example: -->
![Capture d’écran 2025-03-31 à 11 18 23](https://github.com/user-attachments/assets/a5b02946-7681-432e-8418-10491879bcfc)
![Capture d’écran 2025-03-31 à 11 18 10](https://github.com/user-attachments/assets/436f1943-80d6-4f03-be7a-861492824778)

<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->

### Good PR checklist
- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [x] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled
