### PR TITLE
Use portaled dropdowns for OSS::CountrySelector & OSS::PhoneNumberInput

### DIFF
--- a/addon/components/o-s-s/country-selector.hbs
+++ b/addon/components/o-s-s/country-selector.hbs
@@ -33,7 +33,7 @@
         @enableKeyboard={{true}}
         id={{this.portalId}}
         class={{concat "margin-top-px-0 country-selector-container__dropdown " this.dropdownAddressableClass}}
-        {{on-click-outside this.closeDropdown}}
+        {{on-click-outside this.onClickOutside}}
         {{on "click" this.noop}}
       >
         <:option as |item|>

--- a/addon/components/o-s-s/country-selector.hbs
+++ b/addon/components/o-s-s/country-selector.hbs
@@ -1,35 +1,54 @@
-<div id={{this.elementId}} class="country-selector-container fx-1" ...attributes>
-  <div class="upf-input fx-row fx-1 fx-malign-space-between fx-xalign-center {{if this.dropdownVisibility 'active'}}"
-       {{on "click" this.toggleDropdown}} role="button"
-       {{on "keydown" this.handleKeyEvent}}
-       data-control-name="country-selector-input" tabindex="0">
+<div
+  id={{this.elementId}}
+  class="country-selector-container fx-1"
+  data-toggle="oss-dropdown"
+  {{did-insert this.registerContainer}}
+  {{will-destroy this.disconnectObserver}}
+  ...attributes
+>
+  <div
+    class="upf-input fx-row fx-1 fx-malign-space-between fx-xalign-center {{if this.isOpen 'active'}}"
+    {{on "click" this.toggleDropdown}}
+    role="button"
+    {{on "keydown" this.handleKeyEvent}}
+    data-control-name="country-selector-input"
+    tabindex="0"
+  >
     <div class="fx-row fx-xalign-center fx-gap-px-10">
       {{#if this.selectedCountry.id}}
         <div class="fflag fflag-{{this.selectedCountry.id}} ff-sm ff-rounded"></div>
       {{/if}}
       <span class="{{unless this.selectedCountry 'text-color-default-light'}}">{{this.inputLabel}}</span>
     </div>
-    <OSS::Icon @icon="fa-chevron-{{if this.dropdownVisibility 'up' 'down'}}" />
+    <OSS::Icon @icon="fa-chevron-{{if this.isOpen 'up' 'down'}}" />
   </div>
-  {{#if this.dropdownVisibility}}
-    <OSS::InfiniteSelect @items={{this.filteredItems}} @onSearch={{this.search}}
-                         @onSelect={{this.onItemSelected}}
-                         @searchPlaceholder={{t "oss-components.country-selector.search"}}
-                         @onClose={{this.closeDropdown}}
-                         @enableKeyboard={{true}}
-                         {{on-click-outside this.closeDropdown}}>
-      <:option as |item|>
-        <div class="fx-row fx-xalign-center {{if (eq this.selectedCountry item) 'row-selected'}}">
-          {{#if item.id}}
-            <div class="fflag fflag-{{item.id}} ff-sm ff-rounded"></div>
-          {{/if}}
-          <span class="text-color-default-light margin-left-xx-sm">{{item.name}}</span>
-          {{#if (eq this.selectedCountry item)}}
-            <div class="fx-1"></div>
-            <OSS::Icon @icon="fa-check" class="font-color-primary-500 padding-right-px-6" />
-          {{/if}}
-        </div>
-      </:option>
-    </OSS::InfiniteSelect>
+  {{#if this.isOpen}}
+    {{#in-element this.portalTarget insertBefore=null}}
+      <OSS::InfiniteSelect
+        @items={{this.filteredItems}}
+        @onSearch={{this.search}}
+        @onSelect={{this.onItemSelected}}
+        @searchPlaceholder={{t "oss-components.country-selector.search"}}
+        @onClose={{this.closeDropdown}}
+        @enableKeyboard={{true}}
+        id={{this.portalId}}
+        class={{concat "margin-top-px-0 country-selector-container__dropdown " this.dropdownAddressableClass}}
+        {{on-click-outside this.closeDropdown}}
+        {{on "click" this.noop}}
+      >
+        <:option as |item|>
+          <div class="fx-row fx-xalign-center {{if (eq this.selectedCountry item) 'row-selected'}}">
+            {{#if item.id}}
+              <div class="fflag fflag-{{item.id}} ff-sm ff-rounded"></div>
+            {{/if}}
+            <span class="text-color-default-light margin-left-xx-sm">{{item.name}}</span>
+            {{#if (eq this.selectedCountry item)}}
+              <div class="fx-1"></div>
+              <OSS::Icon @icon="fa-check" class="font-color-primary-500 padding-right-px-6" />
+            {{/if}}
+          </div>
+        </:option>
+      </OSS::InfiniteSelect>
+    {{/in-element}}
   {{/if}}
 </div>

--- a/addon/components/o-s-s/country-selector.ts
+++ b/addon/components/o-s-s/country-selector.ts
@@ -1,7 +1,6 @@
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import { assert } from '@ember/debug';
-import { guidFor } from '@ember/object/internals';
 import { inject as service } from '@ember/service';
 import { isEmpty } from '@ember/utils';
 
@@ -46,7 +45,7 @@ export default class OSSCountrySelector extends BaseDropdown<OSSCountrySelectorA
     );
 
     if (!isEmpty(this.args.value)) {
-      this._matchValueWithSourceList();
+      scheduleOnce('afterRender', this, this._matchValueWithSourceList);
     }
   }
 
@@ -84,7 +83,6 @@ export default class OSSCountrySelector extends BaseDropdown<OSSCountrySelectorA
       scheduleOnce('afterRender', this, () => {
         const referenceTarget = this.container.querySelector('.upf-input') as HTMLElement;
         const floatingTarget = document.querySelector(`#${this.portalId}`);
-        console.log(referenceTarget, floatingTarget);
 
         if (referenceTarget && floatingTarget) {
           this.cleanupDrodpownAutoplacement = attachDropdown(

--- a/addon/components/o-s-s/phone-number-input.hbs
+++ b/addon/components/o-s-s/phone-number-input.hbs
@@ -45,7 +45,7 @@
         @searchPlaceholder="Search"
         id={{this.portalId}}
         class={{concat "margin-top-px-0 phone-number-container__dropdown " this.dropdownAddressableClass}}
-        {{on-click-outside this.hideCountrySelector}}
+        {{on-click-outside this.onClickOutside}}
         {{on "click" this.noop}}
       >
         <:option as |country|>

--- a/addon/components/o-s-s/phone-number-input.hbs
+++ b/addon/components/o-s-s/phone-number-input.hbs
@@ -1,8 +1,14 @@
-<div class="phone-number-container fx-1" ...attributes>
+<div
+  class="phone-number-container fx-1"
+  data-toggle="oss-dropdown"
+  {{did-insert this.registerContainer}}
+  {{will-destroy this.disconnectObserver}}
+  ...attributes
+>
   <div class="phone-number-input fx-row fx-1 fx-xalign-center {{this.interactiveClasses}}">
-    <div class="country-selector fx-row" role="button" {{on "click" this.toggleCountrySelector}}>
+    <div class="country-selector fx-row" role="button" {{on "click" this.toggleDropdown}}>
       <div class="fflag fflag-{{this.selectedCountry.id}} ff-sm ff-round"></div>
-      <OSS::Icon @icon="fa-chevron-{{if this.countrySelectorShown 'up' 'down'}}" />
+      <OSS::Icon @icon="fa-chevron-{{if this.isOpen 'up' 'down'}}" />
     </div>
     <div class="fx-1 fx-row upf-input" {{on "click" this.focusInput}}>
       <span class="fx-row fx-xalign-center phone-prefix">{{@prefix}}</span>
@@ -30,24 +36,32 @@
     </div>
   {{/if}}
 
-  {{#if this.countrySelectorShown}}
-    <OSS::InfiniteSelect
-      @items={{this.filteredCountries}}
-      @onSearch={{this.onSearch}}
-      @onSelect={{this.onSelect}}
-      @searchPlaceholder="Search"
-      {{on-click-outside this.hideCountrySelector}}
-    >
-      <:option as |country|>
-        <div class="fx-row fx-xalign-center {{if (eq this.selectedCountry country) 'row-selected'}}">
-          <div class="fflag fflag-{{country.id}} ff-sm ff-rounded"></div>
-          <span class="text-color-default-light margin-left-xx-sm">{{country.name}}</span>
-          <span class="text-color-default-light margin-left-xxx-sm fx-1">(+{{get country.countryCallingCodes 0}})</span>
-          {{#if (eq this.selectedCountry country)}}
-            <OSS::Icon @icon="fa-check" class="font-color-primary-500" />
-          {{/if}}
-        </div>
-      </:option>
-    </OSS::InfiniteSelect>
+  {{#if this.isOpen}}
+    {{#in-element this.portalTarget insertBefore=null}}
+      <OSS::InfiniteSelect
+        @items={{this.filteredCountries}}
+        @onSearch={{this.onSearch}}
+        @onSelect={{this.onSelect}}
+        @searchPlaceholder="Search"
+        id={{this.portalId}}
+        class={{concat "margin-top-px-0 phone-number-container__dropdown " this.dropdownAddressableClass}}
+        {{on-click-outside this.hideCountrySelector}}
+        {{on "click" this.noop}}
+      >
+        <:option as |country|>
+          <div class="fx-row fx-xalign-center {{if (eq this.selectedCountry country) 'row-selected'}}">
+            <div class="fflag fflag-{{country.id}} ff-sm ff-rounded"></div>
+            <span class="text-color-default-light margin-left-xx-sm">{{country.name}}</span>
+            <span class="text-color-default-light margin-left-xxx-sm fx-1">(+{{get
+                country.countryCallingCodes
+                0
+              }})</span>
+            {{#if (eq this.selectedCountry country)}}
+              <OSS::Icon @icon="fa-check" class="font-color-primary-500" />
+            {{/if}}
+          </div>
+        </:option>
+      </OSS::InfiniteSelect>
+    {{/in-element}}
   {{/if}}
 </div>

--- a/addon/components/o-s-s/phone-number-input.ts
+++ b/addon/components/o-s-s/phone-number-input.ts
@@ -143,14 +143,6 @@ export default class OSSPhoneNumberInput extends BaseDropdown<OSSPhoneNumberInpu
   }
 
   @action
-  hideCountrySelector(): void {
-    this.filteredCountries = this._countries;
-    this.closeDropdown();
-    this.cleanupDrodpownAutoplacement?.();
-    document.querySelector(`#${this.portalId}`)?.remove();
-  }
-
-  @action
   focusInput(): void {
     this.inputElement?.focus();
   }
@@ -163,6 +155,13 @@ export default class OSSPhoneNumberInput extends BaseDropdown<OSSPhoneNumberInpu
   @action
   handleSelectorClose(): void {
     this.hideCountrySelector();
+  }
+
+  private hideCountrySelector(): void {
+    this.filteredCountries = this._countries;
+    this.closeDropdown();
+    this.cleanupDrodpownAutoplacement?.();
+    document.querySelector(`#${this.portalId}`)?.remove();
   }
 
   private validateInput(): void {

--- a/addon/components/o-s-s/private/base-dropdown.ts
+++ b/addon/components/o-s-s/private/base-dropdown.ts
@@ -27,7 +27,7 @@ export default class OSSBaseDropdown<T extends BaseDropdownArgs> extends Compone
   }
 
   @action
-  toggleDropdown(event: MouseEvent): void {
+  toggleDropdown(event: Event): void {
     event.stopPropagation();
     event.preventDefault();
 

--- a/addon/components/o-s-s/private/base-dropdown.ts
+++ b/addon/components/o-s-s/private/base-dropdown.ts
@@ -6,6 +6,7 @@ import { isTesting } from '@embroider/macros';
 
 export interface BaseDropdownArgs {
   focusOnOpen?: boolean;
+  addressableAs?: string;
   captureClickOutside?: boolean;
 }
 
@@ -19,6 +20,10 @@ export default class OSSBaseDropdown<T extends BaseDropdownArgs> extends Compone
 
   handleSelectorClose(): void {
     throw new Error('[component][OSS::BaseDropdown] You must implement handleSelectorClose method on the child class');
+  }
+
+  get dropdownAddressableClass(): string {
+    return this.args.addressableAs ? `${this.args.addressableAs}__dropdown` : '';
   }
 
   @action


### PR DESCRIPTION
### What does this PR do?

Use portaled select dropdowns for both OSS::CountrySelector & OSS::PhoneNumberInput in order to properly:
- escape overflow hidden traps
- have autoplacement 

### What are the observable changes?
<!-- This question could be adequate with multiple use cases, for example: -->

<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->

### Good PR checklist
- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled
