### PR TITLE
New @secondarySkin option for OSS::ProgressBar component

### DIFF
--- a/addon/components/o-s-s/progress-bar.stories.js
+++ b/addon/components/o-s-s/progress-bar.stories.js
@@ -67,6 +67,16 @@ export default {
         defaultValue: { summary: undefined }
       },
       control: { type: 'boolean' }
+    },
+    secondarySkin: {
+      description: 'Set the secondary skin to be used for the progress bar.',
+      table: {
+        type: {
+          summary: ProgressBarSkins.join('|')
+        }
+      },
+      options: ProgressBarSkins,
+      control: { type: 'select' }
     }
   },
   parameters: {
@@ -82,7 +92,8 @@ const defaultArgs = {
   value: 30,
   label: 'Hello',
   displayValue: true,
-  coloredBackground: false
+  coloredBackground: false,
+  secondarySkin: undefined
 };
 
 const BasicUsageTemplate = (args) => ({
@@ -94,7 +105,8 @@ const BasicUsageTemplate = (args) => ({
         @displayValue={{this.displayValue}}
         @skin={{this.skin}}
         @size={{this.size}}
-        @coloredBackground={{this.coloredBackground}} />
+        @coloredBackground={{this.coloredBackground}}
+        @secondarySkin={{this.secondarySkin}} />
     </div>
   `,
   context: args

--- a/addon/components/o-s-s/progress-bar.ts
+++ b/addon/components/o-s-s/progress-bar.ts
@@ -12,6 +12,7 @@ interface OSSProgressBarArgs {
   skin?: ProgressBarSkins;
   size?: ProgressBarSizes;
   coloredBackground?: boolean;
+  secondarySkin?: ProgressBarSkins;
 }
 
 export default class OSSProgressBar extends Component<OSSProgressBarArgs> {
@@ -37,6 +38,10 @@ export default class OSSProgressBar extends Component<OSSProgressBarArgs> {
 
     if (this.args.coloredBackground) {
       classes.push('oss-progress-bar--colored-background');
+    }
+
+    if (this.args.secondarySkin) {
+      classes.push('oss-progress-bar--secondary-skin--' + this.args.secondarySkin);
     }
 
     return classes.join(' ');

--- a/app/styles/molecules/progress-bar.less
+++ b/app/styles/molecules/progress-bar.less
@@ -16,6 +16,24 @@
     }
   }
 
+  &--secondary-skin {
+    &--warning {
+      .oss-progress-bar__outer {
+        background-color: var(--color-warning-500);
+      }
+    }
+    &--success {
+      .oss-progress-bar__outer {
+        background-color: var(--color-success-500);
+      }
+    }
+    &--danger {
+      .oss-progress-bar__outer {
+        background-color: var(--color-error-500);
+      }
+    }
+  }
+
   &--warning {
     .oss-progress-bar__inner {
       background-color: var(--color-warning-500);

--- a/tests/dummy/app/templates/visual.hbs
+++ b/tests/dummy/app/templates/visual.hbs
@@ -491,6 +491,8 @@
         @coloredBackground={{true}}
       />
       <OSS::ProgressBar @value={{78}} @displayValue={{true}} @label="Hello" @coloredBackground={{false}} />
+      <OSS::ProgressBar @value={{78}} @displayValue={{true}} @label="Hello" @secondarySkin="danger" @size="sm" />
+      <OSS::ProgressBar @value={{62}} @displayValue={{true}} @skin="success" @secondarySkin="danger" @size="sm" />
     </div>
   </div>
 

--- a/tests/integration/components/o-s-s/progress-bar-test.ts
+++ b/tests/integration/components/o-s-s/progress-bar-test.ts
@@ -154,4 +154,32 @@ module('Integration | Component | o-s-s/progress-bar', function (hooks) {
       assert.dom('.oss-progress-bar').doesNotHaveClass('oss-progress-bar--colored-background');
     });
   });
+
+  module('@secondarySkin arg behaviour', function () {
+    test('if the value is "warning", the progress bar has the correct secondary class', async function (assert) {
+      await render(hbs`<OSS::ProgressBar @value={{this.checkedValue}} @secondarySkin="warning" />`);
+
+      assert.dom('.oss-progress-bar').hasClass('oss-progress-bar--secondary-skin--warning');
+    });
+
+    test('if the value is "success", the progress bar has the correct secondary class', async function (assert) {
+      await render(hbs`<OSS::ProgressBar @value={{this.checkedValue}} @secondarySkin="success" />`);
+
+      assert.dom('.oss-progress-bar').hasClass('oss-progress-bar--secondary-skin--success');
+    });
+
+    test('if the value is "danger", the progress bar has the correct secondary class', async function (assert) {
+      await render(hbs`<OSS::ProgressBar @value={{this.checkedValue}} @secondarySkin="danger" />`);
+
+      assert.dom('.oss-progress-bar').hasClass('oss-progress-bar--secondary-skin--danger');
+    });
+
+    test('if the value is unspecified, the progress bar does not have a secondary class', async function (assert) {
+      await render(hbs`<OSS::ProgressBar @value={{this.checkedValue}} />`);
+
+      assert.dom('.oss-progress-bar').doesNotHaveClass('oss-progress-bar--secondary-skin--warning');
+      assert.dom('.oss-progress-bar').doesNotHaveClass('oss-progress-bar--secondary-skin--success');
+      assert.dom('.oss-progress-bar').doesNotHaveClass('oss-progress-bar--secondary-skin--danger');
+    });
+  });
 });


### PR DESCRIPTION
### What does this PR do?
New @secondarySkin option for OSS::ProgressBar component

Adds the ability to specify a secondary color for the progress bar:
![Screenshot 2025-04-14 at 09 12 19](https://github.com/user-attachments/assets/2035ddb0-8e9f-4a08-a7a5-bd61f47d2471)
![Screenshot 2025-04-14 at 09 13 21](https://github.com/user-attachments/assets/a2b8464e-7710-42c9-bdeb-ddb9df441006)
![Screenshot 2025-04-14 at 09 13 33](https://github.com/user-attachments/assets/e4af7bd1-fcdd-43f0-91e3-ab9756f4745f)

These are based off the existing skin color options. For now nothing makes it look like we will require the default color (primary) to be set as secondary color.

### Good PR checklist
- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [x] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled