### PR TITLE
Input container: Fix issue with right clic copy event

### DIFF
--- a/addon/components/o-s-s/input-container.hbs
+++ b/addon/components/o-s-s/input-container.hbs
@@ -17,6 +17,7 @@
     {{else}}
       <Input
         {{on "keyup" (fn this._onChange @value)}}
+        {{on "paste" this.onPaste}}
         @value={{@value}}
         @type={{this.type}}
         placeholder={{@placeholder}}

--- a/addon/components/o-s-s/input-container.ts
+++ b/addon/components/o-s-s/input-container.ts
@@ -48,4 +48,23 @@ export default class OSSInputContainer extends Component<OSSInputContainerArgs> 
       this.args.onChange(value);
     }
   }
+
+  @action
+  onPaste(event: ClipboardEvent): void {
+    const element = event.target as HTMLInputElement;
+    this.args.onChange?.(
+      this.replaceStringAtRange(
+        element.value,
+        element.selectionStart ?? 0,
+        element.selectionEnd ?? 0,
+        event.clipboardData?.getData('Text') ?? ''
+      )
+    );
+    event.preventDefault();
+    event.stopImmediatePropagation();
+  }
+
+  private replaceStringAtRange(s: string, start: number, end: number, substitute: string): string {
+    return s.substring(0, start) + substitute + s.substring(end);
+  }
 }

--- a/tests/integration/components/o-s-s/input-container-test.js
+++ b/tests/integration/components/o-s-s/input-container-test.js
@@ -1,7 +1,7 @@
 import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, find, typeIn } from '@ember/test-helpers';
+import { render, find, typeIn, triggerEvent } from '@ember/test-helpers';
 import sinon from 'sinon';
 
 module('Integration | Component | o-s-s/input-container', function (hooks) {
@@ -76,6 +76,17 @@ module('Integration | Component | o-s-s/input-container', function (hooks) {
       let inputElement = find('.upf-input');
       await typeIn(inputElement, 'a');
       assert.ok(onValueChange.called);
+    });
+
+    test('Passing an @onChange method works and is triggered on copy event', async function (assert) {
+      this.onChange = sinon.stub();
+      await render(hbs`<OSS::InputContainer data-control-name="firstname-input" @onChange={{this.onChange}} />`);
+
+      assert.ok(this.onChange.notCalled);
+      await triggerEvent('.oss-input-container input', 'paste', {
+        clipboardData: { getData: (format) => `clipboardFormat/${format}` }
+      });
+      assert.ok(this.onChange.calledOnceWith('clipboardFormat/Text'));
     });
   });
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the context of this pull request and its purpose. -->

We have an issue with current implementation of the input.
As the onChange function is only mapped on keyboard key up, when an user right click copy content inside an input, it does not trigger the onChange function

Before:

https://github.com/user-attachments/assets/ab944fde-caf3-467e-b6f2-945f93bf9e39

https://github.com/user-attachments/assets/b318333e-2e9b-4e97-8ad1-90ded87d22af


After:

https://github.com/user-attachments/assets/1c118904-f764-4d2a-9f26-eb25ceeba2f3


https://github.com/user-attachments/assets/095d2aa0-eeaf-42a1-ab48-52887415e996


Related to: #[DRA-2681](https://linear.app/upfluence/issue/DRA-2681/add-tracking-link-button-greyed-out-diamond-pro-tech)

### What are the observable changes?
<!-- This question could be adequate with multiple use cases, for example: -->

<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->

### Good PR checklist
- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled
