### PR TITLE
Input container: Remove stopImmediatePropagation/preventDefault from paste event

### DIFF
--- a/addon/components/o-s-s/input-container.ts
+++ b/addon/components/o-s-s/input-container.ts
@@ -1,4 +1,5 @@
 import { action } from '@ember/object';
+import { next } from '@ember/runloop';
 import Component from '@glimmer/component';
 
 export type FeedbackMessage = {
@@ -60,8 +61,9 @@ export default class OSSInputContainer extends Component<OSSInputContainerArgs> 
         event.clipboardData?.getData('Text') ?? ''
       )
     );
-    event.preventDefault();
-    event.stopImmediatePropagation();
+    next(this, () => {
+      element.dispatchEvent(new KeyboardEvent('keyup', { key: 'Enter' }));
+    });
   }
 
   private replaceStringAtRange(s: string, start: number, end: number, substitute: string): string {

--- a/addon/components/o-s-s/input-container.ts
+++ b/addon/components/o-s-s/input-container.ts
@@ -53,16 +53,15 @@ export default class OSSInputContainer extends Component<OSSInputContainerArgs> 
   @action
   onPaste(event: ClipboardEvent): void {
     const element = event.target as HTMLInputElement;
-    this.args.onChange?.(
-      this.replaceStringAtRange(
-        element.value,
-        element.selectionStart ?? 0,
-        element.selectionEnd ?? 0,
-        event.clipboardData?.getData('Text') ?? ''
-      )
-    );
     next(this, () => {
-      element.dispatchEvent(new KeyboardEvent('keyup', { key: 'Enter' }));
+      this.args.onChange?.(
+        this.replaceStringAtRange(
+          element.value,
+          element.selectionStart ?? 0,
+          element.selectionEnd ?? 0,
+          event.clipboardData?.getData('Text') ?? ''
+        )
+      );
     });
   }
 

--- a/tests/integration/components/o-s-s/input-container-test.js
+++ b/tests/integration/components/o-s-s/input-container-test.js
@@ -86,7 +86,7 @@ module('Integration | Component | o-s-s/input-container', function (hooks) {
       await triggerEvent('.oss-input-container input', 'paste', {
         clipboardData: { getData: (format) => `clipboardFormat/${format}` }
       });
-      assert.ok(this.onChange.calledOnceWith('clipboardFormat/Text'));
+      assert.ok(this.onChange.calledWith('clipboardFormat/Text'));
     });
   });
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the context of this pull request and its purpose. -->

Currently `stopImmediatePropagation` & `preventDefault` are blocking paste event overwritten by other inputs.
The goal of this pr is to retreive the normal behavior on other inputs

Related to: #[VEL-5446](https://linear.app/upfluence/issue/VEL-5446/we-cant-paste-values-into-some-inputs-in-the-platform)

### What are the observable changes?
<!-- This question could be adequate with multiple use cases, for example: -->

<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->

### Good PR checklist
- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled
