### PR TITLE
Make the onSearch argument of the OSS::AccessPanel optional

### DIFF
--- a/addon/components/o-s-s/access-panel.hbs
+++ b/addon/components/o-s-s/access-panel.hbs
@@ -11,21 +11,25 @@
       {{yield to="empty-state"}}
     </div>
   {{else}}
-    <div class="padding-top-px-18 padding-bottom-px-18 padding-left-px-18 padding-right-px-18">
-      <OSS::SearchField
-        @value={{this.searchKeyword}}
-        @placeholder={{t "oss-components.access-panel.search_placeholder"}}
-        @onChange={{this.onSearch}}
-        {{enable-input-autofocus}}
-      />
-    </div>
+    {{#if @onSearch}}
+      <div class="padding-top-px-18 padding-bottom-px-18 padding-left-px-18 padding-right-px-18">
+        <OSS::SearchField
+          @value={{this.searchKeyword}}
+          @placeholder={{t "oss-components.access-panel.search_placeholder"}}
+          @onChange={{this.onSearch}}
+          {{enable-input-autofocus}}
+        />
+      </div>
+    {{/if}}
 
     <div class="oss-access-panel-container__content-wrapper fx-col height-pc-100">
-      <div class="oss-access-panel-container__rows-header">
-        {{yield to="columns"}}
-      </div>
+      {{#if (has-block "columns")}}
+        <div class="oss-access-panel-container__rows-header">
+          {{yield to="columns"}}
+        </div>
 
-      <hr />
+        <hr />
+      {{/if}}
 
       {{#if (and this.displayEmptyState this.searchKeyword)}}
         {{yield to="no-results"}}

--- a/addon/components/o-s-s/access-panel.ts
+++ b/addon/components/o-s-s/access-panel.ts
@@ -7,9 +7,9 @@ interface OSSAccessPanelArgs {
   records: unknown[];
   initialLoad: boolean;
   loading?: boolean;
-  onSearch(keyword: string): void;
   onBottomReached(): void;
   onClose(): void;
+  onSearch?(keyword: string): void;
 }
 
 export default class OSSAccessPanel extends Component<OSSAccessPanelArgs> {
@@ -40,6 +40,6 @@ export default class OSSAccessPanel extends Component<OSSAccessPanelArgs> {
   @action
   onSearch(keyword: string): void {
     this.searchKeyword = keyword;
-    this.args.onSearch(this.searchKeyword);
+    this.args.onSearch!(this.searchKeyword);
   }
 }

--- a/tests/integration/components/o-s-s/access-panel-test.ts
+++ b/tests/integration/components/o-s-s/access-panel-test.ts
@@ -86,7 +86,7 @@ module('Integration | Component | o-s-s/access-panel', function (hooks) {
       assert.ok(this.onSearch.lastCall.calledWithExactly('foo'));
     });
 
-    test('it is autofocus', async function (assert) {
+    test('the input is autofocused', async function (assert) {
       await renderComponent();
       assert.dom('.oss-input-container input').isFocused();
     });
@@ -102,6 +102,12 @@ module('Integration | Component | o-s-s/access-panel', function (hooks) {
 
       assert.dom('.no-results').exists();
       assert.dom('.no-results').hasText('no search results');
+    });
+
+    test('if the onSearch arg is not passed, the search input is not displayed', async function (assert) {
+      this.onSearch = undefined;
+      await renderComponent();
+      assert.dom('.oss-input-container').doesNotExist();
     });
   });
 });


### PR DESCRIPTION
### What does this PR do?
Make the onSearch argument of the OSS::AccessPanel optional

### Good PR checklist
- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled