### PR TITLE
Add fallbackPlacements option to attach-dropdown

### DIFF
--- a/addon/utils/attach-dropdown.ts
+++ b/addon/utils/attach-dropdown.ts
@@ -19,6 +19,7 @@ export type AttachmentOptions = {
   placement?: Placement;
   enableArrow?: boolean;
   placementStrategy?: 'auto' | 'flip';
+  fallbackPlacements?: Placement[];
 };
 
 export const DEFAULT_ATTACHMENT_OPTIONS: AttachmentOptions = {
@@ -26,7 +27,8 @@ export const DEFAULT_ATTACHMENT_OPTIONS: AttachmentOptions = {
   width: undefined,
   maxHeight: undefined,
   placement: 'bottom',
-  enableArrow: false
+  enableArrow: false,
+  fallbackPlacements: undefined
 };
 
 const RELATIVE_ARROW_PLACEMENT: Record<Side, Side> = {
@@ -73,7 +75,7 @@ export default function attachDropdown(
   } else {
     middlewares.push(
       flip({
-        fallbackPlacements: ['top', 'bottom']
+        fallbackPlacements: mergedOptions.fallbackPlacements ?? ['top', 'bottom']
       })
     );
   }


### PR DESCRIPTION
### What does this PR do?

Add fallbackPlacements option to attach-dropdown

### What are the observable changes?

![Peek 2025-04-24 15-31](https://github.com/user-attachments/assets/3f37b8ec-ea94-4442-9e6f-4c3329695ff9)

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled
