### PR TITLE
OSS::Checkbox, OSS::PowerSelect, OSS::Select Updates

### DIFF
--- a/addon/components/o-s-s/checkbox.stories.js
+++ b/addon/components/o-s-s/checkbox.stories.js
@@ -47,6 +47,17 @@ export default {
         type: 'boolean'
       }
     },
+    hasError: {
+      description:
+        'Displays an error border around the checkbox. Note: disabled, checked and partial states prevail over this state.',
+      table: {
+        type: { summary: 'boolean' },
+        defaultValue: { summary: 'false' }
+      },
+      control: {
+        type: 'boolean'
+      }
+    },
     onChange: {
       type: { required: true },
       description: 'The action triggered when the checkbox status is changed',
@@ -69,6 +80,7 @@ const defaultArgs = {
   checked: false,
   partial: false,
   disabled: false,
+  hasError: false,
   size: null,
   onChange: action('onSelect')
 };
@@ -76,7 +88,13 @@ const defaultArgs = {
 const Template = (args) => ({
   template: hbs`
     <OSS::Checkbox
-      @checked={{this.checked}} @partial={{this.partial}} @disabled={{this.disabled}} @size={{this.size}} @onChange={{this.onChange}} />
+      @checked={{this.checked}}
+      @partial={{this.partial}}
+      @disabled={{this.disabled}}
+      @size={{this.size}}
+      @hasError={{this.hasError}}
+      @onChange={{this.onChange}}
+    />
   `,
   context: args
 });

--- a/addon/components/o-s-s/checkbox.ts
+++ b/addon/components/o-s-s/checkbox.ts
@@ -15,6 +15,7 @@ interface OSSCheckboxArgs {
   partial?: boolean;
   disabled?: boolean;
   size?: SizeType;
+  hasError?: boolean;
   onChange(value: boolean): void;
 }
 
@@ -35,6 +36,10 @@ export default class OSSCheckbox extends Component<OSSCheckboxArgs> {
 
     if (this.args.disabled) {
       classes.push('upf-checkbox--disabled');
+    }
+
+    if (this.args.hasError) {
+      classes.push('upf-checkbox--error');
     }
 
     if (this.args.size && Object.keys(SizeDefinition).includes(this.args.size as SizeType)) {

--- a/addon/components/o-s-s/power-select.hbs
+++ b/addon/components/o-s-s/power-select.hbs
@@ -7,7 +7,7 @@
   ...attributes
 >
   <div class="upf-power-select__array-container" role="button" {{on "click" this.toggleDropdown}}>
-    <div class="array-input-container fx-row padding-px-6 {{if this.isOpen 'active'}}">
+    <div class="array-input-container {{this.inputBorderStateClass}} fx-row padding-px-6 {{if this.isOpen 'active'}}">
       <div class="fx-row fx-xalign-center fx-1 padding-left-px-6 padding-right-px-24 fx-gap-px-6 fx-wrap">
         {{#each @selectedItems as |selectedItem|}}
           {{yield selectedItem to="selected-item"}}
@@ -20,6 +20,14 @@
       <OSS::Icon @icon={{if this.isOpen "fa-chevron-up" "fa-chevron-down"}} class="dropdown-icon" />
     </div>
   </div>
+  {{#if this.safeFeedbackMessage}}
+    <span
+      class={{concat "margin-top-px-6 font-color-" this.safeFeedbackMessage.type "-500"}}
+      data-control-name="power-select-feedback-message"
+    >
+      <span>{{this.safeFeedbackMessage.value}}</span>
+    </span>
+  {{/if}}
 
   {{#if this.isOpen}}
     {{#in-element this.portalTarget insertBefore=null}}

--- a/addon/components/o-s-s/power-select.hbs
+++ b/addon/components/o-s-s/power-select.hbs
@@ -25,7 +25,7 @@
       class={{concat "margin-top-px-6 font-color-" this.safeFeedbackMessage.type "-500"}}
       data-control-name="power-select-feedback-message"
     >
-      <span>{{this.safeFeedbackMessage.value}}</span>
+      {{this.safeFeedbackMessage.value}}
     </span>
   {{/if}}
 

--- a/addon/components/o-s-s/power-select.stories.js
+++ b/addon/components/o-s-s/power-select.stories.js
@@ -50,6 +50,27 @@ export default {
       },
       control: { type: 'boolean' }
     },
+    feedbackMessage: {
+      description: 'A success, warning or error message that will be displayed below the input-group.',
+      table: {
+        type: {
+          summary: "{ type: 'error' | 'warning' | 'success', value: string }"
+        },
+        defaultValue: { summary: 'undefined' }
+      },
+      control: { type: 'object' }
+    },
+    hasError: {
+      description:
+        'Allows setting the error style on the input without showing an error message. Useful for form validation.',
+      table: {
+        type: {
+          summary: 'boolean'
+        },
+        defaultValue: { summary: 'undefined' }
+      },
+      control: { type: 'boolean' }
+    },
     loadingMore: {
       description: 'Display loading more state in the list of items',
       table: {
@@ -137,6 +158,8 @@ const defaultArgs = {
   placeholder: 'My placeholder',
   searchPlaceholder: 'My search placeholder',
   addressableAs: undefined,
+  feedbackMessage: undefined,
+  hasError: false,
   onSearch: action('onSearch'),
   onChange: action('onChange', { allowFunction: true }),
   onBottomReached: action('onBottomReached')
@@ -147,7 +170,7 @@ const Template = (args) => ({
     <div style="display: flex; justify-content: center; background-color: white; border-radius: 4px">
       <OSS::PowerSelect class='padding-sm' @selectedItems={{this.selectedItems}} @items={{this.items}}
                         @onSearch={{this.onSearch}} @onChange={{this.onChange}} @loading={{this.loading}} 
-                        @borderless={{this.borderless}}
+                        @borderless={{this.borderless}} @hasError={{this.hasError}} @feedbackMessage={{this.feedbackMessage}}
                         @loadingMore={{this.loadingMore}} @placeholder={{this.placeholder}} @searchPlaceholder={{this.searchPlaceholder}}
                         @onBottomReached={{this.onBottomReached}} @addressableAs={{this.addressableAs}}>
         <:selected-item as |selectedItem|>

--- a/addon/components/o-s-s/power-select.ts
+++ b/addon/components/o-s-s/power-select.ts
@@ -34,6 +34,12 @@ export default class OSSPowerSelect extends BaseDropdown<OSSPowerSelectArgs> {
     return this.args.addressableAs ? `${this.args.addressableAs}__dropdown` : '';
   }
 
+  get inputBorderStateClass(): string | undefined {
+    if (this.args.hasError) return ' array-input-container--error';
+    if (this.safeFeedbackMessage) return ` array-input-container--${this.safeFeedbackMessage.type}`;
+    return undefined;
+  }
+
   @action
   ensureBlockPresence(hasSelectedItem: boolean, hasOptionItem: boolean): void | never {
     assert(`[component][OSS::PowerSelect] You must pass selected-item named block`, hasSelectedItem);
@@ -63,18 +69,7 @@ export default class OSSPowerSelect extends BaseDropdown<OSSPowerSelectArgs> {
       return;
     }
 
-    scheduleOnce('afterRender', this, () => {
-      const referenceTarget = this.container.querySelector('.upf-power-select__array-container');
-      const floatingTarget = document.querySelector(`#${this.portalId}`);
-
-      if (referenceTarget && floatingTarget) {
-        this.cleanupDrodpownAutoplacement = attachDropdown(
-          referenceTarget as HTMLElement,
-          floatingTarget as HTMLElement,
-          { maxHeight: 300, placementStrategy: 'auto' }
-        );
-      }
-    });
+    scheduleOnce('afterRender', this, this.setupDropdownAutoplacement);
   }
 
   @action
@@ -83,5 +78,18 @@ export default class OSSPowerSelect extends BaseDropdown<OSSPowerSelectArgs> {
     this.cleanupDrodpownAutoplacement?.();
     this.args.onSearch?.('');
     document.querySelector(`#${this.portalId}`)?.remove();
+  }
+
+  private setupDropdownAutoplacement(): void {
+    const referenceTarget = this.container.querySelector('.upf-power-select__array-container');
+    const floatingTarget = document.querySelector(`#${this.portalId}`);
+
+    if (referenceTarget && floatingTarget) {
+      this.cleanupDrodpownAutoplacement = attachDropdown(
+        referenceTarget as HTMLElement,
+        floatingTarget as HTMLElement,
+        { maxHeight: 300, placementStrategy: 'auto' }
+      );
+    }
   }
 }

--- a/addon/components/o-s-s/private/base-dropdown.ts
+++ b/addon/components/o-s-s/private/base-dropdown.ts
@@ -3,11 +3,14 @@ import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { guidFor } from '@ember/object/internals';
 import { isTesting } from '@embroider/macros';
+import type { FeedbackMessage } from '../input-container';
 
 export interface BaseDropdownArgs {
   focusOnOpen?: boolean;
   addressableAs?: string;
   captureClickOutside?: boolean;
+  feedbackMessage?: FeedbackMessage;
+  hasError?: boolean;
 }
 
 export default class OSSBaseDropdown<T extends BaseDropdownArgs> extends Component<T> {
@@ -24,6 +27,14 @@ export default class OSSBaseDropdown<T extends BaseDropdownArgs> extends Compone
 
   get dropdownAddressableClass(): string {
     return this.args.addressableAs ? `${this.args.addressableAs}__dropdown` : '';
+  }
+
+  get safeFeedbackMessage(): FeedbackMessage | undefined {
+    if (this.args.feedbackMessage && ['error', 'warning', 'success'].includes(this.args.feedbackMessage.type)) {
+      return this.args.feedbackMessage;
+    }
+
+    return undefined;
   }
 
   @action

--- a/addon/components/o-s-s/select.ts
+++ b/addon/components/o-s-s/select.ts
@@ -98,18 +98,7 @@ export default class OSSSelect extends BaseDropdown<OSSSelectArgs> {
       return;
     }
 
-    scheduleOnce('afterRender', this, () => {
-      const referenceTarget = this.container.querySelector('.upf-input');
-      const floatingTarget = document.querySelector(`#${this.portalId}`);
-
-      if (referenceTarget && floatingTarget) {
-        this.cleanupDrodpownAutoplacement = attachDropdown(
-          referenceTarget as HTMLElement,
-          floatingTarget as HTMLElement,
-          { placementStrategy: 'auto' }
-        );
-      }
-    });
+    scheduleOnce('afterRender', this, this.setupDropdownAutoplacement);
   }
 
   @action
@@ -134,5 +123,18 @@ export default class OSSSelect extends BaseDropdown<OSSSelectArgs> {
   @action
   ensureBlockPresence(hasOptionItem: boolean): void {
     assert(`[component][OSS::Select] You must pass option named block`, hasOptionItem);
+  }
+
+  private setupDropdownAutoplacement(): void {
+    const referenceTarget = this.container.querySelector('.upf-input');
+    const floatingTarget = document.querySelector(`#${this.portalId}`);
+
+    if (referenceTarget && floatingTarget) {
+      this.cleanupDrodpownAutoplacement = attachDropdown(
+        referenceTarget as HTMLElement,
+        floatingTarget as HTMLElement,
+        { maxHeight: 300, placementStrategy: 'auto' }
+      );
+    }
   }
 }

--- a/app/styles/array-input.less
+++ b/app/styles/array-input.less
@@ -33,6 +33,7 @@
     border: none;
 
     &:not(&.array-input-container--disabled) {
+
       &:hover,
       &:active,
       &.active,
@@ -42,10 +43,12 @@
     }
   }
 
-  &--errored {
+  &--errored,
+  &--error {
     .border-color-error;
 
     &:not(&.array-input-container--disabled) {
+
       &:hover,
       &:focus {
         .border-color-error;
@@ -53,6 +56,38 @@
 
       &:active {
         .input-state-error-active;
+      }
+    }
+  }
+
+  &--success {
+    .border-color-success;
+
+    &:not(&.array-input-container--disabled) {
+
+      &:hover,
+      &:focus {
+        .border-color-success;
+      }
+
+      &:active {
+        .input-state-success-active;
+      }
+    }
+  }
+
+  &--warning {
+    .border-color-warning;
+
+    &:not(&.array-input-container--disabled) {
+
+      &:hover,
+      &:focus {
+        .border-color-warning;
+      }
+
+      &:active {
+        .input-state-warning-active;
       }
     }
   }

--- a/app/styles/base/_checkboxes.less
+++ b/app/styles/base/_checkboxes.less
@@ -82,6 +82,10 @@
   }
 }
 
+.upf-checkbox--error .upf-checkbox__fake-checkbox {
+  border-color: var(--color-error-500);
+}
+
 //
 // The real label of a checkbox. Aligned along it.
 //

--- a/app/styles/molecules/select.less
+++ b/app/styles/molecules/select.less
@@ -21,8 +21,7 @@
     .input-state-disabled;
   }
 
-  &:not(.oss-select-container--disabled, .oss-select-container--errorful, .oss-select-container--successful)
-    .upf-input {
+  &:not(.oss-select-container--disabled, .oss-select-container--errorful, .oss-select-container--successful) .upf-input {
     &:hover {
       .input-state-hover;
     }
@@ -39,6 +38,7 @@
 
   :not(&--disabled)&--errorful .upf-input {
     .border-color-error;
+
     &:hover {
       .input-state-error-hover;
     }
@@ -55,6 +55,7 @@
 
   :not(&--disabled)&--successful .upf-input {
     border: 1px solid var(--color-success-500);
+
     &:hover {
       .input-state-hover;
       border: 1px solid var(--color-success-500);
@@ -75,9 +76,13 @@
 }
 
 .oss-select-container__dropdown {
-  max-width: 100%;
-  min-width: 100%;
-  padding: var(--spacing-px-12);
+  overflow: hidden;
+
+  &:has(.upf-input) {
+    .upf-infinite-select__items-container {
+      max-height: calc(var(--floating-max-height) - 78px);
+    }
+  }
 
   .upf-infinite-select__item {
     padding: 0;

--- a/app/styles/power-select.less
+++ b/app/styles/power-select.less
@@ -1,6 +1,14 @@
 .upf-power-select {
   height: 100%;
 
+  &--error {
+    border: red !important;
+    .yielded-input input,
+    .upf-input {
+      .upf-input--errored;
+    }
+  }
+
   .upf-power-select__array-container {
     position: relative;
     height: 100%;
@@ -20,6 +28,7 @@
     .array-input-container {
       border-color: transparent;
       background-color: transparent;
+
       &.active {
         &:hover {
           &:not(.array-input-container--disabled) {
@@ -27,6 +36,7 @@
             border: 1px solid var(--color-border-default);
           }
         }
+
         &:not(.array-input-container--disabled) {
           box-shadow: none;
           background-color: var(--color-gray-100);
@@ -34,6 +44,7 @@
           transition-duration: 0ms;
         }
       }
+
       &:hover {
         &:not(.array-input-container--disabled) {
           box-shadow: none;

--- a/app/styles/power-select.less
+++ b/app/styles/power-select.less
@@ -1,14 +1,6 @@
 .upf-power-select {
   height: 100%;
 
-  &--error {
-    border: red !important;
-    .yielded-input input,
-    .upf-input {
-      .upf-input--errored;
-    }
-  }
-
   .upf-power-select__array-container {
     position: relative;
     height: 100%;

--- a/app/styles/utilities/_borders.less
+++ b/app/styles/utilities/_borders.less
@@ -17,7 +17,7 @@
   border-color: var(--color-border-default);
 }
 
-.border-color-alert {
+.border-color-alert, .border-color-warning {
   border-color: var(--color-warning-500);
 }
 .border-color-error {

--- a/tests/dummy/app/controllers/input.ts
+++ b/tests/dummy/app/controllers/input.ts
@@ -9,7 +9,21 @@ export default class Input extends Controller {
   @tracked inputValue: string = '';
   @tracked searchFieldValue: string = '';
   @tracked textAreaValue: string = '42';
-  @tracked superHeroes: string[] = ['Iron Man', 'Thor', 'Loki', 'Hulk'];
+  @tracked superHeroes: string[] = [
+    'Iron Man',
+    'Thor',
+    'Loki',
+    'Hulk',
+    'Captain America',
+    'Black Widow',
+    'Hawkeye',
+    'Vision',
+    'Scarlet Witch',
+    'Doctor Strange',
+    'Spiderman',
+    'Black Panther',
+    'Captain Marvel'
+  ];
   @tracked items: { name: string; label: string }[] = [
     { name: 'foo', label: 'foo' },
     { name: 'bar', label: 'bar' }

--- a/tests/dummy/app/templates/input.hbs
+++ b/tests/dummy/app/templates/input.hbs
@@ -136,7 +136,7 @@
         @selectedItems={{null}}
         @onChange={{this.onPowerSelectChange}}
         @onSearch={{this.onPowerSelectSearch}}
-        @feedbackMessage={{hash type="error" value=""}}
+        @feedbackMessage={{hash type="error" value="error message"}}
       >
         <:selected-item as |selectedProduct|>
           <OSS::Chip @label={{selectedProduct}} @onRemove={{this.onPowerSelectChange}} @maxDisplayWidth={{100}} />
@@ -151,7 +151,7 @@
         @selectedItems={{null}}
         @onChange={{this.onPowerSelectChange}}
         @onSearch={{this.onPowerSelectSearch}}
-        @feedbackMessage={{hash type="success" value=""}}
+        @feedbackMessage={{hash type="success" value="sucess message"}}
       >
         <:selected-item as |selectedProduct|>
           <OSS::Chip @label={{selectedProduct}} @onRemove={{this.onPowerSelectChange}} @maxDisplayWidth={{100}} />
@@ -166,7 +166,7 @@
         @selectedItems={{null}}
         @onChange={{this.onPowerSelectChange}}
         @onSearch={{this.onPowerSelectSearch}}
-        @feedbackMessage={{hash type="warning" value=""}}
+        @feedbackMessage={{hash type="warning" value="warning message"}}
       >
         <:selected-item as |selectedProduct|>
           <OSS::Chip @label={{selectedProduct}} @onRemove={{this.onPowerSelectChange}} @maxDisplayWidth={{100}} />

--- a/tests/dummy/app/templates/input.hbs
+++ b/tests/dummy/app/templates/input.hbs
@@ -45,12 +45,14 @@
 
         <OSS::Select
           @value={{this.selectedItem}}
-          @items={{this.items}}
+          @items={{this.superHeroes}}
           @onChange={{this.onSelect}}
+          @onSearch={{this.onPowerSelectSearch}}
           @successMessage="It works"
+          class="fx-1"
         >
           <:option as |item|>
-            {{item.name}}
+            {{item}}
           </:option>
         </OSS::Select>
 
@@ -119,6 +121,52 @@
         @selectedItems={{null}}
         @onChange={{this.onPowerSelectChange}}
         @onSearch={{this.onPowerSelectSearch}}
+      >
+        <:selected-item as |selectedProduct|>
+          <OSS::Chip @label={{selectedProduct}} @onRemove={{this.onPowerSelectChange}} @maxDisplayWidth={{100}} />
+        </:selected-item>
+        <:option-item as |item|>
+          {{item}}
+        </:option-item>
+      </OSS::PowerSelect>
+    </div>
+    <div class="fx-row fx-gap-px-24 fx-xalign-start">
+      <OSS::PowerSelect
+        @items={{this.superHeroes}}
+        @selectedItems={{null}}
+        @onChange={{this.onPowerSelectChange}}
+        @onSearch={{this.onPowerSelectSearch}}
+        @feedbackMessage={{hash type="error" value=""}}
+      >
+        <:selected-item as |selectedProduct|>
+          <OSS::Chip @label={{selectedProduct}} @onRemove={{this.onPowerSelectChange}} @maxDisplayWidth={{100}} />
+        </:selected-item>
+        <:option-item as |item|>
+          {{item}}
+        </:option-item>
+      </OSS::PowerSelect>
+
+      <OSS::PowerSelect
+        @items={{this.superHeroes}}
+        @selectedItems={{null}}
+        @onChange={{this.onPowerSelectChange}}
+        @onSearch={{this.onPowerSelectSearch}}
+        @feedbackMessage={{hash type="success" value=""}}
+      >
+        <:selected-item as |selectedProduct|>
+          <OSS::Chip @label={{selectedProduct}} @onRemove={{this.onPowerSelectChange}} @maxDisplayWidth={{100}} />
+        </:selected-item>
+        <:option-item as |item|>
+          {{item}}
+        </:option-item>
+      </OSS::PowerSelect>
+
+      <OSS::PowerSelect
+        @items={{this.superHeroes}}
+        @selectedItems={{null}}
+        @onChange={{this.onPowerSelectChange}}
+        @onSearch={{this.onPowerSelectSearch}}
+        @feedbackMessage={{hash type="warning" value=""}}
       >
         <:selected-item as |selectedProduct|>
           <OSS::Chip @label={{selectedProduct}} @onRemove={{this.onPowerSelectChange}} @maxDisplayWidth={{100}} />

--- a/tests/dummy/app/templates/visual.hbs
+++ b/tests/dummy/app/templates/visual.hbs
@@ -175,6 +175,14 @@
         @partial={{true}}
         @onChange={{this.onCheck}}
       />
+      <OSS::Checkbox
+        @checked={{this.isChecked}}
+        @size="sm"
+        @disabled={{false}}
+        @partial={{false}}
+        @hasError={{true}}
+        @onChange={{this.onCheck}}
+      />
     </div>
   </div>
 

--- a/tests/integration/components/o-s-s/checkbox-test.ts
+++ b/tests/integration/components/o-s-s/checkbox-test.ts
@@ -90,6 +90,35 @@ module('Integration | Component | o-s-s/checkbox', function (hooks) {
     });
   });
 
+  module('@hasError argument', () => {
+    test('When the hasError argument is true, the checkbox has the upf-checkbox--error class', async function (assert: Assert) {
+      this.checked = false;
+      this.hasError = true;
+      await render(
+        hbs`<OSS::Checkbox @checked={{this.checked}} @hasError={{this.hasError}} @onChange={{this.onChange}} />`
+      );
+      assert.dom('.upf-checkbox').hasClass('upf-checkbox--error');
+    });
+
+    test('When the hasError argument is false, the checkbox does not have the upf-checkbox--error class', async function (assert: Assert) {
+      this.checked = false;
+      this.hasError = false;
+      await render(
+        hbs`<OSS::Checkbox @checked={{this.checked}} @hasError={{this.hasError}} @onChange={{this.onChange}} />`
+      );
+      assert.dom('.upf-checkbox').doesNotHaveClass('upf-checkbox--error');
+    });
+
+    test('When the hasError argument is undefined, the checkbox does not have the upf-checkbox--error class', async function (assert: Assert) {
+      this.checked = false;
+      this.hasError = undefined;
+      await render(
+        hbs`<OSS::Checkbox @checked={{this.checked}} @hasError={{this.hasError}} @onChange={{this.onChange}} />`
+      );
+      assert.dom('.upf-checkbox').doesNotHaveClass('upf-checkbox--error');
+    });
+  });
+
   module('Error management', function () {
     test('it throws an error if checked argument is missing', async function (assert) {
       setupOnerror((error: Error) => {

--- a/tests/integration/components/o-s-s/power-select-test.ts
+++ b/tests/integration/components/o-s-s/power-select-test.ts
@@ -2,7 +2,7 @@ import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { setupIntl } from 'ember-intl/test-support';
-import { render, setupOnerror, findAll, click, typeIn, scrollTo } from '@ember/test-helpers';
+import { render, setupOnerror, findAll, click, typeIn, scrollTo, type TestContext } from '@ember/test-helpers';
 import sinon from 'sinon';
 
 module('Integration | Component | o-s-s/power-select', function (hooks) {
@@ -282,6 +282,99 @@ module('Integration | Component | o-s-s/power-select', function (hooks) {
       await click('.upf-power-select__array-container');
       assert.dom('.upf-infinite-select').exists();
       assert.dom('.upf-infinite-select').hasClass('foobar-select__dropdown');
+    });
+  });
+
+  module('with @feedbackMessage', () => {
+    async function renderComponentWithFeedbackMessage(): Promise<void> {
+      await render(hbs`
+        <OSS::PowerSelect @selectedItems={{this.selectedItems}} @items={{this.items}}
+                          @onSearch={{this.onSearch}} @feedbackMessage={{this.feedbackMessage}}>
+          <:selected-item as |selectedItem|>
+            {{selectedItem}}
+          </:selected-item>
+          <:option-item as |item|>
+            {{item}}
+          </:option-item>
+        </OSS::PowerSelect>
+      `);
+    }
+
+    module('For "error" type', () => {
+      test('Passing the error type sets the proper border class on the input container', async function (assert) {
+        this.feedbackMessage = { type: 'error', value: 'error message' };
+        await renderComponentWithFeedbackMessage();
+
+        assert.dom('.upf-power-select .array-input-container').hasClass('array-input-container--error');
+      });
+
+      test('Passing the error type along with a message will display the message', async function (assert) {
+        this.feedbackMessage = { type: 'error', value: 'error message' };
+        await renderComponentWithFeedbackMessage();
+
+        assert.dom('[data-control-name="power-select-feedback-message"]').hasText('error message');
+      });
+    });
+
+    module('For "warning" type', () => {
+      test('Passing the warning type sets the proper border class on the input container', async function (assert) {
+        this.feedbackMessage = { type: 'warning', value: 'warning message' };
+        await renderComponentWithFeedbackMessage();
+
+        assert.dom('.upf-power-select .array-input-container').hasClass('array-input-container--warning');
+      });
+
+      test('Passing the warning type along with a message will display the message', async function (assert) {
+        this.feedbackMessage = { type: 'warning', value: 'warning message' };
+        await renderComponentWithFeedbackMessage();
+
+        assert.dom('[data-control-name="power-select-feedback-message"]').hasText('warning message');
+      });
+    });
+
+    module('For "success" type', () => {
+      test('Passing the success type sets the proper border class on the input container', async function (assert) {
+        this.feedbackMessage = { type: 'success', value: 'success message' };
+        await renderComponentWithFeedbackMessage();
+
+        assert.dom('.upf-power-select .array-input-container').hasClass('array-input-container--success');
+      });
+
+      test('Passing the success type along with a message will display the message', async function (assert) {
+        this.feedbackMessage = { type: 'success', value: 'success message' };
+        await renderComponentWithFeedbackMessage();
+
+        assert.dom('[data-control-name="power-select-feedback-message"]').hasText('success message');
+      });
+    });
+
+    test('Failing to pass the type will not display a border or a message', async function (assert) {
+      this.feedbackMessage = undefined;
+      await renderComponentWithFeedbackMessage();
+      assert.dom('.upf-power-select .array-input-container').doesNotHaveClass('array-input-container--error');
+      assert.dom('[data-control-name="power-select-feedback-message"]').doesNotExist();
+    });
+  });
+
+  module('with @hasError', () => {
+    test('Passing @hasError parameter sets the proper border class on the input container', async function (assert) {
+      this.selectedItems = ['value1', 'value2'];
+      this.items = ['value1', 'value2'];
+      this.hasError = true;
+
+      await render(hbs`
+        <OSS::PowerSelect @selectedItems={{this.selectedItems}} @items={{this.items}} @hasError={{true}}
+                          @onSearch={{this.onSearch}}>
+          <:selected-item as |selectedItem|>
+            {{selectedItem}}
+          </:selected-item>
+          <:option-item as |item|>
+            {{item}}
+          </:option-item>
+        </OSS::PowerSelect />
+      `);
+
+      assert.dom('.upf-power-select .array-input-container').hasClass('array-input-container--error');
     });
   });
 


### PR DESCRIPTION
### What does this PR do?

#### Adds a `hasError` parameter to OSS::Checkbox
![Screenshot 2025-05-06 at 16 24 17](https://github.com/user-attachments/assets/5fde517e-6a7a-47a2-b585-500de44188e4)

#### Adds `hasError` parameter to OSS::PowerSelect
![Screenshot 2025-05-06 at 11 43 18](https://github.com/user-attachments/assets/2232fe1e-e758-4048-9e80-f49a1d4a165c)

#### Adds `feedbackMessage` parameter ( `{ type: 'error' | 'warning' | 'success'; value: string }` ) to OSS::PowerSelect
This follows the same implementation & usage as we have for our `OSS::InputContainer` component
![Screenshot 2025-05-06 at 11 45 48](https://github.com/user-attachments/assets/f5a80c42-2ce3-4089-967f-c5fc6e3965ba)

#### Update to `OSS::Select` to have the search bar fixed at the top of the dropdown
Before update:
![Screenshot 2025-05-06 at 14 40 11](https://github.com/user-attachments/assets/207a1b36-7ffc-4596-8be1-d421d90ef053)

After update:
![Screenshot 2025-05-06 at 16 27 10](https://github.com/user-attachments/assets/bab071a2-2abc-4605-9558-d41dae9c4a8d)

Required test files & storybook entries have been updated.

Linked to:
- https://linear.app/upfluence/issue/DRA-2868/oss-components-osscheckbox-error-state-osspowerselect-errormessage
- https://linear.app/upfluence/issue/DRA-2721/improve-ossselect-component-persistent-search-input

### Good PR checklist
- [x] Title makes sense
- [x] Is against the correct branch
- [ ] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [x] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled