### PR TITLE
Updated: FormManager service with setFieldFeedback method

### DIFF
--- a/addon/services/form-manager.ts
+++ b/addon/services/form-manager.ts
@@ -10,6 +10,7 @@ export type FormInstance = {
   validateField(field: string): boolean;
   getErrors(): ValidationFeedbacks;
   clearErrors(field?: string): void;
+  setFieldFeedback(field: string, feedback: Feedback): void;
 };
 export type Feedback = { kind: string; message: FeedbackMessage };
 export type Validator = () => Feedback | undefined;
@@ -31,7 +32,8 @@ export default class FormManager extends Service {
       validateForm: (): boolean => this.validateForm(id),
       validateField: (field: string): boolean => this.validateField(id, field),
       getErrors: (): ValidationFeedbacks => this.getFieldErrors(id),
-      clearErrors: (field: string) => this.clearErrors(id, field)
+      clearErrors: (field: string) => this.clearErrors(id, field),
+      setFieldFeedback: (field: string, feedback: Feedback): void => this.setFieldFeedback(id, field, feedback)
     };
   }
 
@@ -80,6 +82,14 @@ export default class FormManager extends Service {
     if (isValid) this.clearErrors(id, field);
 
     return isValid;
+  }
+
+  private setFieldFeedback(id: string, field: string, feedback: Feedback): void {
+    this.formFeedbacks[id] = {
+      ...this.formFeedbacks[id],
+      [field]: feedback
+    };
+    this.refreshFormFeedbacks();
   }
 
   private getFieldErrors(id: string): ValidationFeedbacks {

--- a/tests/unit/services/form-manager-test.ts
+++ b/tests/unit/services/form-manager-test.ts
@@ -193,5 +193,16 @@ module('Unit | Service | form-manager', function (hooks) {
         assert.deepEqual(this.formInstance.getErrors(), {});
       });
     });
+
+    module('#setFieldFeedback', function () {
+      test('it sets the feedback for a field', function (assert) {
+        const field = 'testField';
+        const feedback = { kind: 'blank', message: { type: 'error', value: 'Error' } } as Feedback;
+
+        this.formInstance.setFieldFeedback(field, feedback);
+
+        assert.deepEqual(this.service.formFeedbacks['test'][field], feedback);
+      });
+    });
   });
 });


### PR DESCRIPTION
### What does this PR do?
It adds a new `setFieldFeeback` message to the FormManager service.
This method is also returned as a FormInstance which allows easy usage from a parent caller.

e.g. On an error received from the API

```typescript

  private errorHandler({ errors }: { errors: RoleError[] }): void {
    this.args.role.rollbackAttributes();

    if (errors?.[0]?.detail) {
      const { resource, field, code } = errors[0]?.detail;
      if (resource === 'role' && field === 'name' && code === 'taken') {
        this.formInstance.setFieldFeedback('roleName', {
          kind: 'error',
          message: {
            type: 'error',
            value: this.intl.t('roles.error.name.already_exist')
          }
        });
      }
      return this.toast.error(this.intl.t('roles.error.name.already_exist'), this.intl.t('roles.update.error.title'));
    }

    this.toast.error(this.intl.t('roles.update.error.subtitle'), this.intl.t('roles.update.error.title'));
  }
```

### Good PR checklist
- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled