### PR TITLE
Fixed: OSS::Select display overflow when search is disabled

### DIFF
--- a/app/styles/molecules/select.less
+++ b/app/styles/molecules/select.less
@@ -76,9 +76,9 @@
 }
 
 .oss-select-container__dropdown {
-  overflow: hidden;
-
   &:has(.upf-input) {
+    overflow: hidden;
+
     .upf-infinite-select__items-container {
       max-height: calc(var(--floating-max-height) - 78px);
     }


### PR DESCRIPTION
### What does this PR do?
Fixed: OSS::Select display overflow when search is disabled

both version are now displaying properly:
![Screenshot 2025-05-15 at 11 43 11](https://github.com/user-attachments/assets/82ec72dc-95e9-4557-b2e2-10b45a320466)

![Screenshot 2025-05-15 at 11 43 08](https://github.com/user-attachments/assets/f8a13b8c-409e-4d95-a9b3-5e1948bc7dd6)


### Good PR checklist
- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled