### PR TITLE
Add hasError arg to inputGroup

### DIFF
--- a/addon/components/o-s-s/input-group.hbs
+++ b/addon/components/o-s-s/input-group.hbs
@@ -2,7 +2,7 @@
   <div
     class="fx-1 fx-row fx-xalign-center oss-input-group-row
       {{if @disabled 'disabled'}}
-      {{if @errorMessage 'oss-input-group-row--error'}}"
+      {{if this.hasError 'oss-input-group-row--error'}}"
   >
     {{#if @prefix}}
       <div class="oss-input-group-row-prefix">{{@prefix}}</div>

--- a/addon/components/o-s-s/input-group.ts
+++ b/addon/components/o-s-s/input-group.ts
@@ -5,6 +5,7 @@ interface OSSInputGroupArgs {
   value?: string;
   disabled?: boolean;
   errorMessage?: string;
+  hasError?: boolean;
   placeholder?: string;
   prefix?: string;
   suffix?: string;
@@ -24,5 +25,9 @@ export default class OSSInputGroup extends Component<OSSInputGroupArgs> {
 
   get type(): string {
     return this.args.type ?? 'text';
+  }
+
+  get hasError(): boolean {
+    return !!this.args.errorMessage || !!this.args.hasError;
   }
 }

--- a/tests/integration/components/o-s-s/input-group-test.ts
+++ b/tests/integration/components/o-s-s/input-group-test.ts
@@ -39,6 +39,12 @@ module('Integration | Component | o-s-s/input-group', function (hooks) {
     assert.dom('.oss-input-group-row--error').hasStyle({ borderColor: 'rgb(239, 68, 68)' });
   });
 
+  test('Passing the @hasError without errorMessage sets an error border on the whole compoenent', async function (assert) {
+    await render(hbs`<OSS::InputGroup @prefix="random" @suffix="@domain.com" @hasError={{true}} />`);
+    assert.dom('.oss-input-group-row--error').exists();
+    assert.dom('.oss-input-group-row--error').hasStyle({ borderColor: 'rgb(239, 68, 68)' });
+  });
+
   test('it fails if no prefix or suffix parameters are passed', async function (assert: Assert) {
     setupOnerror((err: Error) => {
       assert.equal(


### PR DESCRIPTION
### What does this PR do?
Add hasError arg to inputGroup to allow errored style without error message
<!-- A brief description of the context of this pull request and its purpose. -->

Related to: #<!-- enter issue number here -->

### What are the observable changes?
<!-- This question could be adequate with multiple use cases, for example: -->

<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->

### Good PR checklist
- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [ ] Properly labeled
