### PR TITLE
Updated: prevent autofocus of CountrySelector on load

### DIFF
--- a/addon/components/o-s-s/country-selector.ts
+++ b/addon/components/o-s-s/country-selector.ts
@@ -96,13 +96,13 @@ export default class OSSCountrySelector extends BaseDropdown<OSSCountrySelectorA
   }
 
   @action
-  closeDropdown(): void {
+  closeDropdown(preventFocus: boolean = false): void {
     super.closeDropdown();
 
     document.querySelector(`#${this.portalId}`)?.remove();
 
     const el = this.container.querySelector('.upf-input') as HTMLElement;
-    el?.focus();
+    if (!preventFocus) el?.focus();
   }
 
   @action
@@ -113,12 +113,12 @@ export default class OSSCountrySelector extends BaseDropdown<OSSCountrySelectorA
   }
 
   @action
-  onItemSelected(value: Item): void {
-    this.closeDropdown();
+  onItemSelected(value: Item, preventFocus: boolean = false): void {
+    this.closeDropdown(preventFocus);
     this.args.onChange(value);
   }
 
   private _matchValueWithSourceList(): void {
-    if (this.selectedCountry) this.onItemSelected(this.selectedCountry);
+    if (this.selectedCountry) this.onItemSelected(this.selectedCountry, true);
   }
 }

--- a/tests/integration/components/o-s-s/avatar-test.ts
+++ b/tests/integration/components/o-s-s/avatar-test.ts
@@ -10,11 +10,13 @@ module('Integration | Component | o-s-s/avatar', function (hooks) {
 
   module('Default behavior', function () {
     test('it displays the image when it is provided', async function (assert) {
-      await render(hbs`<OSS::Avatar @image="http://foo.co/bar.png" />`);
+      await render(hbs`<OSS::Avatar @image="/@upfluence/oss-components/assets/images/upfluence-blue-logo.svg" />`);
 
       assert.dom('.upf-avatar').exists();
       assert.dom('.upf-avatar img').exists();
-      assert.dom('.upf-avatar img').hasAttribute('src', 'http://foo.co/bar.png');
+      assert
+        .dom('.upf-avatar img')
+        .hasAttribute('src', '/@upfluence/oss-components/assets/images/upfluence-blue-logo.svg');
     });
 
     test('it displays the initials when they are provided', async function (assert) {
@@ -34,11 +36,15 @@ module('Integration | Component | o-s-s/avatar', function (hooks) {
     });
 
     test('it displays the image when image and initials are provided', async function (assert) {
-      await render(hbs`<OSS::Avatar @image="http://foo.co/bar.png" @initials="TS" />`);
+      await render(
+        hbs`<OSS::Avatar @image="/@upfluence/oss-components/assets/images/upfluence-blue-logo.svg" @initials="TS" />`
+      );
 
       assert.dom('.upf-avatar').exists();
       assert.dom('.upf-avatar img').exists();
-      assert.dom('.upf-avatar img').hasAttribute('src', 'http://foo.co/bar.png');
+      assert
+        .dom('.upf-avatar img')
+        .hasAttribute('src', '/@upfluence/oss-components/assets/images/upfluence-blue-logo.svg');
     });
 
     test('it updates the image when a new @image is provided', async function (assert) {
@@ -49,9 +55,11 @@ module('Integration | Component | o-s-s/avatar', function (hooks) {
       assert.dom('.upf-avatar').exists();
       assert.dom('.upf-avatar img').doesNotExist();
       assert.dom('.upf-avatar span').hasText('TS');
-      this.set('updatedImage', 'https://via.placeholder.com/150');
+      this.set('updatedImage', '/@upfluence/oss-components/assets/images/upfluence-blue-logo.svg');
       assert.dom('.upf-avatar span').doesNotExist();
-      assert.dom('.upf-avatar img').hasAttribute('src', 'https://via.placeholder.com/150');
+      assert
+        .dom('.upf-avatar img')
+        .hasAttribute('src', '/@upfluence/oss-components/assets/images/upfluence-blue-logo.svg');
     });
   });
 
@@ -94,7 +102,7 @@ module('Integration | Component | o-s-s/avatar', function (hooks) {
     });
 
     test('it displays the initials when both initials and image are provided and the image fails to load', async function (assert) {
-      await render(hbs`<OSS::Avatar @image="/foo.co/bar.p" @initials="TS" />`);
+      await render(hbs`<OSS::Avatar @image="/@upfluence/oss-components/assets/images/fail.svg" @initials="TS" />`);
       await waitFor('.upf-avatar span');
 
       assert.dom('.upf-avatar').exists();
@@ -103,7 +111,7 @@ module('Integration | Component | o-s-s/avatar', function (hooks) {
     });
 
     test('it displays the placeholder image when the image provided in parameters fails to load', async function (assert) {
-      await render(hbs`<OSS::Avatar @image="/foo.co/bar.p" />`);
+      await render(hbs`<OSS::Avatar @image="/@upfluence/oss-components/assets/images/fail.svg" />`);
       await waitUntil(function () {
         return find('.upf-avatar img')?.getAttribute('src') === DEFAULT_IMAGE_URL;
       });


### PR DESCRIPTION
### What does this PR do?

The current implementation of the OSS::CountrySelector focuses the input selector when the component is instanciated with an existing value.

This PR disables this, only when instanciating with a valid argument, as it messes up focusing rules in some other components.
Making a selection and then closing the dropdown still focuses the input selector as it did before.

### Good PR checklist
- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled