### PR TITLE
Scrollable-panel: Add new onBottomReached action & micro-improvement on content resize

### DIFF
--- a/addon/components/o-s-s/scrollable-panel.hbs
+++ b/addon/components/o-s-s/scrollable-panel.hbs
@@ -2,8 +2,14 @@
   {{#if (and this.shadowTopVisible (not @disableShadows))}}
     <div class="oss-scrollable-panel--shadow oss-scrollable-panel--shadow__top"></div>
   {{/if}}
-  <div class="oss-scrollable-panel-content" {{did-insert this.initScrollListener}}>
-    {{yield}}
+  <div
+    class="oss-scrollable-panel-content"
+    {{on-bottom-reached this.onBottomReached}}
+    {{did-insert this.initScrollListener}}
+  >
+    <div {{did-insert this.initResizeObserver}}>
+      {{yield}}
+    </div>
   </div>
   {{#if (and this.shadowBottomVisible (not @disableShadows))}}
     <div class="oss-scrollable-panel--shadow oss-scrollable-panel--shadow__bottom"></div>

--- a/addon/components/o-s-s/scrollable-panel.stories.js
+++ b/addon/components/o-s-s/scrollable-panel.stories.js
@@ -1,4 +1,5 @@
 import { hbs } from 'ember-cli-htmlbars';
+import { action } from '@storybook/addon-actions';
 
 export default {
   title: 'Components/OSS::ScrollablePanel',
@@ -23,6 +24,15 @@ export default {
       control: {
         type: 'boolean'
       }
+    },
+    onBottomReached: {
+      description: 'Function to be called when the scroll hits the bottom',
+      table: {
+        category: 'Actions',
+        type: {
+          summary: 'onBottomReached(): void'
+        }
+      }
     }
   },
   parameters: {
@@ -36,13 +46,14 @@ export default {
 
 const defaultArgs = {
   plain: false,
-  disableShadows: false
+  disableShadows: false,
+  onBottomReached: action('onBottomReached')
 };
 
 const Template = (args) => ({
   template: hbs`
     <div style="height:200px; width: 300px; background-color: white; " >
-      <OSS::ScrollablePanel @plain={{this.plain}} @disableShadows={{this.disableShadows}}>
+      <OSS::ScrollablePanel @plain={{this.plain}} @disableShadows={{this.disableShadows}} @onBottomReached={{this.onBottomReached}} >
         <div class="fx-col fx-gap-px-12 padding-px-12">
           <div class="background-color-gray-200" style="height: 50px; width: 100%;" />
           <div class="background-color-gray-200" style="height: 50px; width: 100%;" />

--- a/addon/components/o-s-s/scrollable-panel.ts
+++ b/addon/components/o-s-s/scrollable-panel.ts
@@ -5,12 +5,15 @@ import { tracked } from '@glimmer/tracking';
 interface OSSScrollablePanelComponentSignature {
   plain?: boolean;
   disableShadows?: boolean;
+  onBottomReached?: () => void;
 }
 
 export default class OSSScrollablePanelComponent extends Component<OSSScrollablePanelComponentSignature> {
   @tracked declare parentElement: HTMLElement;
   @tracked shadowTopVisible: boolean = false;
   @tracked shadowBottomVisible: boolean = false;
+
+  resizeObserver = new ResizeObserver(this.resizeObserverCallback.bind(this));
 
   @action
   initScrollListener(element: HTMLElement): void {
@@ -20,9 +23,20 @@ export default class OSSScrollablePanelComponent extends Component<OSSScrollable
   }
 
   @action
+  initResizeObserver(element: HTMLElement): void {
+    this.resizeObserver.observe(element);
+  }
+
+  @action
   willDestroy(): void {
     this.parentElement.removeEventListener('scroll', this.scrollListener.bind(this));
+    this.resizeObserver.disconnect();
     super.willDestroy();
+  }
+
+  @action
+  onBottomReached(): void {
+    this.args.onBottomReached?.();
   }
 
   private scrollListener(): void {
@@ -40,5 +54,9 @@ export default class OSSScrollablePanelComponent extends Component<OSSScrollable
     } else {
       this.shadowBottomVisible = true;
     }
+  }
+
+  private resizeObserverCallback(_: ResizeObserverEntry[]): void {
+    this.scrollListener();
   }
 }

--- a/app/styles/organisms/scrollable-panel.less
+++ b/app/styles/organisms/scrollable-panel.less
@@ -1,11 +1,13 @@
 .oss-scrollable-panel-container {
   height: 100%;
+  max-height: inherit;
   width: 100%;
   position: relative;
   overflow: auto;
 
   .oss-scrollable-panel-content {
     height: inherit;
+    max-height: inherit;
     overflow: auto;
   }
 

--- a/tests/integration/components/o-s-s/scrollable-panel-test.ts
+++ b/tests/integration/components/o-s-s/scrollable-panel-test.ts
@@ -1,10 +1,15 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, settled, waitFor } from '@ember/test-helpers';
+import { render, scrollTo, settled, waitFor } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
+import sinon from 'sinon';
 
 module('Integration | Component | o-s-s/scrollable-panel', function (hooks) {
   setupRenderingTest(hooks);
+
+  hooks.beforeEach(function () {
+    this.onBottomReached = sinon.stub();
+  });
 
   function scrollIntoView(elementId: string) {
     document.querySelector(`#${elementId}`)?.scrollIntoView({ block: 'center' });
@@ -12,7 +17,7 @@ module('Integration | Component | o-s-s/scrollable-panel', function (hooks) {
 
   const renderScrollableContent = hbs`
   <div class="background-color-gray-50" style="height:300px; width: 500px">
-    <OSS::ScrollablePanel @disableShadows={{this.disableShadows}}>
+    <OSS::ScrollablePanel @disableShadows={{this.disableShadows}} @onBottomReached={{this.onBottomReached}}>
       <div class="fx-col fx-gap-px-12 padding-px-12">
         <div class="background-color-gray-200" style="height: 50px; width: 100%;" id="start-element"/>
         <div class="background-color-gray-200" style="height: 50px; width: 100%;" />
@@ -96,5 +101,17 @@ module('Integration | Component | o-s-s/scrollable-panel', function (hooks) {
     assert.dom('.oss-scrollable-panel-content').exists();
     assert.dom('.oss-scrollable-panel--shadow__top').doesNotExist();
     assert.dom('.oss-scrollable-panel--shadow__bottom').doesNotExist();
+  });
+
+  module('with onBottomReached', function () {
+    test('when scrolling to the bottom, it should trigger onBottomReach function', async function (assert) {
+      await render(renderScrollableContent);
+
+      assert.ok(this.onBottomReached.notCalled);
+
+      await scrollTo('.oss-scrollable-panel-content', 0, 1500);
+
+      assert.ok(this.onBottomReached.calledOnce);
+    });
   });
 });


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the context of this pull request and its purpose. -->

Related to: #<!-- enter issue number here -->

### What are the observable changes?
Add a new optional `onBottomReached` action wich is triggered when the user scroll to the bottom of the scrollable panel.
Furthermore added few micro-improvement on the component himself:
 - ResizeObserver => showing/hidding shadows, when the content size of the scroll has changed
 - CSS update => Automatically handle shadow when parent has a max-size defined

<!-- This question could be adequate with multiple use cases, for example: -->

<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->

### Good PR checklist
- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [x] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled
