### PR TITLE
Deprecation: Fix built-in components legacy attributes

### DIFF
--- a/addon/components/o-s-s/array-input.hbs
+++ b/addon/components/o-s-s/array-input.hbs
@@ -1,11 +1,16 @@
 <div class="fx-1 fx-col fx-gap-px-6">
-  <div class={{this.computedClasses}}
-       ...attributes>
+  <div class={{this.computedClasses}} ...attributes>
     {{#each this.items as |item index|}}
       <OSS::Chip @label={{item}} @onRemove={{fn this.removeItem index}} />
     {{/each}}
-    <Input @value={{this.currentValue}} placeholder={{@placeholder}} autocomplete="off" disabled={{@disabled}}
-           {{on "keydown" this.keyListener}} {{on "blur" this.validateTagOnClickOutside}} />
+    <Input
+      @value={{this.currentValue}}
+      placeholder={{@placeholder}}
+      autocomplete="off"
+      disabled={{@disabled}}
+      {{on "keydown" this.keyListener}}
+      {{on "blur" this.validateTagOnClickOutside}}
+    />
   </div>
   <span class="font-color-error-500">{{@errorMessage}}</span>
 </div>

--- a/addon/components/o-s-s/checkbox.hbs
+++ b/addon/components/o-s-s/checkbox.hbs
@@ -1,7 +1,10 @@
 <div class="upf-checkbox {{this.modifierClasses}}" ...attributes {{on "click" this.updateValue}}>
   <Input
-    @type="checkbox" @checked={{@checked}} disabled={{@disabled}} class="upf-checkbox__input"
-    id={{concat "unchecked-checkbox-" this.elementId}} />
-
+    @type="checkbox"
+    @checked={{@checked}}
+    disabled={{@disabled}}
+    class="upf-checkbox__input"
+    id={{concat "unchecked-checkbox-" this.elementId}}
+  />
   <label for={{concat "unchecked-checkbox-" this.elementId}} class={{this.checkboxClasses}}></label>
 </div>

--- a/addon/components/o-s-s/currency-input.hbs
+++ b/addon/components/o-s-s/currency-input.hbs
@@ -19,9 +19,18 @@
       {{/if}}
     </div>
     {{#unless @onlyCurrency}}
-      <Input class="fx-1" type="number" @value={{this.localValue}} min="0" autocomplete="off"
-             placeholder={{this.placeholder}} disabled={{this.disabled}}
-             {{on "keydown" this.onlyNumeric}} {{on "keyup" this.notifyChanges}} {{on "paste" this.handlePaste}} />
+      <Input
+        @value={{this.localValue}}
+        @type="number"
+        min="0"
+        autocomplete="off"
+        placeholder={{this.placeholder}}
+        disabled={{this.disabled}}
+        class="fx-1"
+        {{on "keydown" this.onlyNumeric}}
+        {{on "keyup" this.notifyChanges}}
+        {{on "paste" this.handlePaste}}
+      />
     {{/unless}}
   </div>
   {{#if @errorMessage}}

--- a/addon/components/o-s-s/input-container.hbs
+++ b/addon/components/o-s-s/input-container.hbs
@@ -16,13 +16,13 @@
       </div>
     {{else}}
       <Input
-        {{on "keyup" (fn this._onChange @value)}}
-        {{on "paste" this.onPaste}}
         @value={{@value}}
         @type={{this.type}}
         placeholder={{@placeholder}}
         disabled={{@disabled}}
         class="upf-input"
+        {{on "keyup" (fn this._onChange @value)}}
+        {{on "paste" this.onPaste}}
       />
     {{/if}}
 

--- a/addon/components/o-s-s/password-input.hbs
+++ b/addon/components/o-s-s/password-input.hbs
@@ -1,12 +1,14 @@
 <div class="fx-col fx-1 fx-gap-px-6">
   <OSS::InputContainer @errorMessage={{this.errorMessage}} ...attributes>
     <:input>
-      <Input @value={{@value}}
-             @type={{this.visibility}}
-             disabled={{@disabled}}
-             placeholder={{this.placeholder}}
-             autocomplete="current-password"
-             {{on "keyup" this.validateInput}} />
+      <Input
+        @value={{@value}}
+        @type={{this.visibility}}
+        disabled={{@disabled}}
+        placeholder={{this.placeholder}}
+        autocomplete="current-password"
+        {{on "keyup" this.validateInput}}
+      />
     </:input>
     <:suffix>
       {{#if @disabled}}

--- a/addon/components/o-s-s/phone-number-input.hbs
+++ b/addon/components/o-s-s/phone-number-input.hbs
@@ -14,8 +14,8 @@
       <span class="fx-row fx-xalign-center phone-prefix">{{@prefix}}</span>
       <Input
         @value={{@number}}
+        @type="tel"
         class="fx-1"
-        type="tel"
         name="telephone"
         placeholder={{this.placeholder}}
         {{on "keydown" this.onlyNumeric}}

--- a/addon/components/o-s-s/slider.hbs
+++ b/addon/components/o-s-s/slider.hbs
@@ -43,7 +43,6 @@
         />
       {{else}}
         <Input
-          class="upf-input"
           @type="number"
           @value={{@value}}
           step={{this.sliderOptions.step}}
@@ -51,6 +50,7 @@
           max={{this.sliderOptions.max}}
           placeholder={{this.currentRangeValue}}
           disabled={{@disabled}}
+          class="upf-input"
           {{on "input" this.onNumberInput}}
         />
       {{/if}}

--- a/addon/components/o-s-s/text-area.hbs
+++ b/addon/components/o-s-s/text-area.hbs
@@ -1,7 +1,13 @@
 <div class="fx-1">
   <div class="oss-textarea-container {{if @errorMessage ' oss-textarea-container--errored'}}" ...attributes>
-    <Textarea {{on "keyup" (fn this._onChange @value)}} @value={{@value}} placeholder={{@placeholder}}
-              disabled={{@disabled}} class="oss-textarea {{this.computedClass}}" rows={{this.rows}} />
+    <Textarea
+      @value={{@value}}
+      placeholder={{@placeholder}}
+      disabled={{@disabled}}
+      rows={{this.rows}}
+      class="oss-textarea {{this.computedClass}}"
+      {{on "keyup" (fn this._onChange @value)}}
+    />
   </div>
   {{#if @errorMessage}}
     <span class="font-color-error-500 margin-top-px-6">{{@errorMessage}}</span>

--- a/app/styles/currency-input.less
+++ b/app/styles/currency-input.less
@@ -16,6 +16,17 @@
       height: 100%;
     }
 
+    input::-webkit-outer-spin-button,
+    input::-webkit-inner-spin-button {
+      -webkit-appearance: none;
+      margin: 0;
+    }
+
+    input[type='number'] {
+      -moz-appearance: textfield;
+      appearance: textfield;
+    }
+
     input {
       border: none;
       outline: none;


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the context of this pull request and its purpose. -->

Related to: #[VEL-4672](https://linear.app/upfluence/issue/VEL-4672/httpsdeprecationsemberjscomv3xtoc-ember-built-in-components-legacy)

### What are the observable changes?
<!-- This question could be adequate with multiple use cases, for example: -->
Fix [deprecation](https://deprecations.emberjs.com/v3.x/#toc_ember-built-in-components-legacy-attribute-arguments)
- Reorder <Inputs/> & <Textarea /> attributes
- Fix missing `@` before `type` attribute
<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->

### Good PR checklist
- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled
