### PR TITLE
Added new component Smart ToggleButtons

### DIFF
--- a/addon/components/o-s-s/smart/toggle-buttons.hbs
+++ b/addon/components/o-s-s/smart/toggle-buttons.hbs
@@ -1,0 +1,18 @@
+<div
+  class={{concat "oss-smart-toggle-buttons-container " (if @disabled "oss-smart-toggle-buttons-container--disabled")}}
+  ...attributes
+>
+  {{#each @toggles as |toggle|}}
+    <div
+      class="oss-smart-toggle-buttons-btn
+        {{if (eq @selectedToggle toggle.value) ' oss-smart-toggle-buttons-btn--selected'}}"
+      role="button"
+      {{on "click" (fn this.onSelectToggle toggle.value)}}
+    >
+      {{#if toggle.icon}}
+        <OSS::Icon @style={{fa-icon-style toggle.icon}} @icon={{fa-icon-value toggle.icon}} />
+      {{/if}}
+      {{toggle.label}}
+    </div>
+  {{/each}}
+</div>

--- a/addon/components/o-s-s/smart/toggle-buttons.stories.js
+++ b/addon/components/o-s-s/smart/toggle-buttons.stories.js
@@ -1,0 +1,79 @@
+import { hbs } from 'ember-cli-htmlbars';
+import { action } from '@storybook/addon-actions';
+
+export default {
+  title: 'Components/OSS::Smart::ToggleButtons',
+  component: 'smart toggle-buttons',
+  argTypes: {
+    toggles: {
+      type: { required: true },
+      description: 'An array of toggles passed to the component',
+      table: {
+        type: {
+          summary: '{value: string, label: string}[]'
+        },
+        defaultValue: { summary: 'undefined' }
+      },
+      control: { type: 'object' }
+    },
+    selectedToggle: {
+      type: { required: true },
+      description: 'Value selected',
+      table: {
+        type: {
+          summary: 'string | null'
+        },
+        defaultValue: { summary: 'undefined' }
+      },
+      control: { type: 'text' }
+    },
+    disabled: {
+      type: { required: false },
+      description: 'Disabled state',
+      table: {
+        type: { summary: 'boolean' },
+        defaultValue: { summary: 'undefined' }
+      },
+      control: { type: 'boolean' }
+    },
+    onSelection: {
+      type: { required: true },
+      description: 'Action triggered when selecting a new toggle',
+      table: {
+        category: 'Actions',
+        type: {
+          summary: 'onSelection(selectedToggle: string): void'
+        }
+      }
+    }
+  },
+  parameters: {
+    docs: {
+      description: {
+        component: 'The smart version of the toggle-buttons item component'
+      },
+      iframeHeight: 200
+    }
+  }
+};
+
+const defaultArgs = {
+  toggles: [
+    { value: 'categories', label: 'Categories' },
+    { value: 'products', label: 'Products' }
+  ],
+  selectedToggle: 'categories',
+  onSelection: action('onSelection'),
+  disabled: false
+};
+const DefaultUsageTemplate = (args) => ({
+  template: hbs`
+    <div style="width: 250px">
+      <OSS::Smart::ToggleButtons @toggles={{this.toggles}} @selectedToggle={{this.selectedToggle}} @onSelection={{this.onSelection}} @disabled={{this.disabled}} />
+    </div>
+  `,
+  context: args
+});
+
+export const Default = DefaultUsageTemplate.bind({});
+Default.args = defaultArgs;

--- a/addon/components/o-s-s/smart/toggle-buttons.ts
+++ b/addon/components/o-s-s/smart/toggle-buttons.ts
@@ -1,0 +1,30 @@
+import { assert } from '@ember/debug';
+import OSSToggleButtons, { type OSSToggleButtonsArgs } from '../toggle-buttons';
+
+interface OSSSmartToggleButtonsArgs extends OSSToggleButtonsArgs {}
+
+export default class OSSSmartToggleButtons extends OSSToggleButtons<OSSToggleButtonsArgs> {
+  constructor(owner: unknown, args: OSSSmartToggleButtonsArgs) {
+    super(owner, args, true);
+
+    assert(
+      '[component][OSS::Smart::ToggleButtons] The @toggles parameter of type Toggle[] is mandatory',
+      this.args.toggles instanceof Array
+    );
+
+    assert(
+      '[component][OSS::Smart::ToggleButtons] The @onSelection parameter of type function is mandatory',
+      typeof args.onSelection === 'function'
+    );
+
+    assert(
+      '[component][OSS::Smart::ToggleButtons] The @selectedToggle parameter of type string or null is mandatory',
+      args.selectedToggle === null || typeof args.selectedToggle === 'string'
+    );
+
+    assert(
+      '[component][OSS::Smart::ToggleButtons] The @selectedToggle parameter should be null or a value of toggles',
+      args.selectedToggle === null || args.toggles.map((item) => item.value).includes(args.selectedToggle)
+    );
+  }
+}

--- a/addon/components/o-s-s/toggle-buttons.ts
+++ b/addon/components/o-s-s/toggle-buttons.ts
@@ -8,16 +8,18 @@ export type Toggle = {
   icon?: string;
 };
 
-interface OSSToggleButtonsArgs {
+export interface OSSToggleButtonsArgs {
   toggles: Toggle[];
   selectedToggle: string | null;
   disabled?: boolean;
   onSelection(selectedToggle: string): void;
 }
 
-export default class OSSToggleButtons extends Component<OSSToggleButtonsArgs> {
-  constructor(owner: unknown, args: OSSToggleButtonsArgs) {
+export default class OSSToggleButtons<T extends OSSToggleButtonsArgs> extends Component<T> {
+  constructor(owner: unknown, args: OSSToggleButtonsArgs, preventDefaultAssertions?: boolean) {
     super(owner, args);
+
+    if (preventDefaultAssertions) return;
 
     assert(
       '[component][OSS::ToggleButtons] The @toggles parameter of type Toggle[] is mandatory',

--- a/app/components/o-s-s/smart/toggle-buttons.js
+++ b/app/components/o-s-s/smart/toggle-buttons.js
@@ -1,0 +1,1 @@
+export { default } from '@upfluence/oss-components/components/o-s-s/smart/toggle-buttons';

--- a/app/styles/core/_colors.less
+++ b/app/styles/core/_colors.less
@@ -2,6 +2,7 @@
   --color-primary-50: #f1f3ff;
   --color-primary-100: #d0d9ff;
   --color-primary-200: #afbbfd;
+  --color-primary-300: #8692fd;
   --color-primary-400: #535efc;
   --color-primary-500: #0d0de6;
   --color-primary-600: #0505b8;

--- a/app/styles/molecules/toggle-buttons.less
+++ b/app/styles/molecules/toggle-buttons.less
@@ -35,3 +35,41 @@
     }
   }
 }
+
+.oss-smart-toggle-buttons-container {
+  .border-radius-lg;
+  .background-color-primary-50;
+
+  display: flex;
+  flex: 1;
+  height: 30px;
+  padding: 2px;
+  color: var(--color-primary-300);
+
+  .oss-smart-toggle-buttons-btn {
+    .border-radius-lg;
+
+    display: flex;
+    flex: 1;
+    justify-content: center;
+    align-items: center;
+    gap: var(--spacing-px-6);
+    padding: var(--spacing-px-6) var(--spacing-px-12);
+    transition: background-color 300ms ease-in-out;
+
+    &--selected {
+      background-color: var(--color-primary-400);
+      color: var(--color-white);
+      box-shadow: var(--box-shadow-xs);
+    }
+  }
+
+  &--disabled {
+    .oss-smart-toggle-buttons-btn {
+      &--selected {
+        background-color: var(--color-primary-400);
+        opacity: 0.5;
+      }
+    }
+  }
+}

--- a/tests/dummy/app/controllers/smart.ts
+++ b/tests/dummy/app/controllers/smart.ts
@@ -1,0 +1,24 @@
+import Controller from '@ember/controller';
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+
+export default class Smart extends Controller {
+  @tracked selectedToggle: string = 'first';
+  @tracked selectedToggleTwo: string = 'second';
+  @tracked toggles: { value: string; label: string }[] = [
+    {
+      value: 'first',
+      label: 'First'
+    },
+    {
+      value: 'second',
+      label: 'Second'
+    }
+  ];
+
+  @action
+  triggerSelection(value: string): void {
+    console.log('selected toggle value : ', value);
+    this.selectedToggle = value;
+  }
+}

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -12,4 +12,5 @@ Router.map(function () {
   this.route('data');
   this.route('overlay');
   this.route('extra');
+  this.route('smart');
 });

--- a/tests/dummy/app/routes/smart.ts
+++ b/tests/dummy/app/routes/smart.ts
@@ -1,0 +1,3 @@
+import Route from '@ember/routing/route';
+
+export default class Smart extends Route {}

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -32,6 +32,11 @@
         @link="extra"
       />
       <OSS::Layout::Sidebar::Item
+        @icon="far fa-brain-circuit"
+        class={{if (eq this.router.currentRouteName "smart") "active"}}
+        @link="smart"
+      />
+      <OSS::Layout::Sidebar::Item
         @icon="far fa-lock"
         @locked={{true}}
         @defaultAction={{fn this.redirectTo "credit-card"}}

--- a/tests/dummy/app/templates/smart.hbs
+++ b/tests/dummy/app/templates/smart.hbs
@@ -1,0 +1,32 @@
+<div class="fx-col fx-gap-px-12 padding-px-18">
+  <div class="page-title-container">
+    <span class="font-size-h2 font-weight-semibold">Smart</span>
+    <span class="font-color-gray-500">Components that look like another component and act like another component but
+      aren't said component</span>
+    <span class="font-color-gray-500 font-size-xs text-style-italic">(also they might be smarter than you who knows)</span>
+  </div>
+
+  <div
+    class="fx-col fx-1 background-color-white border border-color-default border-radius-md padding-px-12 fx-gap-px-12"
+  >
+    <div class="font-size-md font-weight-semibold">
+      Smart toggle buttons
+    </div>
+    <div class="fx-row fx-gap-px-24 fx-xalign-center">
+      <div class="fx-row fx-xalign-start fx-gap-px-10">
+        <OSS::Smart::ToggleButtons
+          @toggles={{this.toggles}}
+          @selectedToggle={{this.selectedToggle}}
+          @onSelection={{this.triggerSelection}}
+        />
+        <OSS::Smart::ToggleButtons
+          @toggles={{this.toggles}}
+          @selectedToggle={{this.selectedToggleTwo}}
+          @onSelection={{this.triggerSelection}}
+          @disabled={{true}}
+        />
+      </div>
+    </div>
+  </div>
+
+</div>


### PR DESCRIPTION
### What does this PR do?
Added new component Smart ToggleButtons (with tests & documentation)

Related to: #[dra-3045](https://linear.app/upfluence/issue/DRA-3045/oss-components-smarttogglebuttons)

### What are the observable changes?
![Screenshot from 2025-06-09 16-57-03](https://github.com/user-attachments/assets/200bcdef-5033-4e84-ade7-6ae7e91d229f)

### Good PR checklist
- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [x] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled
