### PR TITLE
OSS::ExpandableBadge & OSS::StackContainer

### DIFF
--- a/addon/components/o-s-s/badge.ts
+++ b/addon/components/o-s-s/badge.ts
@@ -1,15 +1,15 @@
 import Component from '@glimmer/component';
 import { assert } from '@ember/debug';
 
-type SizeType = 'sm' | 'md' | 'lg';
-type SizeDefType = { [key in SizeType]: string };
-const SizeDefinition: SizeDefType = {
+export type SizeType = 'sm' | 'md' | 'lg';
+export type SizeDefType = { [key in SizeType]: string };
+export const SizeDefinition: SizeDefType = {
   sm: 'upf-badge--size-sm',
   md: 'upf-badge--size-md',
   lg: 'upf-badge--size-lg'
 };
 
-type SkinType =
+export type SkinType =
   | 'primary'
   | 'success'
   | 'alert'
@@ -21,7 +21,7 @@ type SkinType =
   | 'xtd-blue'
   | 'xtd-violet'
   | 'xtd-smart';
-type SkinDefType = { [key in SkinType]: string };
+export type SkinDefType = { [key in SkinType]: string };
 export const SkinDefinition: SkinDefType = {
   primary: 'upf-badge--primary',
   success: 'upf-badge--success',
@@ -36,7 +36,7 @@ export const SkinDefinition: SkinDefType = {
   'xtd-smart': 'upf-badge--extended-smart'
 };
 
-interface OSSBadgeArgs {
+export interface OSSBadgeArgs {
   icon: string;
   image: string;
   text: string;
@@ -45,9 +45,11 @@ interface OSSBadgeArgs {
   size?: SizeType;
 }
 
-export default class OSSBadge extends Component<OSSBadgeArgs> {
-  constructor(owner: unknown, args: OSSBadgeArgs) {
+export default class OSSBadge<T extends OSSBadgeArgs> extends Component<T> {
+  constructor(owner: unknown, args: OSSBadgeArgs, bypassAssertions: boolean = false) {
     super(owner, args);
+
+    if (bypassAssertions) return;
 
     const contentArguments = [args.icon, args.image, args.text].filter((arg: string) => arg);
 

--- a/addon/components/o-s-s/expandable-badge.hbs
+++ b/addon/components/o-s-s/expandable-badge.hbs
@@ -1,0 +1,19 @@
+<div
+  class={{this.computedClass}}
+  {{on "mouseenter" this.expand}}
+  {{on "mouseleave" this.collapse}}
+  {{on "touchend" this.handleExpansion}}
+  role="button"
+  ...attributes
+>
+  {{#if @icon}}
+    <OSS::Icon @style={{fa-icon-style @icon}} @icon={{fa-icon-value @icon}} class={{@fontColor}}/>
+  {{else if @image}}
+    <img src={{@image}} alt={{t "oss-components.badge.image_alt"}} />
+  {{else if @flag}}
+    <div class="fflag fflag-{{this.flagCountry}} ff-sm ff-round"></div>
+  {{else}}
+    <span class="upf-badge__text">{{@text}}</span>
+  {{/if}}
+  <span class="upf-expandable-badge__label {{@fontColor}}">{{@expandedLabel}}</span>
+</div>

--- a/addon/components/o-s-s/expandable-badge.hbs
+++ b/addon/components/o-s-s/expandable-badge.hbs
@@ -7,7 +7,7 @@
   ...attributes
 >
   {{#if @icon}}
-    <OSS::Icon @style={{fa-icon-style @icon}} @icon={{fa-icon-value @icon}} class={{@fontColor}}/>
+    <OSS::Icon @style={{fa-icon-style @icon}} @icon={{fa-icon-value @icon}} class={{@fontColorClass}}/>
   {{else if @image}}
     <img src={{@image}} alt={{t "oss-components.badge.image_alt"}} />
   {{else if @flag}}
@@ -15,5 +15,5 @@
   {{else}}
     <span class="upf-badge__text">{{@text}}</span>
   {{/if}}
-  <span class="upf-expandable-badge__label {{@fontColor}}">{{@expandedLabel}}</span>
+  <span class="upf-expandable-badge__label {{@fontColorClass}}">{{@expandedLabel}}</span>
 </div>

--- a/addon/components/o-s-s/expandable-badge.stories.js
+++ b/addon/components/o-s-s/expandable-badge.stories.js
@@ -1,0 +1,132 @@
+import { hbs } from 'ember-cli-htmlbars';
+
+const SizeTypes = ['sm', 'md', 'lg'];
+const SkinTypes = [
+  'primary',
+  'success',
+  'alert',
+  'error',
+  'xtd-cyan',
+  'xtd-orange',
+  'xtd-yellow',
+  'xtd-lime',
+  'xtd-blue',
+  'xtd-violet',
+  'xtd-smart'
+];
+
+export default {
+  title: 'Components/OSS::ExpandableBadge',
+  component: 'expandable-badge',
+  argTypes: {
+    size: {
+      description: 'Adjust the size of the badge',
+      table: {
+        type: {
+          summary: SizeTypes.join('|')
+        },
+        defaultValue: { summary: 'md' }
+      },
+      options: SizeTypes,
+      control: { type: 'select' }
+    },
+    skin: {
+      description: 'Adjust the skin of the badge',
+      table: {
+        type: {
+          summary: SkinTypes.join('|')
+        },
+        defaultValue: { summary: 'undefined' }
+      },
+      options: SkinTypes,
+      control: { type: 'select' }
+    },
+    plain: {
+      description: 'Displays the badge with a plain background',
+      table: {
+        type: { summary: 'boolean' },
+        defaultValue: { summary: 'false' }
+      },
+      control: {
+        type: 'boolean'
+      }
+    },
+    icon: {
+      description: 'Font Awesome class, for example: far fa-envelope-open',
+      table: {
+        type: { summary: 'string' },
+        defaultValue: { summary: 'undefined' }
+      },
+      control: { type: 'text' }
+    },
+    image: {
+      description: 'URL of an image',
+      table: {
+        type: { summary: 'string' },
+        defaultValue: { summary: 'undefined' }
+      },
+      control: { type: 'text' }
+    },
+    text: {
+      description: 'Text to display inside the badge',
+      table: {
+        type: { summary: 'string' },
+        defaultValue: { summary: 'undefined' }
+      },
+      control: { type: 'text' }
+    },
+    expandedLabel: {
+      description: 'Label for the expandable badge',
+      table: {
+        type: { summary: 'string' },
+        defaultValue: { summary: 'undefined' }
+      },
+      control: { type: 'text' },
+      type: { required: true }
+    }
+  },
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'A badge component with the ability to expand to display additional content. On desktop, it expands on hover whereas on mobile, it expands on tap.'
+      }
+    }
+  }
+};
+
+const defaultArgs = {
+  size: 'md',
+  expandedLabel: 'Content',
+  icon: undefined,
+  image: undefined,
+  text: undefined,
+  plain: false,
+  skin: undefined
+};
+
+const Template = (args) => ({
+  template: hbs`
+    <OSS::ExpandableBadge @expandedLabel={{this.expandedLabel}} @image={{this.image}} @icon={{this.icon}} @text={{this.text}}
+                          @size={{this.size}} @skin={{this.skin}} @plain={{this.plain}} />
+  `,
+  context: args
+});
+
+export const WithIcon = Template.bind({});
+WithIcon.args = {
+  ...defaultArgs,
+  ...{ icon: 'fas fa-volume-up' }
+};
+
+export const WithImage = Template.bind({});
+WithImage.args = {
+  ...defaultArgs,
+  ...{ image: '/@upfluence/oss-components/assets/heart.svg' }
+};
+
+export const WithText = Template.bind({});
+WithText.args = {
+  ...defaultArgs,
+  ...{ text: '2x' }
+};

--- a/addon/components/o-s-s/expandable-badge.ts
+++ b/addon/components/o-s-s/expandable-badge.ts
@@ -7,7 +7,7 @@ import { next } from '@ember/runloop';
 interface OSSExpandableBadgeComponentSignature extends OSSBadgeArgs {
   expandedLabel: string;
   flag?: string;
-  fontColor?: string;
+  fontColorClass?: string;
 }
 
 export default class OSSExpandableBadgeComponent extends OSSBadge<OSSExpandableBadgeComponentSignature> {

--- a/addon/components/o-s-s/expandable-badge.ts
+++ b/addon/components/o-s-s/expandable-badge.ts
@@ -1,0 +1,93 @@
+import { tracked } from '@glimmer/tracking';
+import OSSBadge, { SizeDefinition, SkinDefinition, type OSSBadgeArgs, type SizeType, type SkinType } from './badge';
+import { action } from '@ember/object';
+import { assert } from '@ember/debug';
+import { next } from '@ember/runloop';
+
+interface OSSExpandableBadgeComponentSignature extends OSSBadgeArgs {
+  expandedLabel: string;
+  flag?: string;
+  fontColor?: string;
+}
+
+export default class OSSExpandableBadgeComponent extends OSSBadge<OSSExpandableBadgeComponentSignature> {
+  @tracked expanded: boolean = false;
+
+  constructor(owner: unknown, args: OSSExpandableBadgeComponentSignature) {
+    super(owner, args, true);
+
+    const contentArguments = [args.icon, args.image, args.flag, args.text].filter((arg: string) => arg);
+
+    assert(
+      `[component][OSS::ExpandableBadge] One of @icon, @image, @flag or @text arguments is mandatory. You passed ${contentArguments.length} arguments`,
+      contentArguments.length === 1
+    );
+    assert(
+      `[component][OSS::ExpandableBadge] The @expandableLabel argument is mandatory.`,
+      args.expandedLabel !== undefined
+    );
+  }
+
+  get flagCountry(): string {
+    return this.args.flag!.toUpperCase();
+  }
+
+  override get sizeClass(): string {
+    const size: SizeType = this.args.size || 'md';
+
+    assert(
+      `[component][OSS::ExpandableBadge] Unknown size. Available sizes are: ${Object.keys(SizeDefinition).join(', ')}`,
+      Object.keys(SizeDefinition).includes(size as SizeType)
+    );
+
+    return SizeDefinition[size as SizeType];
+  }
+
+  override get skinClass(): string {
+    const skin: SkinType | undefined = this.args?.skin;
+
+    if (!skin) return '';
+
+    assert(
+      `[component][OSS::ExpandableBadge] Unknown skin. Available skins are: ${Object.keys(SkinDefinition).join(', ')}`,
+      Object.keys(SkinDefinition).includes(skin as SkinType)
+    );
+
+    return SkinDefinition[skin as SkinType];
+  }
+
+  override get computedClass(): string {
+    const classes = ['upf-badge', 'upf-expandable-badge'];
+
+    [this.sizeClass, this.skinClass].forEach((klass) => {
+      classes.push(klass);
+    });
+
+    if (this.args.plain) {
+      classes.push('upf-badge--plain');
+    }
+
+    if (this.expanded) {
+      classes.push('upf-expandable-badge--expanded');
+    }
+
+    return classes.join(' ');
+  }
+
+  @action
+  handleExpansion(): void {
+    this.expanded = !this.expanded;
+  }
+
+  @action
+  expand(): void {
+    this.expanded = true;
+  }
+
+  @action
+  collapse(): void {
+    next(() => {
+      this.expanded = false;
+    });
+  }
+}

--- a/addon/components/o-s-s/stack-container.hbs
+++ b/addon/components/o-s-s/stack-container.hbs
@@ -1,0 +1,3 @@
+<div class={{this.computedClass}} ...attributes {{did-insert this.initComponent}}>
+  {{yield}}
+</div>

--- a/addon/components/o-s-s/stack-container.stories.js
+++ b/addon/components/o-s-s/stack-container.stories.js
@@ -1,0 +1,97 @@
+import { hbs } from 'ember-cli-htmlbars';
+
+export default {
+  title: 'Components/OSS::StackContainer',
+  component: 'stack-container',
+  argTypes: {
+    direction: {
+      description: 'Whether the stack is displayed in a column or row. Default is row.',
+      table: {
+        type: {
+          summary: 'string'
+        },
+        defaultValue: { summary: 'row' }
+      },
+      options: ['row', 'column'],
+      control: { type: 'select' }
+    },
+    style: {
+      description: 'Whether to display the next items under the previous ones or over. Default is under.',
+      table: {
+        type: {
+          summary: 'string'
+        },
+        defaultValue: { summary: 'under' }
+      },
+      options: ['under', 'over'],
+      control: { type: 'select' }
+    },
+    pxMargin: {
+      description:
+        'Horizontal margin between items in the stack. The passed value is always transformed to be negative. Default is -6px',
+      table: {
+        type: {
+          summary: 'string'
+        },
+        defaultValue: { summary: '-6px' }
+      },
+      control: { type: 'text' }
+    },
+    bringToFrontOnHover: {
+      description: 'Whether to bring the hovered item to the front. Default is false.',
+      table: {
+        type: {
+          summary: 'boolean'
+        },
+        defaultValue: { summary: false }
+      },
+      control: { type: 'boolean' }
+    },
+    subElementClass: {
+      description: 'Class to be applied to each sub-element in the stack.',
+      table: {
+        type: {
+          summary: 'string'
+        },
+        defaultValue: { summary: 'undefined' }
+      },
+      control: { type: 'text' }
+    }
+  },
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'A stack container component that allows stacking elements in a row or column with customizable styles.'
+      }
+    }
+  }
+};
+
+const defaultArgs = {
+  direction: 'row',
+  style: 'under',
+  pxMargin: '-6px',
+  bringToFrontOnHover: false,
+  subElementClass: undefined
+};
+
+const DefaultUsageTemplate = (args) => ({
+  template: hbs`
+    <OSS::StackContainer
+      @direction={{this.direction}}
+      @style={{this.style}}
+      @pxMargin={{this.pxMargin}}
+      @bringToFrontOnHover={{this.bringToFrontOnHover}}
+      @subElementClass={{this.subElementClass}}
+    >
+      <div class="stack-item" style="border-radius: 8px; color: black; background-color: white; border: 1px solid blue">Item 1</div>
+      <div class="stack-item" style="border-radius: 8px; color: black; background-color: pink; border: 1px solid blue">Item 2</div>
+      <div class="stack-item" style="border-radius: 8px; color: black; background-color: yellow; border: 1px solid blue">Item 3</div>
+    </OSS::StackContainer>
+  `,
+  context: args
+});
+
+export const BasicUsage = DefaultUsageTemplate.bind({});
+BasicUsage.args = defaultArgs;

--- a/addon/components/o-s-s/stack-container.ts
+++ b/addon/components/o-s-s/stack-container.ts
@@ -1,0 +1,91 @@
+import { action } from '@ember/object';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+
+interface OSSStackContainerComponentSignature {
+  direction: 'row' | 'column';
+  style: 'over' | 'under';
+  pxMargin: string;
+  bringToFrontOnHover?: boolean;
+  subElementClass?: string;
+}
+
+const DEFAULT_MARGIN = '-6px';
+
+export default class OSSStackContainerComponent extends Component<OSSStackContainerComponentSignature> {
+  @tracked declare element: HTMLElement;
+  @tracked declare subElements: Element[];
+
+  get computedClass(): string {
+    const classes = ['oss-stack-container'];
+
+    classes.push(`oss-stack-container--${this.direction}`);
+    classes.push(`oss-stack-container--style-${this.style}`);
+
+    return classes.join(' ');
+  }
+
+  get direction(): string {
+    return this.args.direction ?? 'row';
+  }
+
+  get style(): string {
+    return this.args.style ?? 'under';
+  }
+
+  get margin(): string {
+    return this.args.pxMargin ? this.ensureNegativeMargin(this.args.pxMargin) : DEFAULT_MARGIN;
+  }
+
+  @action
+  initComponent(element: HTMLElement): void {
+    this.element = element;
+
+    this.subElements = Array.from(this.element.children);
+    if (this.style === 'over') {
+      this.subElements.reverse();
+    }
+    this.applyStylesToSubElements();
+    if (this.args.bringToFrontOnHover) {
+      this.bringToFront();
+    }
+  }
+
+  @action
+  applyStylesToSubElements(): void {
+    this.subElements.forEach((child, index) => {
+      (child as HTMLElement).style.zIndex = index.toString();
+      if (this.args.subElementClass) {
+        (child as HTMLElement).classList.add(this.args.subElementClass);
+      }
+
+      if (this.args.style === 'under' && index === this.subElements.length - 1) return;
+      if (this.args.style === 'over' && index === 0) return;
+      if (this.direction === 'row') {
+        (child as HTMLElement).style.marginRight = this.margin;
+      } else {
+        (child as HTMLElement).style.marginBottom = this.margin;
+      }
+    });
+  }
+
+  @action
+  bringToFront(): void {
+    this.subElements.forEach((child) => {
+      child.addEventListener('mouseenter', () => {
+        (child as HTMLElement).style.zIndex = this.subElements.length.toString();
+      });
+      child.addEventListener('mouseleave', () => {
+        (child as HTMLElement).style.zIndex = Array.from(this.element.children).indexOf(child).toString();
+      });
+    });
+  }
+
+  private ensureNegativeMargin(margin: string): string {
+    const parsedMargin = parseInt(margin);
+    if (isNaN(parsedMargin)) {
+      return DEFAULT_MARGIN;
+    }
+    return `-${Math.abs(parsedMargin)}px`;
+  }
+}

--- a/app/components/o-s-s/expandable-badge.js
+++ b/app/components/o-s-s/expandable-badge.js
@@ -1,0 +1,1 @@
+export { default } from '@upfluence/oss-components/components/o-s-s/expandable-badge';

--- a/app/components/o-s-s/stack-container.js
+++ b/app/components/o-s-s/stack-container.js
@@ -1,0 +1,1 @@
+export { default } from '@upfluence/oss-components/components/o-s-s/stack-container';

--- a/app/styles/atoms/expandable-badge.less
+++ b/app/styles/atoms/expandable-badge.less
@@ -1,0 +1,75 @@
+.upf-expandable-badge {
+  border-radius: 999px;
+  color: var(--color-gray-900);
+
+  &--expanded.upf-badge--size-sm {
+    &:not(:has(img)) {
+      padding: var(--spacing-px-3);
+    }
+    &:has(img) {
+      padding-right: var(--spacing-px-6);
+    }
+
+    img {
+      width: 22px;
+      height: 22px;
+      border-radius: 50%;
+    }
+  }
+
+  &--expanded.upf-badge--size-md {
+    &:not(:has(img)) {
+      padding: var(--spacing-px-12);
+    }
+    &:has(img) {
+      padding-right: var(--spacing-px-12);
+    }
+
+    img {
+      width: 34px;
+      height: 34px;
+      border-radius: 50%;
+    }
+  }
+
+  &--expanded.upf-badge--size-lg {
+    &:not(:has(img)) {
+      padding: var(--spacing-px-18);
+    }
+    &:has(img) {
+      padding-right: var(--spacing-px-12);
+    }
+
+    img {
+      width: 46px;
+      height: 46px;
+      border-radius: 50%;
+    }
+  }
+
+  &--expanded {
+    &:not(:has(img)) {
+      padding: var(--spacing-px-12);
+    }
+
+    width: fit-content;
+    // min-width: fit-content;
+    transition: width 0.3s linear;
+
+    .upf-expandable-badge__label {
+      opacity: 1;
+      width: auto;
+      margin-left: var(--spacing-px-6);
+      transition: opacity 0.3s linear, width 0.3s linear, margin 0.3s linear;
+    }
+  }
+
+  &__label {
+    display: inline-block;
+    opacity: 0;
+    width: 0;
+    margin-left: 0;
+    overflow: hidden;
+    vertical-align: middle;
+  }
+}

--- a/app/styles/atoms/expandable-badge.less
+++ b/app/styles/atoms/expandable-badge.less
@@ -54,7 +54,7 @@
     }
 
     width: fit-content;
-    // min-width: fit-content;
+    min-width: fit-content;
     transition: width 0.3s linear;
 
     .upf-expandable-badge__label {

--- a/app/styles/atoms/expandable-badge.less
+++ b/app/styles/atoms/expandable-badge.less
@@ -1,6 +1,7 @@
 .upf-expandable-badge {
   border-radius: 999px;
   color: var(--color-gray-900);
+  white-space: nowrap;
 
   &--expanded.upf-badge--size-sm {
     &:not(:has(img)) {

--- a/app/styles/molecules/stack-container.less
+++ b/app/styles/molecules/stack-container.less
@@ -1,0 +1,12 @@
+.oss-stack-container {
+  position: relative;
+  display: flex;
+  
+  &--row {
+    flex-direction: row;
+  }
+
+  &--column {
+    flex-direction: column;
+  }
+}

--- a/app/styles/oss-components.less
+++ b/app/styles/oss-components.less
@@ -54,6 +54,7 @@
 @import 'molecules/togglable-section';
 @import 'molecules/password-input';
 @import 'molecules/avatar-group';
+@import 'molecules/stack-container';
 @import 'organisms/table';
 @import 'organisms/dialog';
 @import 'organisms/modal-dialog';

--- a/app/styles/oss-components.less
+++ b/app/styles/oss-components.less
@@ -30,6 +30,7 @@
 @import 'atoms/attribute';
 @import 'atoms/button';
 @import 'atoms/badge';
+@import 'atoms/expandable-badge';
 @import 'atoms/chip';
 @import 'atoms/avatar';
 @import 'atoms/copy';

--- a/tests/dummy/app/templates/visual.hbs
+++ b/tests/dummy/app/templates/visual.hbs
@@ -328,6 +328,76 @@
     class="fx-col fx-1 background-color-white border border-color-default border-radius-md padding-px-12 fx-gap-px-12"
   >
     <div class="font-size-md font-weight-semibold">
+      Expandable badge
+    </div>
+    <div class="fx-row fx-xalign-start fx-gap-px-6">
+      <div class="fx-row fx-gap-px-12 fx-xalign-center">
+        <OSS::ExpandableBadge @expandedLabel="content" @icon="fas fa-box-open" @size="lg" />
+        <OSS::ExpandableBadge @expandedLabel="content" @icon="fas fa-box-open" />
+        <OSS::ExpandableBadge @expandedLabel="content" @size="md" @icon="fas fa-box-open" />
+        <OSS::ExpandableBadge @expandedLabel="content" @size="sm" @icon="fas fa-box-open" />
+      </div>
+    </div>
+    <div class="fx-row fx-xalign-start fx-gap-px-6">
+      <OSS::ExpandableBadge @expandedLabel="content" @icon="fas fa-box-open" @skin="primary" />
+      <OSS::ExpandableBadge @expandedLabel="content" @icon="fas fa-box-open" @skin="primary" @plain={{true}} />
+      <OSS::ExpandableBadge @expandedLabel="content" @icon="fas fa-box-open" @skin="success" />
+      <OSS::ExpandableBadge @expandedLabel="content" @icon="fas fa-box-open" @skin="success" @plain={{true}} />
+      <OSS::ExpandableBadge @expandedLabel="content" @icon="fas fa-box-open" @skin="alert" />
+      <OSS::ExpandableBadge @expandedLabel="content" @icon="fas fa-box-open" @skin="alert" @plain={{true}} />
+      <OSS::ExpandableBadge @expandedLabel="content" @icon="fas fa-box-open" @skin="error" />
+      <OSS::ExpandableBadge @expandedLabel="content" @icon="fas fa-box-open" @skin="error" @plain={{true}} />
+      <OSS::ExpandableBadge @expandedLabel="content" @icon="fas fa-box-open" @skin="xtd-orange" />
+      <OSS::ExpandableBadge @expandedLabel="content" @icon="fas fa-box-open" @skin="xtd-orange" @plain={{true}} />
+      <OSS::ExpandableBadge @expandedLabel="content" @icon="fas fa-box-open" @skin="xtd-yellow" />
+      <OSS::ExpandableBadge @expandedLabel="content" @icon="fas fa-box-open" @skin="xtd-yellow" @plain={{true}} />
+      <OSS::ExpandableBadge @expandedLabel="content" @icon="fas fa-box-open" @skin="xtd-lime" />
+      <OSS::ExpandableBadge @expandedLabel="content" @icon="fas fa-box-open" @skin="xtd-lime" @plain={{true}} />
+      <OSS::ExpandableBadge @expandedLabel="content" @icon="fas fa-box-open" @skin="xtd-cyan" />
+      <OSS::ExpandableBadge @expandedLabel="content" @icon="fas fa-box-open" @skin="xtd-cyan" @plain={{true}} />
+      <OSS::ExpandableBadge @expandedLabel="content" @icon="fas fa-box-open" @skin="xtd-blue" />
+      <OSS::ExpandableBadge @expandedLabel="content" @icon="fas fa-box-open" @skin="xtd-blue" @plain={{true}} />
+      <OSS::ExpandableBadge @expandedLabel="content" @icon="fas fa-box-open" @skin="xtd-violet" />
+      <OSS::ExpandableBadge @expandedLabel="content" @icon="fas fa-box-open" @skin="xtd-violet" @plain={{true}} />
+    </div>
+    <div class="fx-row fx-xalign-start fx-gap-px-6">
+      <OSS::ExpandableBadge @icon="fas fa-user-bounty-hunter" @size="md" @expandedLabel="The Mandalorian" />
+      <OSS::ExpandableBadge @icon="fas fa-robot-astromech" @size="md" @expandedLabel="R2-D2" />
+      <OSS::ExpandableBadge
+        @icon="fab fa-pinterest"
+        @size="md"
+        @expandedLabel="pinterest"
+        @fontColor="font-color-pinterest-500"
+        class="font-color-pinterest-500"
+      />
+    </div>
+    <div class="fx-row fx-xalign-start fx-gap-px-6">
+      <OSS::ExpandableBadge @flag="us" @expandedLabel="United-States" />
+      <OSS::ExpandableBadge @flag="fr" @expandedLabel="France" />
+      <OSS::ExpandableBadge @flag="ca" @expandedLabel="Canada" />
+    </div>
+    <div class="fx-row fx-gap-px-12 fx-xalign-center">
+      <OSS::ExpandableBadge
+        @expandedLabel="content"
+        @image="https://reachr-assets.s3.us-west-2.amazonaws.com/influencer-server/influencer/7219681.png"
+        @size="lg"
+      />
+      <OSS::ExpandableBadge
+        @expandedLabel="content"
+        @image="https://reachr-assets.s3.us-west-2.amazonaws.com/influencer-server/influencer/7219681.png"
+      />
+      <OSS::ExpandableBadge
+        @expandedLabel="content"
+        @image="https://reachr-assets.s3.us-west-2.amazonaws.com/influencer-server/influencer/7219681.png"
+        @size="sm"
+      />
+    </div>
+  </div>
+
+  <div
+    class="fx-col fx-1 background-color-white border border-color-default border-radius-md padding-px-12 fx-gap-px-12"
+  >
+    <div class="font-size-md font-weight-semibold">
       Icon
     </div>
     <div class="fx-row fx-gap-px-24 fx-xalign-center">
@@ -600,10 +670,14 @@
     </div>
     <div class="fx-row fx-gap-px-24 fx-xalign-center">
       <div class="fx-row fx-xalign-center fx-gap-px-12">
-        Primary: <OSS::PulsatingDot />
-        Success: <OSS::PulsatingDot @skin="success" />
-        Error: <OSS::PulsatingDot @skin="error" />
-        Warning: <OSS::PulsatingDot @skin="warning" />
+        Primary:
+        <OSS::PulsatingDot />
+        Success:
+        <OSS::PulsatingDot @skin="success" />
+        Error:
+        <OSS::PulsatingDot @skin="error" />
+        Warning:
+        <OSS::PulsatingDot @skin="warning" />
       </div>
     </div>
   </div>

--- a/tests/dummy/app/templates/visual.hbs
+++ b/tests/dummy/app/templates/visual.hbs
@@ -238,6 +238,61 @@
   <div
     class="fx-col fx-1 background-color-white border border-color-default border-radius-md padding-px-12 fx-gap-px-12"
   >
+    <div class="font-size-md font-weight-semibold">
+      Stack container
+    </div>
+    <div class="fx-row fx-xalign-start fx-gap-px-18">
+      <div class="fx-col fx-xalign-start fx-gap-px-12">
+        <span>@style="under"</span>
+        <OSS::StackContainer @direction="row" @style="under" @pxMargin="6px">
+          <OSS::ExpandableBadge @flag="us" @expandedLabel="United-States" />
+          <OSS::ExpandableBadge @flag="fr" @expandedLabel="France" />
+          <OSS::ExpandableBadge @flag="ca" @expandedLabel="Canada" />
+          <OSS::ExpandableBadge @flag="de" @expandedLabel="Germany" />
+        </OSS::StackContainer>
+      </div>
+      <div class="fx-col fx-xalign-start fx-gap-px-12">
+        <span>@style="over"</span>
+        <OSS::StackContainer @direction="row" @style="over">
+          <OSS::ExpandableBadge @flag="us" @expandedLabel="United-States" />
+          <OSS::ExpandableBadge @flag="fr" @expandedLabel="France" />
+          <OSS::ExpandableBadge @flag="ca" @expandedLabel="Canada" />
+          <OSS::ExpandableBadge @flag="de" @expandedLabel="Germany" />
+        </OSS::StackContainer>
+      </div>
+      <div class="fx-col fx-xalign-start fx-gap-px-12">
+        <span>@direction="column"</span>
+        <div class="fx-row fx-xalign-start fx-gap-px-12">
+          <OSS::StackContainer @direction="column" @style="over">
+            <OSS::ExpandableBadge @flag="us" @expandedLabel="United-States" />
+            <OSS::ExpandableBadge @flag="fr" @expandedLabel="France" />
+            <OSS::ExpandableBadge @flag="ca" @expandedLabel="Canada" />
+            <OSS::ExpandableBadge @flag="de" @expandedLabel="Germany" />
+          </OSS::StackContainer>
+          <OSS::StackContainer @direction="column" @style="under">
+            <OSS::ExpandableBadge @flag="us" @expandedLabel="United-States" />
+            <OSS::ExpandableBadge @flag="fr" @expandedLabel="France" />
+            <OSS::ExpandableBadge @flag="ca" @expandedLabel="Canada" />
+            <OSS::ExpandableBadge @flag="de" @expandedLabel="Germany" />
+          </OSS::StackContainer>
+        </div>
+      </div>
+      <div class="fx-col fx-xalign-start fx-gap-px-12">
+        <span>Usage with random component and @bringToFrontOnHover={{true}}</span>
+        <OSS::StackContainer @pxMargin="-30px" @bringToFrontOnHover={{true}}>
+          <OSS::Button @skin="xtd-orange" @label="Extended orange" @icon="fas fa-plus" @size="md" />
+          <OSS::Button @skin="xtd-yellow" @label="Extended yellow" @icon="fas fa-plus" @size="md" />
+          <OSS::Button @skin="xtd-lime" @label="Extended lime" @icon="fas fa-plus" @size="md" />
+          <OSS::Button @skin="xtd-cyan" @label="Extended Cyan" @icon="fas fa-plus" @size="md" />
+          <OSS::Button @skin="xtd-blue" @label="Extended blue" @icon="fas fa-plus" @size="md" />
+        </OSS::StackContainer>
+      </div>
+    </div>
+  </div>
+
+  <div
+    class="fx-col fx-1 background-color-white border border-color-default border-radius-md padding-px-12 fx-gap-px-12"
+  >
 
     <div class="font-size-md font-weight-semibold">
       Avatar group
@@ -360,22 +415,6 @@
       <OSS::ExpandableBadge @expandedLabel="content" @icon="fas fa-box-open" @skin="xtd-violet" />
       <OSS::ExpandableBadge @expandedLabel="content" @icon="fas fa-box-open" @skin="xtd-violet" @plain={{true}} />
     </div>
-    <div class="fx-row fx-xalign-start fx-gap-px-6">
-      <OSS::ExpandableBadge @icon="fas fa-user-bounty-hunter" @size="md" @expandedLabel="The Mandalorian" />
-      <OSS::ExpandableBadge @icon="fas fa-robot-astromech" @size="md" @expandedLabel="R2-D2" />
-      <OSS::ExpandableBadge
-        @icon="fab fa-pinterest"
-        @size="md"
-        @expandedLabel="pinterest"
-        @fontColor="font-color-pinterest-500"
-        class="font-color-pinterest-500"
-      />
-    </div>
-    <div class="fx-row fx-xalign-start fx-gap-px-6">
-      <OSS::ExpandableBadge @flag="us" @expandedLabel="United-States" />
-      <OSS::ExpandableBadge @flag="fr" @expandedLabel="France" />
-      <OSS::ExpandableBadge @flag="ca" @expandedLabel="Canada" />
-    </div>
     <div class="fx-row fx-gap-px-12 fx-xalign-center">
       <OSS::ExpandableBadge
         @expandedLabel="content"
@@ -390,6 +429,17 @@
         @expandedLabel="content"
         @image="https://reachr-assets.s3.us-west-2.amazonaws.com/influencer-server/influencer/7219681.png"
         @size="sm"
+      />
+    </div>
+    <div class="fx-row fx-xalign-start fx-gap-px-6">
+      <OSS::ExpandableBadge @icon="fas fa-user-bounty-hunter" @size="md" @expandedLabel="The Mandalorian" />
+      <OSS::ExpandableBadge @icon="fas fa-robot-astromech" @size="md" @expandedLabel="R2-D2" />
+      <OSS::ExpandableBadge
+        @icon="fab fa-pinterest"
+        @size="md"
+        @expandedLabel="pinterest"
+        @fontColor="font-color-pinterest-500"
+        class="font-color-pinterest-500"
       />
     </div>
   </div>

--- a/tests/dummy/app/templates/visual.hbs
+++ b/tests/dummy/app/templates/visual.hbs
@@ -438,7 +438,7 @@
         @icon="fab fa-pinterest"
         @size="md"
         @expandedLabel="pinterest"
-        @fontColor="font-color-pinterest-500"
+        @fontColorClass="font-color-pinterest-500"
         class="font-color-pinterest-500"
       />
     </div>

--- a/tests/integration/components/o-s-s/expandable-badge-test.ts
+++ b/tests/integration/components/o-s-s/expandable-badge-test.ts
@@ -136,6 +136,22 @@ module('Integration | Component | o-s-s/expandable-badge', function (hooks) {
     });
   });
 
+  module('@fontColorClass parameter', function () {
+    test('applies to the icon when passed', async function (assert: Assert) {
+      await render(
+        hbs`<OSS::ExpandableBadge @icon="fas fa-users" @fontColorClass="text-primary" @expandedLabel="content" />`
+      );
+
+      assert.dom('.upf-expandable-badge i').hasClass('text-primary');
+    });
+
+    test('applies to the span when passed', async function (assert: Assert) {
+      await render(hbs`<OSS::ExpandableBadge @text="2x" @fontColorClass="text-primary" @expandedLabel="content" />`);
+
+      assert.dom('.upf-expandable-badge__label').hasClass('text-primary');
+    });
+  });
+
   module('Error management', function () {
     test('it throws an error when an unsupported skin is passed', async function (assert: Assert) {
       setupOnerror((err: Error) => {

--- a/tests/integration/components/o-s-s/expandable-badge-test.ts
+++ b/tests/integration/components/o-s-s/expandable-badge-test.ts
@@ -1,0 +1,195 @@
+import { hbs } from 'ember-cli-htmlbars';
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { setupIntl } from 'ember-intl/test-support';
+import { render, settled, setupOnerror } from '@ember/test-helpers';
+
+import { SkinDefinition } from '@upfluence/oss-components/components/o-s-s/badge';
+
+module('Integration | Component | o-s-s/expandable-badge', function (hooks) {
+  setupRenderingTest(hooks);
+  setupIntl(hooks);
+
+  module('sizes', function () {
+    test('it sets the right class when usng a supported size', async function (assert: Assert) {
+      await render(hbs`<OSS::ExpandableBadge @size="lg" @text="2x" @expandedLabel="content" />`);
+
+      assert.dom('.upf-badge').exists();
+      assert.dom('.upf-badge').hasClass('upf-badge--size-lg');
+    });
+
+    test('it defaults to md size if none is passed', async function (assert: Assert) {
+      await render(hbs`<OSS::ExpandableBadge @text="2x" @expandedLabel="content" />`);
+
+      assert.dom('.upf-badge').exists();
+      assert.dom('.upf-badge').hasClass('upf-badge--size-md');
+    });
+  });
+
+  module('Expansion behavior', function () {
+    test('On touch event, it expands the badge', async function (assert: Assert) {
+      await render(hbs`<OSS::ExpandableBadge @icon="fa-robot" @expandedLabel="content" />`);
+      assert.dom('.upf-expandable-badge').doesNotHaveClass('upf-expandable-badge--expanded');
+
+      const touch = new Touch({
+        identifier: Date.now(),
+        target: this.element.querySelector('.upf-expandable-badge') as EventTarget
+      });
+
+      await this.element.querySelector('.upf-expandable-badge')?.dispatchEvent(
+        new TouchEvent('touchend', {
+          touches: [touch],
+          bubbles: true,
+          cancelable: true
+        })
+      );
+      await settled();
+      assert.dom('.upf-expandable-badge').hasClass('upf-expandable-badge--expanded');
+    });
+
+    test('On mouse enter, it expands the badge', async function (assert: Assert) {
+      await render(hbs`<OSS::ExpandableBadge @icon="fa-robot" @expandedLabel="content" />`);
+      assert.dom('.upf-expandable-badge').doesNotHaveClass('upf-expandable-badge--expanded');
+
+      await this.element.querySelector('.upf-expandable-badge')?.dispatchEvent(
+        new MouseEvent('mouseenter', {
+          bubbles: true,
+          cancelable: true
+        })
+      );
+      await settled();
+      assert.dom('.upf-expandable-badge').hasClass('upf-expandable-badge--expanded');
+    });
+
+    test('On mouse leave, it collapses the badge', async function (assert: Assert) {
+      await render(hbs`<OSS::ExpandableBadge @icon="fa-robot" @expandedLabel="content" />`);
+      assert.dom('.upf-expandable-badge').doesNotHaveClass('upf-expandable-badge--expanded');
+
+      await this.element.querySelector('.upf-expandable-badge')?.dispatchEvent(
+        new MouseEvent('mouseenter', {
+          bubbles: true,
+          cancelable: true
+        })
+      );
+      await settled();
+      assert.dom('.upf-expandable-badge').hasClass('upf-expandable-badge--expanded');
+
+      await this.element.querySelector('.upf-expandable-badge')?.dispatchEvent(
+        new MouseEvent('mouseleave', {
+          bubbles: true,
+          cancelable: true
+        })
+      );
+      await settled();
+      assert.dom('.upf-expandable-badge').doesNotHaveClass('upf-expandable-badge--expanded');
+    });
+  });
+
+  module('skins', function () {
+    Object.keys(SkinDefinition).forEach((skin) => {
+      test(`it sets the right class when using a supported skin: ${skin}`, async function (assert: Assert) {
+        this.skin = skin;
+        await render(hbs`<OSS::ExpandableBadge @skin={{this.skin}} @text="2x" @expandedLabel="content" />`);
+
+        assert.dom('.upf-badge').exists();
+        assert
+          .dom('.upf-badge')
+          .hasClass(`upf-badge--${skin.startsWith('xtd') ? skin.replace('xtd', 'extended') : skin}`);
+      });
+    });
+
+    test('it adds the plain class when passed', async function (assert: Assert) {
+      await render(hbs`<OSS::ExpandableBadge @skin="primary" @plain={{true}} @text="2x" @expandedLabel="content" />`);
+
+      assert.dom('.upf-badge').hasClass('upf-badge--plain');
+    });
+  });
+
+  module('content args', function () {
+    test('it displays the right icon when using the @icon arg', async function (assert: Assert) {
+      await render(hbs`<OSS::ExpandableBadge @icon="fas fa-users" @expandedLabel="content" />`);
+
+      assert.dom('.upf-badge').exists();
+      assert.dom('.upf-badge i').hasAttribute('class', 'fas fa-users');
+    });
+
+    test('it displays the right text when using the @text arg', async function (assert: Assert) {
+      await render(hbs`<OSS::ExpandableBadge @text="2x" @expandedLabel="content" />`);
+
+      assert.dom('.upf-badge').exists();
+      assert.dom('.upf-badge .upf-badge__text').exists();
+      assert.dom('.upf-badge .upf-badge__text').hasText('2x');
+    });
+
+    test('it displays the right image when using the @image arg', async function (assert: Assert) {
+      await render(hbs`<OSS::ExpandableBadge @image="http://foo.co/bar.png" @expandedLabel="content" />`);
+
+      assert.dom('.upf-badge').exists();
+      assert.dom('.upf-badge img').exists();
+      assert.dom('.upf-badge img').hasAttribute('src', 'http://foo.co/bar.png');
+    });
+
+    test('it displays the right flag when using the @flag arg', async function (assert: Assert) {
+      await render(hbs`<OSS::ExpandableBadge @flag="fr" @expandedLabel="France" />`);
+
+      assert.dom('.upf-badge .fflag.fflag-FR').exists();
+    });
+  });
+
+  module('Error management', function () {
+    test('it throws an error when an unsupported skin is passed', async function (assert: Assert) {
+      setupOnerror((err: Error) => {
+        assert.equal(
+          err.message,
+          'Assertion Failed: [component][OSS::ExpandableBadge] Unknown skin. Available skins are: primary, success, alert, error, xtd-cyan, xtd-orange, xtd-yellow, xtd-lime, xtd-blue, xtd-violet, xtd-smart'
+        );
+      });
+
+      await render(hbs`<OSS::ExpandableBadge @skin="foo" @text="2x" @expandedLabel="content" />`);
+    });
+
+    test('it throws an error when an unsupported size is passed', async function (assert: Assert) {
+      setupOnerror((err: Error) => {
+        assert.equal(
+          err.message,
+          'Assertion Failed: [component][OSS::ExpandableBadge] Unknown size. Available sizes are: sm, md, lg'
+        );
+      });
+
+      await render(hbs`<OSS::ExpandableBadge @size="foo" @text="2x" @expandedLabel="content" />`);
+    });
+
+    test('it throws an error if no @expandableLabel argument is passed', async function (assert: Assert) {
+      setupOnerror((err: Error) => {
+        assert.equal(
+          err.message,
+          'Assertion Failed: [component][OSS::ExpandableBadge] The @expandableLabel argument is mandatory.'
+        );
+      });
+
+      await render(hbs`<OSS::ExpandableBadge @icon="fas fa-users" />`);
+    });
+
+    test('it throws an error if no argument is passed', async function (assert: Assert) {
+      setupOnerror((err: Error) => {
+        assert.equal(
+          err.message,
+          'Assertion Failed: [component][OSS::ExpandableBadge] One of @icon, @image, @flag or @text arguments is mandatory. You passed 0 arguments'
+        );
+      });
+
+      await render(hbs`<OSS::ExpandableBadge />`);
+    });
+
+    test('it throws an error if more than one content argument is passed', async function (assert: Assert) {
+      setupOnerror((err: Error) => {
+        assert.equal(
+          err.message,
+          'Assertion Failed: [component][OSS::ExpandableBadge] One of @icon, @image, @flag or @text arguments is mandatory. You passed 2 arguments'
+        );
+      });
+
+      await render(hbs`<OSS::ExpandableBadge @icon="fas fa-users" @text="2x" />`);
+    });
+  });
+});

--- a/tests/integration/components/o-s-s/stack-container-test.ts
+++ b/tests/integration/components/o-s-s/stack-container-test.ts
@@ -1,0 +1,155 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Component | o-s-s/stack-container', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function (assert) {
+    await render(hbs`<OSS::StackContainer />`);
+
+    assert.dom('.oss-stack-container').exists();
+  });
+
+  module('@direction parameter', function () {
+    test('it defaults to "row"', async function (assert) {
+      await render(hbs`<OSS::StackContainer />`);
+
+      assert.dom('.oss-stack-container').hasClass('oss-stack-container--row');
+    });
+
+    test('passing "row" as parameter sets the direction to row', async function (assert) {
+      await render(hbs`<OSS::StackContainer @direction="row" />`);
+
+      assert.dom('.oss-stack-container').hasClass('oss-stack-container--row');
+    });
+
+    test('passing "column" as parameter sets the direction to column', async function (assert) {
+      await render(hbs`<OSS::StackContainer @direction="column" />`);
+
+      assert.dom('.oss-stack-container').hasClass('oss-stack-container--column');
+    });
+  });
+
+  module('@style parameter', function () {
+    test('when "under" is passed, sub-elements have a raising z-index', async function (assert) {
+      await render(hbs`<OSS::StackContainer @style="under"><div></div><div></div><div></div></OSS::StackContainer>`);
+      assert.dom('.oss-stack-container').hasClass('oss-stack-container--style-under');
+      const subElements = document.querySelectorAll('.oss-stack-container > *');
+      subElements.forEach((child, index) => {
+        assert.strictEqual(
+          (child as HTMLElement).style.zIndex,
+          index.toString(),
+          `Child ${index} has z-index ${index}`
+        );
+      });
+    });
+
+    test('when "over" is passed, sub-elements have a lowering z-index', async function (assert) {
+      await render(hbs`<OSS::StackContainer @style="over"><div></div><div></div><div></div></OSS::StackContainer>`);
+      assert.dom('.oss-stack-container').hasClass('oss-stack-container--style-over');
+      const subElements = document.querySelectorAll('.oss-stack-container > *');
+      subElements.forEach((child, index) => {
+        assert.strictEqual(
+          (child as HTMLElement).style.zIndex,
+          (subElements.length - 1 - index).toString(),
+          `Child ${index} has z-index ${subElements.length - 1 - index}`
+        );
+      });
+    });
+
+    test('it defaults to "under" style', async function (assert) {
+      await render(hbs`<OSS::StackContainer />`);
+
+      assert.dom('.oss-stack-container').hasClass('oss-stack-container--style-under');
+    });
+  });
+
+  module('@pxMargin parameter', function () {
+    test('it applies a margin to sub-elements except the last one', async function (assert) {
+      await render(
+        hbs`<OSS::StackContainer @pxMargin="10" @style="under"><div></div><div></div><div></div></OSS::StackContainer>`
+      );
+
+      const subElements = document.querySelectorAll('.oss-stack-container > *');
+      subElements.forEach((child, index) => {
+        if (index < subElements.length - 1) {
+          assert.strictEqual((child as HTMLElement).style.marginRight, '-10px');
+        } else {
+          assert.strictEqual((child as HTMLElement).style.marginRight, '');
+        }
+      });
+
+      test('the margin defaults to -3px if not specified', async function (assert) {
+        await render(hbs`<OSS::StackContainer @style="under"><div></div><div></div><div></div></OSS::StackContainer>`);
+
+        const subElements = document.querySelectorAll('.oss-stack-container > *');
+        subElements.forEach((child, index) => {
+          if (index < subElements.length - 1) {
+            assert.strictEqual((child as HTMLElement).style.marginRight, '-3px', 'Default margin is applied');
+          } else {
+            assert.strictEqual((child as HTMLElement).style.marginRight, '', 'No margin for the last child');
+          }
+        });
+      });
+
+      test('passing a positive margin converts it to a negative margin', async function (assert) {
+        await render(
+          hbs`<OSS::StackContainer @pxMargin="20" @style="under"><div></div><div></div><div></div></OSS::StackContainer>`
+        );
+
+        const subElements = document.querySelectorAll('.oss-stack-container > *');
+        subElements.forEach((child, index) => {
+          if (index < subElements.length - 1) {
+            assert.strictEqual((child as HTMLElement).style.marginRight, '-20px', 'Margin is negative');
+          } else {
+            assert.strictEqual((child as HTMLElement).style.marginRight, '', 'No margin for the last child');
+          }
+        });
+      });
+    });
+  });
+
+  module('@bringToFrontOnHover parameter', function () {
+    test('it does not bring elements to front by default', async function (assert) {
+      await render(hbs`<OSS::StackContainer @style="under"><div></div><div></div><div></div></OSS::StackContainer>`);
+
+      const subElements = document.querySelectorAll('.oss-stack-container > *');
+      subElements.forEach((child, index) => {
+        assert.strictEqual(
+          (child as HTMLElement).style.zIndex,
+          index.toString(),
+          `Child ${index} has z-index ${index}`
+        );
+      });
+    });
+
+    test('it brings elements to front on hover when specified', async function (assert) {
+      await render(
+        hbs`<OSS::StackContainer @bringToFrontOnHover={{true}} @style="under"><div></div><div></div><div></div></OSS::StackContainer>`
+      );
+
+      const subElements = document.querySelectorAll('.oss-stack-container > *');
+      subElements.forEach((child, index) => {
+        child.dispatchEvent(new MouseEvent('mouseenter'));
+        assert.strictEqual((child as HTMLElement).style.zIndex, subElements.length.toString());
+        child.dispatchEvent(new MouseEvent('mouseleave'));
+        assert.strictEqual((child as HTMLElement).style.zIndex, index.toString());
+      });
+    });
+  });
+
+  module('@subElementClass parameter', function () {
+    test('it applies the specified class to each sub-element', async function (assert) {
+      await render(
+        hbs`<OSS::StackContainer @subElementClass="custom-class" @style="under"><div></div><div></div><div></div></OSS::StackContainer>`
+      );
+
+      const subElements = document.querySelectorAll('.oss-stack-container > *');
+      subElements.forEach((child) => {
+        assert.dom(child).hasClass('custom-class');
+      });
+    });
+  });
+});

--- a/tests/integration/components/o-s-s/stack-container-test.ts
+++ b/tests/integration/components/o-s-s/stack-container-test.ts
@@ -80,33 +80,33 @@ module('Integration | Component | o-s-s/stack-container', function (hooks) {
           assert.strictEqual((child as HTMLElement).style.marginRight, '');
         }
       });
+    });
 
-      test('the margin defaults to -3px if not specified', async function (assert) {
-        await render(hbs`<OSS::StackContainer @style="under"><div></div><div></div><div></div></OSS::StackContainer>`);
+    test('the margin defaults to -6px if not specified', async function (assert) {
+      await render(hbs`<OSS::StackContainer @style="under"><div></div><div></div><div></div></OSS::StackContainer>`);
 
-        const subElements = document.querySelectorAll('.oss-stack-container > *');
-        subElements.forEach((child, index) => {
-          if (index < subElements.length - 1) {
-            assert.strictEqual((child as HTMLElement).style.marginRight, '-3px', 'Default margin is applied');
-          } else {
-            assert.strictEqual((child as HTMLElement).style.marginRight, '', 'No margin for the last child');
-          }
-        });
+      const subElements = document.querySelectorAll('.oss-stack-container > *');
+      subElements.forEach((child, index) => {
+        if (index < subElements.length - 1) {
+          assert.strictEqual((child as HTMLElement).style.marginRight, '-6px', 'Default margin is applied');
+        } else {
+          assert.strictEqual((child as HTMLElement).style.marginRight, '', 'No margin for the last child');
+        }
       });
+    });
 
-      test('passing a positive margin converts it to a negative margin', async function (assert) {
-        await render(
-          hbs`<OSS::StackContainer @pxMargin="20" @style="under"><div></div><div></div><div></div></OSS::StackContainer>`
-        );
+    test('passing a positive margin converts it to a negative margin', async function (assert) {
+      await render(
+        hbs`<OSS::StackContainer @pxMargin="20" @style="under"><div></div><div></div><div></div></OSS::StackContainer>`
+      );
 
-        const subElements = document.querySelectorAll('.oss-stack-container > *');
-        subElements.forEach((child, index) => {
-          if (index < subElements.length - 1) {
-            assert.strictEqual((child as HTMLElement).style.marginRight, '-20px', 'Margin is negative');
-          } else {
-            assert.strictEqual((child as HTMLElement).style.marginRight, '', 'No margin for the last child');
-          }
-        });
+      const subElements = document.querySelectorAll('.oss-stack-container > *');
+      subElements.forEach((child, index) => {
+        if (index < subElements.length - 1) {
+          assert.strictEqual((child as HTMLElement).style.marginRight, '-20px', 'Margin is negative');
+        } else {
+          assert.strictEqual((child as HTMLElement).style.marginRight, '', 'No margin for the last child');
+        }
       });
     });
   });


### PR DESCRIPTION
### What does this PR do?

Introduces two new components.

#### OSS::ExpandableBadge

A new badge component that expands to show a label.

https://github.com/user-attachments/assets/2e0f3b01-9ccb-454c-adee-3ff476c3541e

Note:
The behaviour on desktop is to expand on hover while it is on "tap" events for mobile.

It extends the existing OSS::Badge so that all its features & parameters remain functional.
On top of that, it adds the following parameters:
- expandedLabel: the label displayed on hover / touch
- flag: allows rendering an fflag as icon inside the badge
- fontColorClass: allows passing a class that will be applied to the icon & label

---

#### OSS::StackContainer

![Screenshot 2025-06-25 at 10 22 07](https://github.com/user-attachments/assets/812c8cd0-e669-4384-86cd-ad99dc308bfd)

https://github.com/user-attachments/assets/da4ec940-3f9f-4ae4-b1d5-d6114dea5f0c

A new component that allows us to have row & column stacks with negative margins.
It has the following options:
- direction: row or column (applies a "flex-direction" display on the component)
- style: over or under (whether the element goes over the next one or under)
- pxMargin: the margin to apply. number or string values are accepted, it will always apply a negative margin.
- bringToFrontOnHover: as the name suggests brings the element behind the cursor to the front of the stack
- subElementClass: optional class to append to every sub-element.


### Good PR checklist
- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [x] Added/updated documentation
- [x] Properly labeled
