### PR TITLE
OSS::ExpandableBadge - new argument for custom span class

### DIFF
--- a/addon/components/o-s-s/expandable-badge.hbs
+++ b/addon/components/o-s-s/expandable-badge.hbs
@@ -7,7 +7,7 @@
   ...attributes
 >
   {{#if @icon}}
-    <OSS::Icon @style={{fa-icon-style @icon}} @icon={{fa-icon-value @icon}} class={{@fontColorClass}}/>
+    <OSS::Icon @style={{fa-icon-style @icon}} @icon={{fa-icon-value @icon}} class={{@iconColorClass}}/>
   {{else if @image}}
     <img src={{@image}} alt={{t "oss-components.badge.image_alt"}} />
   {{else if @flag}}
@@ -15,5 +15,5 @@
   {{else}}
     <span class="upf-badge__text">{{@text}}</span>
   {{/if}}
-  <span class="upf-expandable-badge__label {{@fontColorClass}}">{{@expandedLabel}}</span>
+  <span class="upf-expandable-badge__label {{@labelColorClass}}">{{@expandedLabel}}</span>
 </div>

--- a/addon/components/o-s-s/expandable-badge.stories.js
+++ b/addon/components/o-s-s/expandable-badge.stories.js
@@ -83,6 +83,30 @@ export default {
       },
       control: { type: 'text' },
       type: { required: true }
+    },
+    flag: {
+      description: 'Allows passing a Alpha2 country code to display a flag as the icon.',
+      table: {
+        type: { summary: 'string' },
+        defaultValue: { summary: 'undefined' }
+      },
+      control: { type: 'text' }
+    },
+    iconColorClass: {
+      description: 'Allows passing a color class to the icon.',
+      table: {
+        type: { summary: 'string' },
+        defaultValue: { summary: 'undefined' }
+      },
+      control: { type: 'text' }
+    },
+    labelColorClass: {
+      description: 'Allows passing a color class to the label.',
+      table: {
+        type: { summary: 'string' },
+        defaultValue: { summary: 'undefined' }
+      },
+      control: { type: 'text' }
     }
   },
   parameters: {
@@ -101,6 +125,7 @@ const defaultArgs = {
   icon: undefined,
   image: undefined,
   text: undefined,
+  flag: undefined,
   plain: false,
   skin: undefined
 };
@@ -108,7 +133,7 @@ const defaultArgs = {
 const Template = (args) => ({
   template: hbs`
     <OSS::ExpandableBadge @expandedLabel={{this.expandedLabel}} @image={{this.image}} @icon={{this.icon}} @text={{this.text}}
-                          @size={{this.size}} @skin={{this.skin}} @plain={{this.plain}} />
+                          @flag={{this.flag}} @size={{this.size}} @skin={{this.skin}} @plain={{this.plain}} />
   `,
   context: args
 });
@@ -123,6 +148,12 @@ export const WithImage = Template.bind({});
 WithImage.args = {
   ...defaultArgs,
   ...{ image: '/@upfluence/oss-components/assets/heart.svg' }
+};
+
+export const WithFlag = Template.bind({});
+WithFlag.args = {
+  ...defaultArgs,
+  ...{ flag: 'us' }
 };
 
 export const WithText = Template.bind({});

--- a/addon/components/o-s-s/expandable-badge.ts
+++ b/addon/components/o-s-s/expandable-badge.ts
@@ -7,7 +7,8 @@ import { next } from '@ember/runloop';
 interface OSSExpandableBadgeComponentSignature extends OSSBadgeArgs {
   expandedLabel: string;
   flag?: string;
-  fontColorClass?: string;
+  iconColorClass?: string;
+  labelColorClass?: string;
 }
 
 export default class OSSExpandableBadgeComponent extends OSSBadge<OSSExpandableBadgeComponentSignature> {
@@ -23,7 +24,7 @@ export default class OSSExpandableBadgeComponent extends OSSBadge<OSSExpandableB
       contentArguments.length === 1
     );
     assert(
-      `[component][OSS::ExpandableBadge] The @expandableLabel argument is mandatory.`,
+      `[component][OSS::ExpandableBadge] The @expandedLabel argument is mandatory.`,
       args.expandedLabel !== undefined
     );
   }

--- a/tests/integration/components/o-s-s/expandable-badge-test.ts
+++ b/tests/integration/components/o-s-s/expandable-badge-test.ts
@@ -136,19 +136,23 @@ module('Integration | Component | o-s-s/expandable-badge', function (hooks) {
     });
   });
 
-  module('@fontColorClass parameter', function () {
-    test('applies to the icon when passed', async function (assert: Assert) {
+  module('ColorClass parameters', function () {
+    test('@iconColorClass applies to the icon when passed', async function (assert: Assert) {
       await render(
-        hbs`<OSS::ExpandableBadge @icon="fas fa-users" @fontColorClass="text-primary" @expandedLabel="content" />`
+        hbs`<OSS::ExpandableBadge @icon="fas fa-users" @iconColorClass="text-primary" @expandedLabel="content" />`
       );
 
       assert.dom('.upf-expandable-badge i').hasClass('text-primary');
+      assert.dom('.upf-expandable-badge__label').doesNotHaveClass('text-primary');
     });
 
-    test('applies to the span when passed', async function (assert: Assert) {
-      await render(hbs`<OSS::ExpandableBadge @text="2x" @fontColorClass="text-primary" @expandedLabel="content" />`);
+    test('@labelColorClass applies to the span when passed', async function (assert: Assert) {
+      await render(
+        hbs`<OSS::ExpandableBadge @icon="fas fa-users" @labelColorClass="text-primary" @expandedLabel="content" />`
+      );
 
       assert.dom('.upf-expandable-badge__label').hasClass('text-primary');
+      assert.dom('.upf-expandable-badge i').doesNotHaveClass('text-primary');
     });
   });
 
@@ -179,7 +183,7 @@ module('Integration | Component | o-s-s/expandable-badge', function (hooks) {
       setupOnerror((err: Error) => {
         assert.equal(
           err.message,
-          'Assertion Failed: [component][OSS::ExpandableBadge] The @expandableLabel argument is mandatory.'
+          'Assertion Failed: [component][OSS::ExpandableBadge] The @expandedLabel argument is mandatory.'
         );
       });
 


### PR DESCRIPTION
### What does this PR do?

Separates arguments for setting custom classes on the badge icon and on the badge label.

Updated tests & documentation.

### Good PR checklist
- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [x] Added/updated documentation
- [x] Properly labeled