### PR TITLE
Tooltip: Add option on tooltip modifier to display only when overflow/ellipsis

### DIFF
--- a/addon/modifiers/enable-tooltip.ts
+++ b/addon/modifiers/enable-tooltip.ts
@@ -5,6 +5,7 @@ import { run } from '@ember/runloop';
 import { createAnimation } from '@upfluence/oss-components/utils/animation-manager';
 import { isTesting } from '@embroider/macros';
 import { isEmpty } from '@ember/utils';
+import { bool } from '@ember/object/computed';
 
 type TooltipConfig = {
   title?: string;
@@ -13,6 +14,7 @@ type TooltipConfig = {
   subtitle?: string;
   icon?: string;
   html?: boolean;
+  displayOnOverflow?: boolean;
 };
 
 type EnableTooltipArgs = {
@@ -89,6 +91,10 @@ function generateHTMLStructure(state: EnableTooltipState): void {
 }
 
 function delayedRender(state: EnableTooltipState): void {
+  if (state.tooltipConfig.displayOnOverflow && !hasOverflow(state.originElement)) {
+    return;
+  }
+
   if (isEmpty(state.tooltipConfig.title) || state.isRendered || state.setTimeoutId) return;
   state.setTimeoutId = setTimeout(() => {
     renderTooltip(state);
@@ -188,6 +194,16 @@ function initEventListener(state: EnableTooltipState, element: HTMLElement): voi
       destroyWithEvent(state, event);
     });
   }
+}
+
+function hasOverflow(element: HTMLElement): boolean {
+  if (!Array.from(element.children).length) {
+    return element.offsetWidth < element.scrollWidth;
+  }
+
+  return Array.from(element.children).some((child: HTMLElement) => {
+    return hasOverflow(child);
+  });
 }
 
 export default setModifierManager(

--- a/tests/dummy/app/templates/visual.hbs
+++ b/tests/dummy/app/templates/visual.hbs
@@ -488,10 +488,15 @@
           <OSS::Tag @label="Tag" @skin="chat-gpt" />
         </div>
         <div class="fx-row fx-gap-px-12">
-          <OSS::Tag @label="Test with a huge label sentence" @skin="danger" @icon="far fa-thumbs-up" />
           <OSS::Tag
             @label="Test with a huge label sentence"
-            {{enable-tooltip title="Test with a huge label sentence" placement="top"}}
+            @skin="danger"
+            @icon="far fa-thumbs-up"
+            {{enable-tooltip title="Test with a huge label sentence" placement="top" displayOnOverflow=true}}
+          />
+          <OSS::Tag
+            @label="Test with a huge label sentence"
+            {{enable-tooltip title="Test with a huge label sentence" placement="top" displayOnOverflow=true}}
             @skin="danger"
             @icon="far fa-thumbs-up"
             @hasEllipsis={{true}}

--- a/tests/integration/components/modifiers/enable-tooltip-test.ts
+++ b/tests/integration/components/modifiers/enable-tooltip-test.ts
@@ -68,6 +68,45 @@ module('Integration | Component | modifiers/enable-tooltip', function (hooks) {
     });
   });
 
+  module('display on overflow', (hooks) => {
+    hooks.beforeEach(function () {
+      this.displayOnOverflow = true;
+    });
+    test('When content has no overflow, it does not display tooltip on hover', async function (assert) {
+      await render(hbs`
+      <div class="test-container" style="height: 20px; width: 40px"
+           {{enable-tooltip title=this.title
+                            subtitle=this.subtitle
+                            placement=this.placement
+                            icon=this.icon
+                            trigger=this.trigger
+                            html=this.html
+                            displayOnOverflow=this.displayOnOverflow }}>
+           abc
+      </div>
+    `);
+
+      await assert.tooltip('.test-container').doesNotExist();
+    });
+
+    test('When content has overflow, it displays tooltip on hover', async function (assert) {
+      await render(hbs`
+      <div class="test-container" style="height: 20px; width: 40px"
+           {{enable-tooltip title=this.title
+                            subtitle=this.subtitle
+                            placement=this.placement
+                            icon=this.icon
+                            trigger=this.trigger
+                            html=this.html
+                            displayOnOverflow=this.displayOnOverflow }}>
+           abcdefghijklmnopqrstuvwxyz
+      </div>
+    `);
+
+      await assert.tooltip('.test-container').exists();
+    });
+  });
+
   module('trigger attribute', () => {
     test('it renders when hovering and focusing the element with undefined trigger', async function (assert) {
       await renderTooltip();


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the context of this pull request and its purpose. -->

Related to: #[DRA-3228](https://linear.app/upfluence/issue/DRA-3228/creators-web-socialmediabanner-component)

### What are the observable changes?
<!-- This question could be adequate with multiple use cases, for example: -->
Add new option to display tooltip only when content overflow 🙏 

https://github.com/user-attachments/assets/aea898f9-eb7c-4263-baad-fae732c1d4ee


<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->

### Good PR checklist
- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled
