### PR TITLE
Add autocomplete arg to slider

### DIFF
--- a/addon/components/o-s-s/input-container.hbs
+++ b/addon/components/o-s-s/input-container.hbs
@@ -20,6 +20,7 @@
         @type={{this.type}}
         placeholder={{@placeholder}}
         disabled={{@disabled}}
+        autocomplete={{this.autocomplete}}
         class="upf-input"
         {{on "keyup" (fn this._onChange @value)}}
         {{on "paste" this.onPaste}}

--- a/addon/components/o-s-s/input-container.stories.js
+++ b/addon/components/o-s-s/input-container.stories.js
@@ -1,6 +1,8 @@
 import { hbs } from 'ember-cli-htmlbars';
 import { action } from '@storybook/addon-actions';
 
+const AutocompleteValues = ['on', 'off'];
+
 export default {
   title: 'Components/OSS::InputContainer',
   component: 'input-container',
@@ -76,6 +78,17 @@ export default {
       },
       control: { type: 'boolean' }
     },
+    autocomplete: {
+      description: 'The autocomplete attribute of the input',
+      table: {
+        type: {
+          summary: AutocompleteValues.join('|')
+        },
+        defaultValue: { summary: 'on' }
+      },
+      options: AutocompleteValues,
+      control: { type: 'select' }
+    },
     onChange: {
       description: 'Method called every time the input is updated',
       table: {
@@ -101,13 +114,14 @@ const defaultArgs = {
   type: undefined,
   placeholder: 'this is the placeholder',
   errorMessage: undefined,
+  autocomplete: undefined,
   onChange: action('onChange')
 };
 
 const DefaultUsageTemplate = (args) => ({
   template: hbs`
       <OSS::InputContainer @value={{this.value}} @disabled={{this.disabled}} @placeholder={{this.placeholder}} @type={{this.type}}
-                           @errorMessage={{this.errorMessage}} @onChange={{this.onChange}} />
+                           @errorMessage={{this.errorMessage}} @onChange={{this.onChange}} @autocomplete={{this.autocomplete}} />
   `,
   context: args
 });

--- a/addon/components/o-s-s/input-container.ts
+++ b/addon/components/o-s-s/input-container.ts
@@ -47,10 +47,7 @@ export default class OSSInputContainer extends Component<OSSInputContainerArgs> 
   }
 
   get autocomplete(): 'on' | 'off' {
-    if (!this.args.autocomplete) {
-      return 'on';
-    }
-    return AutocompleteValues.includes(this.args.autocomplete) ? this.args.autocomplete : 'on';
+    return AutocompleteValues.includes(this.args.autocomplete ?? '') ? this.args.autocomplete! : 'on';
   }
 
   @action

--- a/addon/components/o-s-s/input-container.ts
+++ b/addon/components/o-s-s/input-container.ts
@@ -19,6 +19,8 @@ interface OSSInputContainerArgs {
   onChange?(value: string): void;
 }
 
+export const AutocompleteValues = ['on', 'off'];
+
 export default class OSSInputContainer extends Component<OSSInputContainerArgs> {
   get feedbackMessage(): FeedbackMessage | undefined {
     if (this.args.feedbackMessage && ['error', 'warning', 'success'].includes(this.args.feedbackMessage.type)) {
@@ -45,7 +47,10 @@ export default class OSSInputContainer extends Component<OSSInputContainerArgs> 
   }
 
   get autocomplete(): 'on' | 'off' {
-    return this.args.autocomplete ?? 'on';
+    if (!this.args.autocomplete) {
+      return 'on';
+    }
+    return AutocompleteValues.includes(this.args.autocomplete) ? this.args.autocomplete : 'on';
   }
 
   @action

--- a/addon/components/o-s-s/input-container.ts
+++ b/addon/components/o-s-s/input-container.ts
@@ -15,6 +15,7 @@ interface OSSInputContainerArgs {
   hasError?: boolean;
   placeholder?: string;
   type?: string;
+  autocomplete?: 'on' | 'off';
   onChange?(value: string): void;
 }
 
@@ -41,6 +42,10 @@ export default class OSSInputContainer extends Component<OSSInputContainerArgs> 
 
   get type(): string {
     return this.args.type ?? 'text';
+  }
+
+  get autocomplete(): 'on' | 'off' {
+    return this.args.autocomplete ?? 'on';
   }
 
   @action

--- a/addon/components/o-s-s/input-group.hbs
+++ b/addon/components/o-s-s/input-group.hbs
@@ -14,6 +14,7 @@
         @type={{this.type}}
         @placeholder={{@placeholder}}
         @onChange={{@onChange}}
+        @autocomplete={{@autocomplete}}
         class="{{if @prefix 'prefix-radius-fix'}} {{if @suffix 'suffix-radius-fix'}}"
       />
     </div>

--- a/addon/components/o-s-s/input-group.stories.js
+++ b/addon/components/o-s-s/input-group.stories.js
@@ -1,6 +1,8 @@
 import { hbs } from 'ember-cli-htmlbars';
 import { action } from '@storybook/addon-actions';
 
+const AutocompleteValues = ['on', 'off'];
+
 export default {
   title: 'Components/OSS::InputGroup',
   component: 'input-group',
@@ -75,6 +77,17 @@ export default {
       },
       control: { type: 'text' }
     },
+    autocomplete: {
+      description: 'The autocomplete attribute of the input',
+      table: {
+        type: {
+          summary: AutocompleteValues.join('|')
+        },
+        defaultValue: { summary: 'on' }
+      },
+      options: AutocompleteValues,
+      control: { type: 'select' }
+    },
     onChange: {
       description: 'Method called every time the input is updated',
       table: {
@@ -104,13 +117,14 @@ const defaultArgs = {
   suffix: '@domain.com',
   errorMessage: undefined,
   placeholder: 'My placeholder',
+  autocomplete: undefined,
   onChange: action('onChange')
 };
 
 const Template = (args) => ({
   template: hbs`
       <OSS::InputGroup @prefix={{this.prefix}} @disabled={{this.disabled}} @suffix={{this.suffix}} @type={{this.type}} @value={{this.value}}
-                       @errorMessage={{this.errorMessage}} @placeholder={{this.placeholder}} @onChange={{this.onChange}} />
+                       @errorMessage={{this.errorMessage}} @placeholder={{this.placeholder}} @onChange={{this.onChange}} @autocomplete={{this.autocomplete}} />
   `,
   context: args
 });

--- a/addon/components/o-s-s/input-group.ts
+++ b/addon/components/o-s-s/input-group.ts
@@ -9,6 +9,7 @@ interface OSSInputGroupArgs {
   prefix?: string;
   suffix?: string;
   type?: string;
+  autocomplete?: 'on' | 'off';
   onChange?(value: string): void;
 }
 

--- a/addon/components/o-s-s/slider.hbs
+++ b/addon/components/o-s-s/slider.hbs
@@ -39,6 +39,7 @@
           @suffix={{this.unitIcon}}
           @placeholder={{this.currentRangeValue}}
           @disabled={{@disabled}}
+          @autocomplete={{this.sliderOptions.autocomplete}}
           {{on "input" this.onNumberInput}}
         />
       {{else}}
@@ -50,6 +51,7 @@
           max={{this.sliderOptions.max}}
           placeholder={{this.currentRangeValue}}
           disabled={{@disabled}}
+          autocomplete={{this.sliderOptions.autocomplete}}
           class="upf-input"
           {{on "input" this.onNumberInput}}
         />

--- a/addon/components/o-s-s/slider.stories.js
+++ b/addon/components/o-s-s/slider.stories.js
@@ -1,6 +1,8 @@
 import { hbs } from 'ember-cli-htmlbars';
 import { action } from '@storybook/addon-actions';
 
+const AutocompleteValues = ['on', 'off'];
+
 export default {
   title: 'Components/OSS::Slider',
   component: 'slider',
@@ -86,6 +88,17 @@ export default {
         defaultValue: { summary: 'undefined' }
       }
     },
+    autocomplete: {
+      description: 'The autocomplete attribute of the input',
+      table: {
+        type: {
+          summary: AutocompleteValues.join('|')
+        },
+        defaultValue: { summary: 'on' }
+      },
+      options: AutocompleteValues,
+      control: { type: 'select' }
+    },
     inputOptions: {
       description: 'Options min and max for the input field and slider',
       table: {
@@ -125,6 +138,7 @@ const defaultArgs = {
   unit: 'percentage',
   disabled: false,
   inputOptions: { min: 0, max: 100 },
+  autocomplete: undefined,
   onChange: action('onChange')
 };
 
@@ -140,6 +154,7 @@ const Template = (args) => ({
                  @unit={{this.unit}}
                  @disabled={{this.disabled}}
                  @inputOptions={{this.inputOptions}}
+                 @autocomplete={{this.autocomplete}}
                  @onChange={{this.onChange}}
     />
   `,

--- a/addon/components/o-s-s/slider.ts
+++ b/addon/components/o-s-s/slider.ts
@@ -3,6 +3,7 @@ import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import { htmlSafe } from '@ember/template';
 import { isBlank } from '@ember/utils';
+import { AutocompleteValues } from './input-container';
 
 interface SliderComponentArgs {
   value: string;
@@ -27,7 +28,8 @@ export default class SliderComponent extends Component<SliderComponentArgs> {
     min: this.args.min ?? 0,
     max: this.args.max ?? 100,
     step: this.args.step ?? 1,
-    autocomplete: this.args.autocomplete ?? 'on'
+    autocomplete:
+      this.args.autocomplete && AutocompleteValues.includes(this.args.autocomplete) ? this.args.autocomplete : 'on'
   };
 
   @tracked displayTooltip: boolean = false;

--- a/addon/components/o-s-s/slider.ts
+++ b/addon/components/o-s-s/slider.ts
@@ -6,6 +6,7 @@ import { isBlank } from '@ember/utils';
 
 interface SliderComponentArgs {
   value: string;
+  autocomplete?: 'on' | 'off';
   defaultValue?: string;
   displayInputValue?: boolean;
   unit?: 'percentage' | 'number';
@@ -25,7 +26,8 @@ export default class SliderComponent extends Component<SliderComponentArgs> {
   sliderOptions = {
     min: this.args.min ?? 0,
     max: this.args.max ?? 100,
-    step: this.args.step ?? 1
+    step: this.args.step ?? 1,
+    autocomplete: this.args.autocomplete ?? 'on'
   };
 
   @tracked displayTooltip: boolean = false;

--- a/addon/components/o-s-s/slider.ts
+++ b/addon/components/o-s-s/slider.ts
@@ -28,8 +28,7 @@ export default class SliderComponent extends Component<SliderComponentArgs> {
     min: this.args.min ?? 0,
     max: this.args.max ?? 100,
     step: this.args.step ?? 1,
-    autocomplete:
-      this.args.autocomplete && AutocompleteValues.includes(this.args.autocomplete) ? this.args.autocomplete : 'on'
+    autocomplete: AutocompleteValues.includes(this.args.autocomplete ?? '') ? this.args.autocomplete! : 'on'
   };
 
   @tracked displayTooltip: boolean = false;

--- a/tests/dummy/app/templates/input.hbs
+++ b/tests/dummy/app/templates/input.hbs
@@ -258,7 +258,7 @@
       Input group
     </div>
     <div class="fx-row fx-gap-px-24 fx-xalign-start">
-      <OSS::InputGroup @value={{this.inputValue}} @prefix="@" @placeholder="Username" />
+      <OSS::InputGroup @value={{this.inputValue}} @prefix="@" @placeholder="Username" @autocomplete="off"/>
       <OSS::InputGroup @value={{this.inputValue}} @suffix="@example.com" @placeholder="john.doe" />
       <OSS::InputGroup
         @value={{this.inputValue}}

--- a/tests/integration/components/o-s-s/input-container-test.js
+++ b/tests/integration/components/o-s-s/input-container-test.js
@@ -52,12 +52,14 @@ module('Integration | Component | o-s-s/input-container', function (hooks) {
       this.set('value', 'testValue');
       this.set('placeholder', 'Type your text');
       this.set('onValueChange', onValueChange);
+      this.set('autocomplete', undefined);
     });
     async function renderComponentWithParameters() {
       await render(hbs`
         <OSS::InputContainer @value={{this.value}}
                              @onChange={{this.onValueChange}}
-                             @placeholder={{this.placeholder}} />`);
+                             @placeholder={{this.placeholder}}
+                             @autocomplete={{this.autocomplete}} />`);
     }
 
     test('Passing a @value parameter works', async function (assert) {
@@ -87,6 +89,17 @@ module('Integration | Component | o-s-s/input-container', function (hooks) {
         clipboardData: { getData: (format) => `clipboardFormat/${format}` }
       });
       assert.ok(this.onChange.calledWith('clipboardFormat/Text'));
+    });
+
+    test('Passing no @autocomplete parameter works', async function (assert) {
+      await renderComponentWithParameters();
+      assert.dom('.upf-input').hasAttribute('autocomplete', 'on');
+    });
+
+    test('Passing a @autocomplete parameter works', async function (assert) {
+      this.autocomplete = 'off';
+      await renderComponentWithParameters();
+      assert.dom('.upf-input').hasAttribute('autocomplete', 'off');
     });
   });
 

--- a/tests/integration/components/o-s-s/input-container-test.js
+++ b/tests/integration/components/o-s-s/input-container-test.js
@@ -91,7 +91,7 @@ module('Integration | Component | o-s-s/input-container', function (hooks) {
       assert.ok(this.onChange.calledWith('clipboardFormat/Text'));
     });
 
-    test('Passing no @autocomplete parameter works', async function (assert) {
+    test('Not passing an @autocomplete parameter defaults to "on" state', async function (assert) {
       await renderComponentWithParameters();
       assert.dom('.upf-input').hasAttribute('autocomplete', 'on');
     });

--- a/tests/integration/components/o-s-s/input-group-test.ts
+++ b/tests/integration/components/o-s-s/input-group-test.ts
@@ -27,7 +27,7 @@ module('Integration | Component | o-s-s/input-group', function (hooks) {
     assert.dom('.oss-input-group-row-suffix').hasText('@domain.com');
   });
 
-  test('Passing no @autocomplete parameter works', async function (assert) {
+  test('Not passing an @autocomplete parameter defaults to "on" state', async function (assert) {
     await render(hbs`<OSS::InputGroup @prefix="email" @suffix="@domain.com"/>`);
     assert.dom('.upf-input').hasAttribute('autocomplete', 'on');
   });

--- a/tests/integration/components/o-s-s/input-group-test.ts
+++ b/tests/integration/components/o-s-s/input-group-test.ts
@@ -27,6 +27,16 @@ module('Integration | Component | o-s-s/input-group', function (hooks) {
     assert.dom('.oss-input-group-row-suffix').hasText('@domain.com');
   });
 
+  test('Passing no @autocomplete parameter works', async function (assert) {
+    await render(hbs`<OSS::InputGroup @prefix="email" @suffix="@domain.com"/>`);
+    assert.dom('.upf-input').hasAttribute('autocomplete', 'on');
+  });
+
+  test('Passing a @autocomplete parameter works', async function (assert) {
+    await render(hbs`<OSS::InputGroup @prefix="email" @suffix="@domain.com" @autocomplete="off"/>`);
+    assert.dom('.upf-input').hasAttribute('autocomplete', 'off');
+  });
+
   test('Passing the @errorMessage parameter displays the error message', async function (assert) {
     await render(hbs`<OSS::InputGroup @suffix="@domain.com" @errorMessage="This is an error." />`);
     assert.dom('.oss-input-group-row--error').exists();

--- a/tests/integration/components/o-s-s/slider-test.ts
+++ b/tests/integration/components/o-s-s/slider-test.ts
@@ -177,6 +177,20 @@ module('Integration | Component | o-s-s/slider', function (hooks) {
       );
       assert.dom('.oss-slider__number-input').doesNotExist();
     });
+
+    test('with no autocomplete arg, it is on by default', async function (assert) {
+      await render(
+        hbs`<OSS::Slider @value={{this.value}} @displayInputValue={{this.displayInputValue}} @onChange={{this.onChange}} />`
+      );
+      assert.dom('.oss-slider__number-input input').hasAttribute('autocomplete', 'on');
+    });
+
+    test('when autocomplete is off', async function (assert) {
+      await render(
+        hbs`<OSS::Slider @value={{this.value}} @displayInputValue={{this.displayInputValue}} @onChange={{this.onChange}} @autocomplete="off" />`
+      );
+      assert.dom('.oss-slider__number-input input').hasAttribute('autocomplete', 'off');
+    });
   });
 
   module('Unit container', function () {


### PR DESCRIPTION
### What does this PR do?
Add autocomplete option to OSS::Slider, which is activated by default.

The Input element has a native autocomplete arg which takes only "on" or "off" values. More information in this documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/autocomplete#off

Since the autocomplete option was needed in the OSS::Slider, the arg had to be propagated in the OSS::InputGroup used in the Slider as well as in the OSS::InputContainer used in the OSS::InputGroup.

Tests and stories have been updated to manage and showcase this new option.
<!-- A brief description of the context of this pull request and its purpose. -->

Related to: #<!-- enter issue number here -->

### What are the observable changes?
<!-- This question could be adequate with multiple use cases, for example: -->

<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->

### Good PR checklist
- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [ ] Properly labeled
