### PR TITLE
OSS::CompletionBadge

### DIFF
--- a/addon/components/o-s-s/badge.ts
+++ b/addon/components/o-s-s/badge.ts
@@ -59,30 +59,6 @@ export default class OSSBadge<T extends OSSBadgeArgs> extends Component<T> {
     );
   }
 
-  get sizeClass(): string {
-    const size: SizeType = this.args.size || 'md';
-
-    assert(
-      `[component][OSS::Badge] Unknown size. Available sizes are: ${Object.keys(SizeDefinition).join(', ')}`,
-      Object.keys(SizeDefinition).includes(size as SizeType)
-    );
-
-    return SizeDefinition[size as SizeType];
-  }
-
-  get skinClass(): string {
-    const skin: SkinType | undefined = this.args?.skin;
-
-    if (!skin) return '';
-
-    assert(
-      `[component][OSS::Badge] Unknown skin. Available skins are: ${Object.keys(SkinDefinition).join(', ')}`,
-      Object.keys(SkinDefinition).includes(skin as SkinType)
-    );
-
-    return SkinDefinition[skin as SkinType];
-  }
-
   get computedClass(): string {
     const classes = ['upf-badge', 'upf-badge--shape-round'];
 
@@ -95,5 +71,29 @@ export default class OSSBadge<T extends OSSBadgeArgs> extends Component<T> {
     }
 
     return classes.join(' ');
+  }
+
+  protected get skinClass(): string {
+    const skin: SkinType | undefined = this.args?.skin;
+
+    if (!skin) return '';
+
+    assert(
+      `[component][OSS::Badge] Unknown skin. Available skins are: ${Object.keys(SkinDefinition).join(', ')}`,
+      Object.keys(SkinDefinition).includes(skin as SkinType)
+    );
+
+    return SkinDefinition[skin as SkinType];
+  }
+
+  protected get sizeClass(): string {
+    const size: SizeType = this.args.size || 'md';
+
+    assert(
+      `[component][OSS::Badge] Unknown size. Available sizes are: ${Object.keys(SizeDefinition).join(', ')}`,
+      Object.keys(SizeDefinition).includes(size as SizeType)
+    );
+
+    return SizeDefinition[size as SizeType];
   }
 }

--- a/addon/components/o-s-s/completion-badge.hbs
+++ b/addon/components/o-s-s/completion-badge.hbs
@@ -1,0 +1,16 @@
+<div
+  class="upf-completion-badge-wrapper"
+  {{did-insert this.animateProgress}}
+  {{did-update this.animateProgress @progress}}
+>
+  <div class="upf-completion-badge-ring" style={{this.progressRingStyle}}></div>
+  <div class={{this.computedClass}} ...attributes>
+    {{#if @icon}}
+      <OSS::Icon @style={{fa-icon-style @icon}} @icon={{fa-icon-value @icon}} />
+    {{else if @image}}
+      <img src={{@image}} alt={{t "oss-components.badge.image_alt"}} />
+    {{else}}
+      <span class="upf-badge__text">{{@text}}</span>
+    {{/if}}
+  </div>
+</div>

--- a/addon/components/o-s-s/completion-badge.hbs
+++ b/addon/components/o-s-s/completion-badge.hbs
@@ -2,9 +2,10 @@
   class="upf-completion-badge-wrapper"
   {{did-insert this.animateProgress}}
   {{did-update this.animateProgress @progress}}
+  ...attributes
 >
   <div class="upf-completion-badge-ring" style={{this.progressRingStyle}}></div>
-  <div class={{this.computedClass}} ...attributes>
+  <div class={{this.computedClass}}>
     {{#if @icon}}
       <OSS::Icon @style={{fa-icon-style @icon}} @icon={{fa-icon-value @icon}} />
     {{else if @image}}

--- a/addon/components/o-s-s/completion-badge.stories.js
+++ b/addon/components/o-s-s/completion-badge.stories.js
@@ -1,0 +1,131 @@
+import { hbs } from 'ember-cli-htmlbars';
+
+const SizeTypes = ['sm', 'md', 'lg'];
+const SkinTypes = [
+  'primary',
+  'success',
+  'alert',
+  'error',
+  'xtd-cyan',
+  'xtd-orange',
+  'xtd-yellow',
+  'xtd-lime',
+  'xtd-blue',
+  'xtd-violet',
+  'xtd-smart'
+];
+
+export default {
+  title: 'Components/OSS::CompletionBadge',
+  component: 'completion-badge',
+  argTypes: {
+    size: {
+      description: 'Adjust the size of the badge',
+      table: {
+        type: {
+          summary: SizeTypes.join('|')
+        },
+        defaultValue: { summary: 'md' }
+      },
+      options: SizeTypes,
+      control: { type: 'select' }
+    },
+    skin: {
+      description: 'Adjust the skin of the badge',
+      table: {
+        type: {
+          summary: SkinTypes.join('|')
+        },
+        defaultValue: { summary: 'undefined' }
+      },
+      options: SkinTypes,
+      control: { type: 'select' }
+    },
+    plain: {
+      description: 'Displays the badge with a plain background',
+      table: {
+        type: { summary: 'boolean' },
+        defaultValue: { summary: 'false' }
+      },
+      control: {
+        type: 'boolean'
+      }
+    },
+    icon: {
+      description: 'Font Awesome class, for example: far fa-envelope-open',
+      table: {
+        type: { summary: 'string' },
+        defaultValue: { summary: 'undefined' }
+      },
+      control: { type: 'text' }
+    },
+    image: {
+      description: 'URL of an image',
+      table: {
+        type: { summary: 'string' },
+        defaultValue: { summary: 'undefined' }
+      },
+      control: { type: 'text' }
+    },
+    text: {
+      description: 'Text to display inside the badge',
+      table: {
+        type: { summary: 'string' },
+        defaultValue: { summary: 'undefined' }
+      },
+      control: { type: 'text' }
+    },
+    progress: {
+      description: 'Progress percentage to display around the badge',
+      table: {
+        type: { summary: 'number' },
+        defaultValue: { summary: '0' }
+      },
+      control: { type: 'number' }
+    }
+  },
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'A badge component that displays a progress ring around the badge content. It can be used to indicate completion status or progress of a task.'
+      }
+    }
+  }
+};
+
+const defaultArgs = {
+  progress: 42,
+  size: 'md',
+  icon: undefined,
+  image: undefined,
+  text: undefined,
+  plain: false,
+  skin: undefined
+};
+
+const Template = (args) => ({
+  template: hbs`
+    <OSS::CompletionBadge @progress={{this.progress}} @image={{this.image}} @icon={{this.icon}} @text={{this.text}}
+                          @flag={{this.flag}} @size={{this.size}} @skin={{this.skin}} @plain={{this.plain}} />
+  `,
+  context: args
+});
+
+export const WithIcon = Template.bind({});
+WithIcon.args = {
+  ...defaultArgs,
+  ...{ icon: 'fas fa-volume-up' }
+};
+
+export const WithImage = Template.bind({});
+WithImage.args = {
+  ...defaultArgs,
+  ...{ image: '/@upfluence/oss-components/assets/heart.svg' }
+};
+
+export const WithText = Template.bind({});
+WithText.args = {
+  ...defaultArgs,
+  ...{ text: '2x' }
+};

--- a/addon/components/o-s-s/completion-badge.ts
+++ b/addon/components/o-s-s/completion-badge.ts
@@ -2,7 +2,6 @@ import { tracked } from '@glimmer/tracking';
 import { assert } from '@ember/debug';
 import { action } from '@ember/object';
 import { htmlSafe } from '@ember/template';
-import type { SafeString } from '@ember/template/-private/handlebars';
 import { isTesting } from '@embroider/macros';
 
 import type { OSSBadgeArgs, SizeType, SkinType } from './badge';
@@ -32,7 +31,7 @@ export default class OSSCompletionBadgeComponent extends OSSBadge<OSSCompletionB
     );
   }
 
-  get progressRingStyle(): SafeString {
+  get progressRingStyle(): ReturnType<typeof htmlSafe> {
     const progress = this.animatedProgress;
     const angle = (progress / 100) * 360;
     if (progress >= 100) {

--- a/addon/components/o-s-s/completion-badge.ts
+++ b/addon/components/o-s-s/completion-badge.ts
@@ -1,0 +1,114 @@
+import { tracked } from '@glimmer/tracking';
+import { assert } from '@ember/debug';
+import { action } from '@ember/object';
+import { htmlSafe } from '@ember/template';
+import type { SafeString } from '@ember/template/-private/handlebars';
+import { isTesting } from '@embroider/macros';
+
+import type { OSSBadgeArgs, SizeType, SkinType } from './badge';
+import OSSBadge, { SizeDefinition, SkinDefinition } from './badge';
+
+export const SUCCESS_COLOR = 'var(--color-success-500)';
+export const PROGRESS_COLOR = 'var(--color-primary-500)';
+export const BACKGROUND_COLOR = 'var(--color-gray-200)';
+export const ANIMATION_DURATION = isTesting() ? 25 : 1200;
+
+interface OSSCompletionBadgeComponentSignature extends OSSBadgeArgs {
+  progress: number;
+}
+
+export default class OSSCompletionBadgeComponent extends OSSBadge<OSSCompletionBadgeComponentSignature> {
+  @tracked animatedProgress: number = 0;
+  animationFrameId?: number;
+
+  constructor(owner: unknown, args: OSSCompletionBadgeComponentSignature) {
+    super(owner, args, true);
+
+    const contentArguments = [args.icon, args.image, args.text].filter((arg: string) => arg);
+
+    assert(
+      `[component][OSS::CompletionBadge] One of @icon, @image or @text arguments is mandatory. You passed ${contentArguments.length} arguments`,
+      contentArguments.length === 1
+    );
+  }
+
+  get progressRingStyle(): SafeString {
+    const progress = this.animatedProgress;
+    const angle = (progress / 100) * 360;
+    if (progress >= 100) {
+      return htmlSafe(`background: conic-gradient(${SUCCESS_COLOR} 0deg 360deg, ${SUCCESS_COLOR} 360deg 360deg);`);
+    }
+    return htmlSafe(
+      `background: conic-gradient(${PROGRESS_COLOR} 0deg ${angle}deg, ${BACKGROUND_COLOR} ${angle}deg 360deg);`
+    );
+  }
+
+  override get computedClass(): string {
+    const classes = ['upf-badge', 'upf-badge--shape-round'];
+
+    [this.sizeClass, this.skinClass].forEach((klass) => {
+      classes.push(klass);
+    });
+
+    if (this.args.plain) {
+      classes.push('upf-badge--plain');
+    }
+
+    return classes.join(' ');
+  }
+
+  protected override get sizeClass(): string {
+    const size: SizeType = this.args.size || 'md';
+
+    assert(
+      `[component][OSS::CompletionBadge] Unknown size. Available sizes are: ${Object.keys(SizeDefinition).join(', ')}`,
+      Object.keys(SizeDefinition).includes(size as SizeType)
+    );
+
+    return SizeDefinition[size as SizeType];
+  }
+
+  protected override get skinClass(): string {
+    const skin: SkinType | undefined = this.args?.skin;
+
+    if (!skin) return '';
+
+    assert(
+      `[component][OSS::CompletionBadge] Unknown skin. Available skins are: ${Object.keys(SkinDefinition).join(', ')}`,
+      Object.keys(SkinDefinition).includes(skin as SkinType)
+    );
+
+    return SkinDefinition[skin as SkinType];
+  }
+
+  @action
+  animateProgress(): void {
+    if (this.animationFrameId) {
+      cancelAnimationFrame(this.animationFrameId);
+    }
+    const initial = this.animatedProgress;
+    const target = this.progressValue;
+    const duration = ANIMATION_DURATION;
+    const start = performance.now();
+    this.animationFrameId = requestAnimationFrame((now) => this.animateStep(now, initial, target, duration, start));
+  }
+
+  private get progressValue(): number {
+    const value = Number(this.args.progress);
+    return isNaN(value) ? 0 : Math.round(value);
+  }
+
+  private animateStep(now: number, initial: number, target: number, duration: number, start: number): void {
+    const elapsed = now - start;
+    const percent = Math.min(elapsed / duration, 1);
+    this.animatedProgress = initial + percent * (target - initial);
+    if (percent < 1) {
+      this.animationFrameId = requestAnimationFrame((nextNow) =>
+        this.animateStep(nextNow, initial, target, duration, start)
+      );
+    } else {
+      this.animatedProgress = target;
+      this.animationFrameId = undefined;
+    }
+  }
+}

--- a/addon/components/o-s-s/expandable-badge.ts
+++ b/addon/components/o-s-s/expandable-badge.ts
@@ -33,30 +33,6 @@ export default class OSSExpandableBadgeComponent extends OSSBadge<OSSExpandableB
     return this.args.flag!.toUpperCase();
   }
 
-  override get sizeClass(): string {
-    const size: SizeType = this.args.size || 'md';
-
-    assert(
-      `[component][OSS::ExpandableBadge] Unknown size. Available sizes are: ${Object.keys(SizeDefinition).join(', ')}`,
-      Object.keys(SizeDefinition).includes(size as SizeType)
-    );
-
-    return SizeDefinition[size as SizeType];
-  }
-
-  override get skinClass(): string {
-    const skin: SkinType | undefined = this.args?.skin;
-
-    if (!skin) return '';
-
-    assert(
-      `[component][OSS::ExpandableBadge] Unknown skin. Available skins are: ${Object.keys(SkinDefinition).join(', ')}`,
-      Object.keys(SkinDefinition).includes(skin as SkinType)
-    );
-
-    return SkinDefinition[skin as SkinType];
-  }
-
   override get computedClass(): string {
     const classes = ['upf-badge', 'upf-expandable-badge'];
 
@@ -73,6 +49,30 @@ export default class OSSExpandableBadgeComponent extends OSSBadge<OSSExpandableB
     }
 
     return classes.join(' ');
+  }
+
+  protected override get sizeClass(): string {
+    const size: SizeType = this.args.size || 'md';
+
+    assert(
+      `[component][OSS::ExpandableBadge] Unknown size. Available sizes are: ${Object.keys(SizeDefinition).join(', ')}`,
+      Object.keys(SizeDefinition).includes(size as SizeType)
+    );
+
+    return SizeDefinition[size as SizeType];
+  }
+
+  protected override get skinClass(): string {
+    const skin: SkinType | undefined = this.args?.skin;
+
+    if (!skin) return '';
+
+    assert(
+      `[component][OSS::ExpandableBadge] Unknown skin. Available skins are: ${Object.keys(SkinDefinition).join(', ')}`,
+      Object.keys(SkinDefinition).includes(skin as SkinType)
+    );
+
+    return SkinDefinition[skin as SkinType];
   }
 
   @action

--- a/app/components/o-s-s/completion-badge.js
+++ b/app/components/o-s-s/completion-badge.js
@@ -1,0 +1,1 @@
+export { default } from '@upfluence/oss-components/components/o-s-s/completion-badge';

--- a/app/styles/atoms/completion-badge.less
+++ b/app/styles/atoms/completion-badge.less
@@ -1,0 +1,20 @@
+.upf-completion-badge-wrapper {
+  position: relative;
+  padding: 2px;
+}
+
+.upf-completion-badge-ring {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  border-radius: 50%;
+  z-index: 0;
+}
+
+.upf-completion-badge-wrapper .upf-badge {
+  position: relative;
+  z-index: 1;
+  border: none;
+}

--- a/app/styles/oss-components.less
+++ b/app/styles/oss-components.less
@@ -31,6 +31,7 @@
 @import 'atoms/button';
 @import 'atoms/badge';
 @import 'atoms/expandable-badge';
+@import 'atoms/completion-badge';
 @import 'atoms/chip';
 @import 'atoms/avatar';
 @import 'atoms/copy';

--- a/tests/dummy/app/controllers/visual.ts
+++ b/tests/dummy/app/controllers/visual.ts
@@ -10,6 +10,7 @@ export default class Visual extends Controller {
   @tracked isChecked: boolean = true;
   @tracked radio1: boolean = true;
   @tracked radio2: boolean = false;
+  @tracked dynamicProgress: number = 0;
   @tracked avatars: { image: string; initials: string }[] = [
     {
       image: 'https://reachr-assets.s3.us-west-2.amazonaws.com/influencer-server/influencer/7219681.png',
@@ -165,7 +166,16 @@ export default class Visual extends Controller {
   @action onChangeMode1(selectedMode: string): void {
     this.modeSwitchSelected1 = selectedMode;
   }
+
   @action onChangeMode2(selectedMode: string): void {
     this.modeSwitchSelected2 = selectedMode;
+  }
+
+  @action
+  increaseProgress(): void {
+    if (this.dynamicProgress < 100) {
+      set(this, 'dynamicProgress', this.dynamicProgress + 10);
+      setTimeout(() => this.increaseProgress(), 1000);
+    }
   }
 }

--- a/tests/dummy/app/templates/visual.hbs
+++ b/tests/dummy/app/templates/visual.hbs
@@ -448,6 +448,30 @@
     class="fx-col fx-1 background-color-white border border-color-default border-radius-md padding-px-12 fx-gap-px-12"
   >
     <div class="font-size-md font-weight-semibold">
+      Completion badge
+    </div>
+    <div class="fx-row fx-gap-px-12 fx-xalign-center">
+      <OSS::CompletionBadge @icon="fas fa-box-open" @size="lg" />
+      <OSS::CompletionBadge @progress="27" @icon="fas fa-box-open" @size="lg" />
+      <OSS::CompletionBadge @progress="50" @size="md" @icon="fas fa-box-open" />
+      <OSS::CompletionBadge @progress="76" @size="sm" @icon="fas fa-box-open" />
+    </div>
+    <div class="fx-row fx-gap-px-12 fx-xalign-center">
+      <OSS::CompletionBadge @progress="100" @text="2x" />
+      <OSS::CompletionBadge
+        @progress={{this.dynamicProgress}}
+        @image="https://reachr-assets.s3.us-west-2.amazonaws.com/influencer-server/influencer/7219681.png"
+        {{did-insert this.increaseProgress}}
+      />
+      <OSS::CompletionBadge @icon="fas fa-box-open" @skin="xtd-orange" />
+      <OSS::CompletionBadge @progress="66" @icon="fas fa-box-open" @skin="xtd-orange" @plain={{true}} />
+    </div>
+  </div>
+
+  <div
+    class="fx-col fx-1 background-color-white border border-color-default border-radius-md padding-px-12 fx-gap-px-12"
+  >
+    <div class="font-size-md font-weight-semibold">
       Icon
     </div>
     <div class="fx-row fx-gap-px-24 fx-xalign-center">

--- a/tests/integration/components/o-s-s/badge-test.ts
+++ b/tests/integration/components/o-s-s/badge-test.ts
@@ -11,7 +11,7 @@ module('Integration | Component | o-s-s/badge', function (hooks) {
   setupIntl(hooks);
 
   module('sizes', function () {
-    test('it sets the right class when usng a supported size', async function (assert: Assert) {
+    test('it sets the right class when using a supported size', async function (assert: Assert) {
       await render(hbs`<OSS::Badge @size="lg" @text="2x" />`);
 
       assert.dom('.upf-badge').exists();

--- a/tests/integration/components/o-s-s/completion-badge-test.ts
+++ b/tests/integration/components/o-s-s/completion-badge-test.ts
@@ -1,0 +1,249 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render, setupOnerror } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import { SkinDefinition } from '@upfluence/oss-components/components/o-s-s/badge';
+import { setupIntl } from 'ember-intl/test-support';
+import {
+  ANIMATION_DURATION,
+  BACKGROUND_COLOR,
+  PROGRESS_COLOR,
+  SUCCESS_COLOR
+} from '@upfluence/oss-components/components/o-s-s/completion-badge';
+import { set } from '@ember/object';
+
+module('Integration | Component | o-s-s/completion-badge', function (hooks) {
+  setupRenderingTest(hooks);
+  setupIntl(hooks);
+
+  test('it renders', async function (assert) {
+    await render(hbs`<OSS::CompletionBadge @icon="fas fa-check" />`);
+
+    assert.dom('.upf-completion-badge-wrapper').exists();
+  });
+
+  function hexToRgb(hex: string): string {
+    const bigint = parseInt(hex.slice(1), 16);
+    const r = (bigint >> 16) & 255;
+    const g = (bigint >> 8) & 255;
+    const b = bigint & 255;
+    return `rgb(${r}, ${g}, ${b})`;
+  }
+
+  function getCSSVarValuesInRGB(): {
+    backgroundColor: string;
+    successColor: string;
+    progressColor: string;
+  } {
+    const ring = document.querySelector('.upf-completion-badge-ring');
+    const backgroundSelector = BACKGROUND_COLOR.replace('var(', '').replace(')', '');
+    const backgroundVarHexValue = getComputedStyle(ring!).getPropertyValue(backgroundSelector).trim();
+
+    const successSelector = SUCCESS_COLOR.replace('var(', '').replace(')', '');
+    const successVarHexValue = getComputedStyle(ring!).getPropertyValue(successSelector).trim();
+
+    const progressSelector = PROGRESS_COLOR.replace('var(', '').replace(')', '');
+    const progressVarHexValue = getComputedStyle(ring!).getPropertyValue(progressSelector).trim();
+
+    return {
+      successColor: successVarHexValue.startsWith('#') ? hexToRgb(successVarHexValue) : successVarHexValue,
+      progressColor: progressVarHexValue.startsWith('#') ? hexToRgb(progressVarHexValue) : progressVarHexValue,
+      backgroundColor: backgroundVarHexValue.startsWith('#') ? hexToRgb(backgroundVarHexValue) : backgroundVarHexValue
+    };
+  }
+
+  module('progress', function () {
+    test('it renders only the background border when @progress is undefined', async function (assert) {
+      await render(hbs`<OSS::CompletionBadge @icon="fas fa-check" />`);
+
+      const rgbValues = getCSSVarValuesInRGB();
+      console.log('RGB Values:', rgbValues);
+
+      assert.dom('.upf-completion-badge-ring').hasStyle({
+        backgroundImage: `conic-gradient(${rgbValues.progressColor} 0deg, ${rgbValues.progressColor} 0deg, ${rgbValues.backgroundColor} 0deg, ${rgbValues.backgroundColor} 360deg)`
+      });
+    });
+
+    test('it renders the progress ring with 0% progress', async function (assert) {
+      await render(hbs`<OSS::CompletionBadge @progress="0" @icon="fas fa-check" />`);
+
+      const rgbValues = getCSSVarValuesInRGB();
+      assert.dom('.upf-completion-badge-ring').hasStyle({
+        backgroundImage: `conic-gradient(${rgbValues.progressColor} 0deg, ${rgbValues.progressColor} 0deg, ${rgbValues.backgroundColor} 0deg, ${rgbValues.backgroundColor} 360deg)`
+      });
+    });
+
+    test('it renders the progress ring with 100% progress', async function (assert) {
+      await render(hbs`<OSS::CompletionBadge @progress="100" @icon="fas fa-check" />`);
+      const rgbValues = getCSSVarValuesInRGB();
+
+      await new Promise((resolve) => setTimeout(resolve, ANIMATION_DURATION * 2));
+      assert.dom('.upf-completion-badge-ring').hasStyle({
+        backgroundImage: `conic-gradient(${rgbValues.successColor} 0deg, ${rgbValues.successColor} 360deg, ${rgbValues.successColor} 360deg, ${rgbValues.successColor} 360deg)`
+      });
+    });
+
+    test('it renders the progress ring with 25% progress', async function (assert) {
+      await render(hbs`<OSS::CompletionBadge @progress="25" @icon="fas fa-check" />`);
+      const rgbValues = getCSSVarValuesInRGB();
+
+      await new Promise((resolve) => setTimeout(resolve, ANIMATION_DURATION * 2));
+      assert.dom('.upf-completion-badge-ring').hasStyle({
+        backgroundImage: `conic-gradient(${rgbValues.progressColor} 0deg, ${rgbValues.progressColor} 90deg, ${rgbValues.backgroundColor} 90deg, ${rgbValues.backgroundColor} 360deg)`
+      });
+    });
+
+    test('it renders the progress ring with 50% progress', async function (assert) {
+      await render(hbs`<OSS::CompletionBadge @progress="50" @icon="fas fa-check" />`);
+      const rgbValues = getCSSVarValuesInRGB();
+
+      await new Promise((resolve) => setTimeout(resolve, ANIMATION_DURATION * 2));
+      assert.dom('.upf-completion-badge-ring').hasStyle({
+        backgroundImage: `conic-gradient(${rgbValues.progressColor} 0deg, ${rgbValues.progressColor} 180deg, ${rgbValues.backgroundColor} 180deg, ${rgbValues.backgroundColor} 360deg)`
+      });
+    });
+
+    test('it renders the progress ring with 75% progress', async function (assert) {
+      await render(hbs`<OSS::CompletionBadge @progress="75" @icon="fas fa-check" />`);
+      const rgbValues = getCSSVarValuesInRGB();
+
+      await new Promise((resolve) => setTimeout(resolve, ANIMATION_DURATION * 2));
+      assert.dom('.upf-completion-badge-ring').hasStyle({
+        backgroundImage: `conic-gradient(${rgbValues.progressColor} 0deg, ${rgbValues.progressColor} 270deg, ${rgbValues.backgroundColor} 270deg, ${rgbValues.backgroundColor} 360deg)`
+      });
+    });
+
+    test('passing a @progress value above 100 caps the value to 100', async function (assert) {
+      await render(hbs`<OSS::CompletionBadge @progress="150" @icon="fas fa-check" />`);
+      const rgbValues = getCSSVarValuesInRGB();
+      await new Promise((resolve) => setTimeout(resolve, ANIMATION_DURATION * 2));
+      assert.dom('.upf-completion-badge-ring').hasStyle({
+        backgroundImage: `conic-gradient(${rgbValues.successColor} 0deg, ${rgbValues.successColor} 360deg, ${rgbValues.successColor} 360deg, ${rgbValues.successColor} 360deg)`
+      });
+    });
+
+    test('it updates the progress ring when @progress changes', async function (assert) {
+      this.progress = 0;
+      await render(hbs`<OSS::CompletionBadge @progress={{this.progress}} @icon="fas fa-check" />`);
+      const rgbValues = getCSSVarValuesInRGB();
+
+      await new Promise((resolve) => setTimeout(resolve, ANIMATION_DURATION * 2));
+      assert.dom('.upf-completion-badge-ring').hasStyle({
+        backgroundImage: `conic-gradient(${rgbValues.progressColor} 0deg, ${rgbValues.progressColor} 0deg, ${rgbValues.backgroundColor} 0deg, ${rgbValues.backgroundColor} 360deg)`
+      });
+
+      set(this, 'progress', 50);
+      await new Promise((resolve) => setTimeout(resolve, ANIMATION_DURATION * 2));
+      assert.dom('.upf-completion-badge-ring').hasStyle({
+        backgroundImage: `conic-gradient(${rgbValues.progressColor} 0deg, ${rgbValues.progressColor} 180deg, ${rgbValues.backgroundColor} 180deg, ${rgbValues.backgroundColor} 360deg)`
+      });
+    });
+  });
+
+  module('sizes', function () {
+    test('it sets the right class when using a supported size', async function (assert: Assert) {
+      await render(hbs`<OSS::CompletionBadge @size="lg" @text="2x" />`);
+
+      assert.dom('.upf-badge').exists();
+      assert.dom('.upf-badge').hasClass('upf-badge--size-lg');
+    });
+
+    test('it defaults to md size if none is passed', async function (assert: Assert) {
+      await render(hbs`<OSS::CompletionBadge @text="2x" />`);
+
+      assert.dom('.upf-badge').exists();
+      assert.dom('.upf-badge').hasClass('upf-badge--size-md');
+    });
+  });
+
+  module('skins', function () {
+    Object.keys(SkinDefinition).forEach((skin) => {
+      test(`it sets the right class when using a supported skin: ${skin}`, async function (assert: Assert) {
+        this.skin = skin;
+        await render(hbs`<OSS::CompletionBadge @skin={{this.skin}} @text="2x" />`);
+
+        assert.dom('.upf-badge').exists();
+        assert
+          .dom('.upf-badge')
+          .hasClass(`upf-badge--${skin.startsWith('xtd') ? skin.replace('xtd', 'extended') : skin}`);
+      });
+    });
+
+    test('it adds the plain class when passed', async function (assert: Assert) {
+      await render(hbs`<OSS::CompletionBadge @skin="primary" @plain={{true}} @text="2x" />`);
+
+      assert.dom('.upf-badge').hasClass('upf-badge--plain');
+    });
+  });
+
+  module('content args', function () {
+    test('it displays the right icon when using the @icon arg', async function (assert: Assert) {
+      await render(hbs`<OSS::CompletionBadge @icon="fas fa-users" />`);
+
+      assert.dom('.upf-badge').exists();
+      assert.dom('.upf-badge i').hasAttribute('class', 'fas fa-users');
+    });
+
+    test('it displays the right text when using the @text arg', async function (assert: Assert) {
+      await render(hbs`<OSS::CompletionBadge @text="2x" />`);
+
+      assert.dom('.upf-badge').exists();
+      assert.dom('.upf-badge .upf-badge__text').exists();
+      assert.dom('.upf-badge .upf-badge__text').hasText('2x');
+    });
+
+    test('it displays the right image when using the @image arg', async function (assert: Assert) {
+      await render(hbs`<OSS::CompletionBadge @image="http://foo.co/bar.png" />`);
+
+      assert.dom('.upf-badge').exists();
+      assert.dom('.upf-badge img').exists();
+      assert.dom('.upf-badge img').hasAttribute('src', 'http://foo.co/bar.png');
+    });
+  });
+
+  module('Error management', function () {
+    test('it throws an error when an unsupported skin is passed', async function (assert: Assert) {
+      setupOnerror((err: Error) => {
+        assert.equal(
+          err.message,
+          'Assertion Failed: [component][OSS::CompletionBadge] Unknown skin. Available skins are: primary, success, alert, error, xtd-cyan, xtd-orange, xtd-yellow, xtd-lime, xtd-blue, xtd-violet, xtd-smart'
+        );
+      });
+
+      await render(hbs`<OSS::CompletionBadge @skin="foo" @text="2x" />`);
+    });
+
+    test('it throws an error when an unsupported size is passed', async function (assert: Assert) {
+      setupOnerror((err: Error) => {
+        assert.equal(
+          err.message,
+          'Assertion Failed: [component][OSS::CompletionBadge] Unknown size. Available sizes are: sm, md, lg'
+        );
+      });
+
+      await render(hbs`<OSS::CompletionBadge @size="foo" @text="2x" />`);
+    });
+
+    test('it throws an error if no argument is passed', async function (assert: Assert) {
+      setupOnerror((err: Error) => {
+        assert.equal(
+          err.message,
+          'Assertion Failed: [component][OSS::CompletionBadge] One of @icon, @image or @text arguments is mandatory. You passed 0 arguments'
+        );
+      });
+
+      await render(hbs`<OSS::CompletionBadge />`);
+    });
+
+    test('it throws an error if more than one content argument is passed', async function (assert: Assert) {
+      setupOnerror((err: Error) => {
+        assert.equal(
+          err.message,
+          'Assertion Failed: [component][OSS::CompletionBadge] One of @icon, @image or @text arguments is mandatory. You passed 2 arguments'
+        );
+      });
+
+      await render(hbs`<OSS::CompletionBadge @icon="fas fa-users" @text="2x" />`);
+    });
+  });
+});

--- a/tests/integration/components/o-s-s/completion-badge-test.ts
+++ b/tests/integration/components/o-s-s/completion-badge-test.ts
@@ -55,9 +55,7 @@ module('Integration | Component | o-s-s/completion-badge', function (hooks) {
   module('progress', function () {
     test('it renders only the background border when @progress is undefined', async function (assert) {
       await render(hbs`<OSS::CompletionBadge @icon="fas fa-check" />`);
-
       const rgbValues = getCSSVarValuesInRGB();
-      console.log('RGB Values:', rgbValues);
 
       assert.dom('.upf-completion-badge-ring').hasStyle({
         backgroundImage: `conic-gradient(${rgbValues.progressColor} 0deg, ${rgbValues.progressColor} 0deg, ${rgbValues.backgroundColor} 0deg, ${rgbValues.backgroundColor} 360deg)`


### PR DESCRIPTION
### What does this PR do?
_**YABC**_ - _Yet another badge component_

The CompletionBadge component brings a new badge component with a custom progression border around it.

It extends `OSS::Badge` and thus features the same options, such as size, skin, plain, etc. (Minor updates were made to the Badge component class to have better TS typings)

The progression value can be passed as a value between 0 & 100 in the `@progress` variable; this value will then be used to apply the correct border around the component.
Not providing a value defaults to 0, and going above 100 will cap the progress at 100.

https://github.com/user-attachments/assets/9e37b3f5-b20b-4290-a37a-cf6f2c9c5935

As you can see in the video, it also supports the ability to react to the live updates of the `progress` value.
There's a code example of this in the dummy app, but basically any change to a tracked "progress" variable will be applied to the borders dynamically & with a proper animation.

### Good PR checklist
- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [x] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled
