### PR TITLE
Remove compact notion for value inferior to 1000

### DIFF
--- a/addon/helpers/format-money.ts
+++ b/addon/helpers/format-money.ts
@@ -1,6 +1,6 @@
 import Helper from '@ember/component/helper';
 
-var _getFormatter = function (currency: string, compact?: boolean) {
+let _getFormatter = function (currency: string, compact?: boolean) {
   return Intl.NumberFormat(['en-EN', 'fr-FR'], {
     style: 'currency',
     currency: currency,
@@ -10,7 +10,7 @@ var _getFormatter = function (currency: string, compact?: boolean) {
   });
 };
 
-var _formatMoney = function (
+let _formatMoney = function (
   amount: string,
   currency: string,
   format: 'raw' | 'cents' = 'raw',
@@ -22,7 +22,8 @@ var _formatMoney = function (
 };
 
 export function formatMoneyHelper(params: any[]) {
-  const [amount, currency, format = 'raw', compact = false] = params;
+  let [amount, currency, format = 'raw', compact = false] = params;
+  if ((amount < 1000 && format === 'raw') || (amount < 100000 && format === 'cents')) compact = false;
   return _formatMoney(amount, currency, format, compact);
 }
 

--- a/addon/helpers/format-money.ts
+++ b/addon/helpers/format-money.ts
@@ -1,6 +1,9 @@
 import Helper from '@ember/component/helper';
 
-let _getFormatter = function (currency: string, compact?: boolean) {
+export const PREVENT_COMPACT_NOTATION_ON_RAW_BELOW = 1000;
+export const PREVENT_COMPACT_NOTATION_ON_CENTS_BELOW = PREVENT_COMPACT_NOTATION_ON_RAW_BELOW * 100;
+
+const _getFormatter = function (currency: string, compact?: boolean) {
   return Intl.NumberFormat(['en-EN', 'fr-FR'], {
     style: 'currency',
     currency: currency,
@@ -10,7 +13,7 @@ let _getFormatter = function (currency: string, compact?: boolean) {
   });
 };
 
-let _formatMoney = function (
+const _formatMoney = function (
   amount: string,
   currency: string,
   format: 'raw' | 'cents' = 'raw',
@@ -23,7 +26,11 @@ let _formatMoney = function (
 
 export function formatMoneyHelper(params: any[]) {
   let [amount, currency, format = 'raw', compact = false] = params;
-  if ((amount < 1000 && format === 'raw') || (amount < 100000 && format === 'cents')) compact = false;
+  if (
+    (amount < PREVENT_COMPACT_NOTATION_ON_RAW_BELOW && format === 'raw') ||
+    (amount < PREVENT_COMPACT_NOTATION_ON_CENTS_BELOW && format === 'cents')
+  )
+    compact = false;
   return _formatMoney(amount, currency, format, compact);
 }
 

--- a/tests/integration/helpers/format-money-test.ts
+++ b/tests/integration/helpers/format-money-test.ts
@@ -2,6 +2,10 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
+import {
+  PREVENT_COMPACT_NOTATION_ON_CENTS_BELOW,
+  PREVENT_COMPACT_NOTATION_ON_RAW_BELOW
+} from '@upfluence/oss-components/helpers/format-money';
 
 module('Integration | Helper | format-money', function (hooks) {
   setupRenderingTest(hooks);
@@ -25,10 +29,13 @@ module('Integration | Helper | format-money', function (hooks) {
     });
   });
 
-  module('Compact formatting (K/M/B)', function () {
-    test('Before thousands value, it renders complete number when compact is passed as true', async function (assert) {
+  module('Compact formatting (K/M/B)', function (hooks) {
+    hooks.beforeEach(function () {
       this.format = 'raw';
       this.compact = true;
+    });
+
+    test(`Below ${PREVENT_COMPACT_NOTATION_ON_RAW_BELOW} value, it renders complete number when compact is passed as true`, async function (assert) {
       this.amount = 834.89;
 
       await render(hbs`<div>{{format-money this.amount this.currency this.format this.compact}}</div>`);
@@ -36,17 +43,12 @@ module('Integration | Helper | format-money', function (hooks) {
     });
 
     test('Applies a K notation to thousands when compact is passed as true', async function (assert) {
-      this.format = 'raw';
-      this.compact = true;
-
       await render(hbs`<div>{{format-money this.amount this.currency this.format this.compact}}</div>`);
       assert.dom('div').hasText('$1.2K');
     });
 
     test('Applies a M notation to millions when compact is passed as true', async function (assert) {
       this.amount = 1234567.89;
-      this.format = 'raw';
-      this.compact = true;
 
       await render(hbs`<div>{{format-money this.amount this.currency this.format this.compact}}</div>`);
       assert.dom('div').hasText('$1.2M');
@@ -54,19 +56,20 @@ module('Integration | Helper | format-money', function (hooks) {
 
     test('Applies a B notation to billions when compact is passed as true', async function (assert) {
       this.amount = 1234567890.89;
-      this.format = 'raw';
-      this.compact = true;
 
       await render(hbs`<div>{{format-money this.amount this.currency this.format this.compact}}</div>`);
       assert.dom('div').hasText('$1.2B');
     });
   });
 
-  module('Compact + cents formatting', function () {
-    test('Applies a division by 100 when compact is passed as true', async function (assert) {
-      this.amount = 83489;
+  module('Compact + cents formatting', function (hooks) {
+    hooks.beforeEach(function () {
       this.format = 'cents';
       this.compact = true;
+    });
+
+    test(`Below ${PREVENT_COMPACT_NOTATION_ON_CENTS_BELOW} value, it applies a division by 100 when compact is passed as true`, async function (assert) {
+      this.amount = 83489;
 
       await render(hbs`<div>{{format-money this.amount this.currency this.format this.compact}}</div>`);
       assert.dom('div').hasText('$834.89');
@@ -74,8 +77,6 @@ module('Integration | Helper | format-money', function (hooks) {
 
     test('Applies a division by 100 and K notation to thousands when compact is passed as true', async function (assert) {
       this.amount = 123457;
-      this.format = 'cents';
-      this.compact = true;
 
       await render(hbs`<div>{{format-money this.amount this.currency this.format this.compact}}</div>`);
       assert.dom('div').hasText('$1.2K');
@@ -83,8 +84,6 @@ module('Integration | Helper | format-money', function (hooks) {
 
     test('Applies a division by 100 and M notation to millions when compact is passed as true', async function (assert) {
       this.amount = 123457890;
-      this.format = 'cents';
-      this.compact = true;
 
       await render(hbs`<div>{{format-money this.amount this.currency this.format this.compact}}</div>`);
       assert.dom('div').hasText('$1.2M');
@@ -92,8 +91,6 @@ module('Integration | Helper | format-money', function (hooks) {
 
     test('Applies a division by 100 and B notation to billions when compact is passed as true', async function (assert) {
       this.amount = 123457890123;
-      this.format = 'cents';
-      this.compact = true;
 
       await render(hbs`<div>{{format-money this.amount this.currency this.format this.compact}}</div>`);
       assert.dom('div').hasText('$1.2B');

--- a/tests/integration/helpers/format-money-test.ts
+++ b/tests/integration/helpers/format-money-test.ts
@@ -7,25 +7,34 @@ module('Integration | Helper | format-money', function (hooks) {
   setupRenderingTest(hooks);
 
   hooks.beforeEach(function () {
-    this.amount = 1234;
+    this.amount = 1234.89;
     this.currency = 'USD';
   });
 
   module('Basic formatting', function () {
     test('Formats money when an amount and a currency are passed', async function (assert) {
       await render(hbs`<div>{{format-money this.amount this.currency}}</div>`);
-      assert.dom('div').hasText('$1,234');
+      assert.dom('div').hasText('$1,234.89');
     });
 
     test('Divides amount by 100 when cents are passed', async function (assert) {
       this.format = 'cents';
 
       await render(hbs`<div>{{format-money this.amount this.currency this.format}}</div>`);
-      assert.dom('div').hasText('$12.34');
+      assert.dom('div').hasText('$12.35');
     });
   });
 
   module('Compact formatting (K/M/B)', function () {
+    test('Before thousands value, it renders complete number when compact is passed as true', async function (assert) {
+      this.format = 'raw';
+      this.compact = true;
+      this.amount = 834.89;
+
+      await render(hbs`<div>{{format-money this.amount this.currency this.format this.compact}}</div>`);
+      assert.dom('div').hasText('$834.89');
+    });
+
     test('Applies a K notation to thousands when compact is passed as true', async function (assert) {
       this.format = 'raw';
       this.compact = true;
@@ -35,7 +44,7 @@ module('Integration | Helper | format-money', function (hooks) {
     });
 
     test('Applies a M notation to millions when compact is passed as true', async function (assert) {
-      this.amount = 1234567;
+      this.amount = 1234567.89;
       this.format = 'raw';
       this.compact = true;
 
@@ -44,7 +53,7 @@ module('Integration | Helper | format-money', function (hooks) {
     });
 
     test('Applies a B notation to billions when compact is passed as true', async function (assert) {
-      this.amount = 1234567890;
+      this.amount = 1234567890.89;
       this.format = 'raw';
       this.compact = true;
 
@@ -54,6 +63,15 @@ module('Integration | Helper | format-money', function (hooks) {
   });
 
   module('Compact + cents formatting', function () {
+    test('Applies a division by 100 when compact is passed as true', async function (assert) {
+      this.amount = 83489;
+      this.format = 'cents';
+      this.compact = true;
+
+      await render(hbs`<div>{{format-money this.amount this.currency this.format this.compact}}</div>`);
+      assert.dom('div').hasText('$834.89');
+    });
+
     test('Applies a division by 100 and K notation to thousands when compact is passed as true', async function (assert) {
       this.amount = 123457;
       this.format = 'cents';
@@ -63,7 +81,7 @@ module('Integration | Helper | format-money', function (hooks) {
       assert.dom('div').hasText('$1.2K');
     });
 
-    test('Applies a division by 100 and K notation to millions when compact is passed as true', async function (assert) {
+    test('Applies a division by 100 and M notation to millions when compact is passed as true', async function (assert) {
       this.amount = 123457890;
       this.format = 'cents';
       this.compact = true;
@@ -72,7 +90,7 @@ module('Integration | Helper | format-money', function (hooks) {
       assert.dom('div').hasText('$1.2M');
     });
 
-    test('Applies a division by 100 and K notation to billions when compact is passed as true', async function (assert) {
+    test('Applies a division by 100 and B notation to billions when compact is passed as true', async function (assert) {
       this.amount = 123457890123;
       this.format = 'cents';
       this.compact = true;


### PR DESCRIPTION
### What does this PR do?

Remove compact notion for value inferior to 1000 to avoid displaying unnecessary rounding. This allows alignment with the existing `format-numeric` helper

Before the fix with compact true:
- 859.89 -> 860
- 1256.56 -> 1.2k

After the fix with compact true:
- 859.89 -> 859.89
- 1256.56 -> 1.2k

### What are the observable changes?

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled
