### PR TITLE
Allow any other attribute on Steps in WizardConfiguration

### DIFF
--- a/addon/services/wizard-manager.ts
+++ b/addon/services/wizard-manager.ts
@@ -38,6 +38,7 @@ export type WizardConfiguration = {
       key: string;
       componentClass: any;
       validateStep?: () => Promise<boolean>;
+      [key: string]: unknown;
     }[];
   }[];
 };
@@ -195,7 +196,7 @@ export default class WizardManager extends Service {
         id: guidFor(section.key),
         key: section.key,
         steps: section.steps.map((step) => {
-          return {
+          let defaultStep: Step = {
             id: guidFor(step.key),
             key: step.key,
             componentClass: step.componentClass,
@@ -203,6 +204,8 @@ export default class WizardManager extends Service {
             displayState: 'none',
             visited: false
           };
+
+          return { ...defaultStep, ...step };
         })
       };
     });

--- a/tests/unit/services/wizard-manager-test.ts
+++ b/tests/unit/services/wizard-manager-test.ts
@@ -43,6 +43,27 @@ module('Unit | Service | wizard-manager', function (hooks) {
       assert.equal(this.service.allSteps[1].key, 'step-2');
     });
 
+    test('Extra step properties are preserved', function (assert) {
+      const extraProperty = { customProp: 'customValue' };
+      this.config = {
+        sections: [createSection('section-1', [createStep('step-1', extraProperty), createStep('step-2')])]
+      };
+      this.service.initialize(this.config as WizardConfiguration);
+      const step1 = this.service.allSteps[0];
+      assert.equal(step1.customProp, 'customValue', 'Extra properties are preserved in steps');
+    });
+
+    test('Setting a visited attribute on steps overwrites the default', function (assert) {
+      this.config = {
+        sections: [createSection('section-1', [createStep('step-1', { visited: true }), createStep('step-2')])]
+      };
+      this.service.initialize(this.config as WizardConfiguration);
+      const step1 = this.service.allSteps[0];
+      const step2 = this.service.allSteps[1];
+      assert.true(step1.visited);
+      assert.false(step2.visited);
+    });
+
     test('Focused step is set to first step', function (assert) {
       this.service.initialize(this.config as WizardConfiguration);
 


### PR DESCRIPTION
### What does this PR do?

Allow any other attribute on Steps in WizardConfiguration

### Good PR checklist
- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled