### PR TITLE
Wizard-manager: Handle hidden steps & allow passing options to sections

### DIFF
--- a/addon/components/wizard/step-wrapper.ts
+++ b/addon/components/wizard/step-wrapper.ts
@@ -39,6 +39,8 @@ export default class WizardStepWrapperComponent extends Component<WizardStepWrap
       classArray.push(`${this.baseClass}__next`);
     } else if (this.args.step.displayState === 'active') {
       classArray.push(`${this.baseClass}__active`);
+    } else if (this.args.step.hidden === true) {
+      classArray.push(`${this.baseClass}__hidden`);
     }
     return classArray.join(' ');
   }

--- a/app/styles/organisms/wizard-container.less
+++ b/app/styles/organisms/wizard-container.less
@@ -19,6 +19,12 @@
     padding: var(--spacing-px-12);
   }
 
+  .step-wrapper__hidden {
+    min-height: 0px;
+    padding: 0px;
+    display: none;
+  }
+
   .step-wrapper__active {
     border: 1px solid var(--color-border-default);
     background: var(--color-white);
@@ -28,7 +34,7 @@
   .step-wrapper__next {
     overflow: hidden;
     pointer-events: none;
-    opacity: .5;
+    opacity: 0.5;
     background-color: var(--color-gray-50);
     border: 1px solid var(--color-border-default);
     box-shadow: var(--box-shadow-xs);

--- a/tests/integration/components/wizard/step-wrapper-test.ts
+++ b/tests/integration/components/wizard/step-wrapper-test.ts
@@ -55,6 +55,13 @@ module('Integration | Component | wizard/step-wrapper', function (hooks) {
 
         assert.dom('.step-wrapper__next').exists();
       });
+
+      test('Hidden step - It applies the "hidden" class when the step is not visited', async function (assert) {
+        this.step.hidden = true;
+        await render(hbs`<Wizard::StepWrapper @step={{this.step}} @stepWrapperBaseClass="custom-step-wrapper" />`);
+
+        assert.dom('.step-wrapper__hidden').exists();
+      });
     });
 
     module('When a stepWrapperBaseClass is set in the wizard-manager', function (hooks) {


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the context of this pull request and its purpose. -->

Related to: #[DRA-3596](https://linear.app/upfluence/issue/DRA-3596/publishr-admin-web-groundwork-make-hidewhennotinfocus-step-not)

### What are the observable changes?
<!-- This question could be adequate with multiple use cases, for example: -->
Wizard manager: Handle new hidden property on step
- Hidden steps are not visible 
- Hidden steps does not appears in next/previous step
- Allow passing options to sections 

Step-wrapper:
- Add new __hidden class

<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->

### Good PR checklist
- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled
