### PR TITLE
Smart pill: Enable rotating gradient animation only when pill is sele…

### DIFF
--- a/addon/components/o-s-s/smart/immersive/select.hbs
+++ b/addon/components/o-s-s/smart/immersive/select.hbs
@@ -50,8 +50,8 @@
       >
         <:option as |item|>
           <div
-            class="item-wrapper fx-row fx-xalign-center
-              {{if @multiple 'fx-gap-px-6' 'fx-malign-space-between'}}
+            class="item-wrapper fx-row fx-xalign-center fx-gap-px-6
+              {{unless @multiple 'fx-malign-space-between'}}
               {{if (this.isSelected value=item.value) 'selected'}}"
           >
             {{#if (and @multiple (not @hideCheckboxes))}}

--- a/addon/components/o-s-s/smart/pill.ts
+++ b/addon/components/o-s-s/smart/pill.ts
@@ -31,7 +31,7 @@ export default class OSSSmartPill extends OSSPill<OSSSmartPillArgs> {
 
   @action
   runAnimationOnLoadEnd(): void {
-    if (this.element && this.args.loading === false) {
+    if (this.element && this.args.loading === false && this.args.selected) {
       runSmartGradientAnimation(this.element);
     }
   }

--- a/tests/integration/components/o-s-s/smart/pill-test.ts
+++ b/tests/integration/components/o-s-s/smart/pill-test.ts
@@ -47,11 +47,30 @@ module('Integration | Component | o-s-s/smart/pill', function (hooks) {
       assert.dom('.label').hasClass('loading-animation');
     });
 
-    test('Once loading is over, it displays the corresponding animation', async function (assert) {
-      await render(hbs`<OSS::Smart::Pill @label="Pill" @loading={{this.loading}} />`);
+    module('When selected is true', (hooks) => {
+      hooks.beforeEach(function () {
+        this.selected = true;
+      });
 
-      this.set('loading', false);
-      assert.dom('.oss-smart-pill-container').hasClass('smart-rotating-gradient');
+      test('Once loading is over, it displays the corresponding animation', async function (assert) {
+        await render(hbs`<OSS::Smart::Pill @label="Pill" @loading={{this.loading}} @selected={{this.selected}}/>`);
+
+        this.set('loading', false);
+        assert.dom('.oss-smart-pill-container').hasClass('smart-rotating-gradient');
+      });
+    });
+
+    module('When selected is false', (hooks) => {
+      hooks.beforeEach(function () {
+        this.selected = false;
+      });
+
+      test('Once loading is over, it does not displays the corresponding animation', async function (assert) {
+        await render(hbs`<OSS::Smart::Pill @label="Pill" @loading={{this.loading}} @selected={{this.selected}}/>`);
+
+        this.set('loading', false);
+        assert.dom('.oss-smart-pill-container').doesNotHaveClass('smart-rotating-gradient');
+      });
     });
   });
 });


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the context of this pull request and its purpose. -->

Related to: #[DRA-3532](https://linear.app/upfluence/issue/DRA-3532/publishr-admin-web-new-targetaudience-step)

### What are the observable changes?
<!-- This question could be adequate with multiple use cases, for example: -->

- Trigger smart animation when pill is selected
- Smart::Immersive::Select add gap in items when multiple is false
<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->

### Good PR checklist
- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled
