### PR TITLE
Visual (logo size / active color) & group delay fixes

### DIFF
--- a/addon/components/o-s-s/layout/sidebar/group.hbs
+++ b/addon/components/o-s-s/layout/sidebar/group.hbs
@@ -42,7 +42,7 @@
       "oss-sidebar-group__items-container"
       (if (or @expanded this.displayGroupList) " oss-sidebar-group__items-container--visible")
     }}
-    {{on "mouseenter" (fn (mut this.groupListHovered) true)}}
+    {{on "mouseenter" this.handleGroupListEnter}}
     {{on "mouseleave" this.handleGroupListLeave}}
   >
     {{#unless @expanded}}

--- a/addon/components/o-s-s/layout/sidebar/group.ts
+++ b/addon/components/o-s-s/layout/sidebar/group.ts
@@ -30,8 +30,8 @@ export default class OSSLayoutSidebarGroupComponent extends Component<OSSLayoutS
   @tracked triggerHovered: boolean = false;
   @tracked groupListHovered: boolean = false;
   @tracked collapsed: boolean = false;
-  @tracked hideGroupListTimeout: number = 0;
-  @tracked handleMouseLeaveTimeout: number = 0;
+  hideGroupListTimeout: number = 0;
+  handleMouseLeaveTimeout: number = 0;
 
   declare triggerElement: HTMLElement;
 

--- a/addon/components/o-s-s/layout/sidebar/group.ts
+++ b/addon/components/o-s-s/layout/sidebar/group.ts
@@ -1,7 +1,7 @@
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
-import { later, scheduleOnce } from '@ember/runloop';
+import { scheduleOnce } from '@ember/runloop';
 
 export type GroupItem = {
   icon?: string;
@@ -23,12 +23,15 @@ interface OSSLayoutSidebarGroupComponentSignature {
 }
 
 const GROUP_LIST_HIDE_DELAY = 450;
+const ITEM_LEAVE_DELAY = 50;
 
 export default class OSSLayoutSidebarGroupComponent extends Component<OSSLayoutSidebarGroupComponentSignature> {
   @tracked displayGroupList: boolean = false;
   @tracked triggerHovered: boolean = false;
   @tracked groupListHovered: boolean = false;
   @tracked collapsed: boolean = false;
+  @tracked hideGroupListTimeout: number = 0;
+  @tracked handleMouseLeaveTimeout: number = 0;
 
   declare triggerElement: HTMLElement;
 
@@ -69,29 +72,36 @@ export default class OSSLayoutSidebarGroupComponent extends Component<OSSLayoutS
   handleMouseEnter(): void {
     if (this.args.expanded) return;
 
+    this.clearTimeouts();
     scheduleOnce('afterRender', this, () => {
       this.triggerHovered = this.displayGroupList = true;
+    });
+
+    document.querySelectorAll('.oss-sidebar-group__items-container--visible').forEach((el) => {
+      if (!this.triggerElement.contains(el)) {
+        el.classList.remove('oss-sidebar-group__items-container--visible');
+      }
     });
   }
 
   @action
-  handleMouseLeave(event: MouseEvent & { relatedTarget: HTMLElement }): void {
-    if (this.args.expanded || this.triggerElement.querySelector('.oss-sidebar-item')!.contains(event.relatedTarget)) {
-      return;
-    }
+  handleMouseLeave(): void {
+    if (this.args.expanded) return;
 
     this.triggerHovered = false;
 
-    later(
-      this,
-      () => {
-        const hoveredAway =
-          document.querySelector('.oss-sidebar-group.oss-sidebar-group--hovered') !== null &&
-          document.querySelector('.oss-sidebar-group.oss-sidebar-group--hovered') !== this.triggerElement;
-        this.hideGroupList(hoveredAway);
-      },
-      50
-    );
+    this.handleMouseLeaveTimeout = setTimeout(() => {
+      const hoveredAway =
+        document.querySelector('.oss-sidebar-group.oss-sidebar-group--hovered') !== null &&
+        document.querySelector('.oss-sidebar-group.oss-sidebar-group--hovered') !== this.triggerElement;
+      this.hideGroupList(hoveredAway);
+    }, ITEM_LEAVE_DELAY);
+  }
+
+  @action
+  handleGroupListEnter(): void {
+    this.groupListHovered = true;
+    this.clearTimeouts();
   }
 
   @action
@@ -116,6 +126,11 @@ export default class OSSLayoutSidebarGroupComponent extends Component<OSSLayoutS
       return;
     }
 
-    later(this, hide, GROUP_LIST_HIDE_DELAY);
+    this.hideGroupListTimeout = setTimeout(() => hide(), GROUP_LIST_HIDE_DELAY);
+  }
+
+  private clearTimeouts(): void {
+    clearTimeout(this.hideGroupListTimeout);
+    clearTimeout(this.handleMouseLeaveTimeout);
   }
 }

--- a/addon/components/o-s-s/layout/sidebar/item.hbs
+++ b/addon/components/o-s-s/layout/sidebar/item.hbs
@@ -3,6 +3,7 @@
   class={{this.computedClasses}}
   disabled={{this.locked}}
   {{on "click" this.onClick}}
+  {{on "mouseenter" this.handleMouseEnter}}
   ...attributes
 >
   {{#if this.locked}}

--- a/addon/components/o-s-s/layout/sidebar/item.ts
+++ b/addon/components/o-s-s/layout/sidebar/item.ts
@@ -39,4 +39,13 @@ export default class OSSLayoutSidebarItem extends Component<OSSLayoutSidebarItem
       this.args.lockedAction?.();
     }
   }
+
+  @action
+  handleMouseEnter(event: PointerEvent): void {
+    if (this.args.expanded || (event.currentTarget as HTMLElement).closest('.oss-sidebar-group') !== null) return;
+
+    document.querySelectorAll('.oss-sidebar-group__items-container--visible').forEach((el) => {
+      el.classList.remove('oss-sidebar-group__items-container--visible');
+    });
+  }
 }

--- a/app/styles/organisms/sidebar.less
+++ b/app/styles/organisms/sidebar.less
@@ -39,6 +39,7 @@
       max-height: 30px;
     }
 
+    .oss-sidebar-item:not(:hover),
     .oss-sidebar-item.active:not(:hover) {
       background-color: transparent;
       border: 1px solid transparent;
@@ -69,10 +70,6 @@
     border-top: 1px solid var(--sidebar-inner-border-color);
     margin-right: -1px;
   }
-}
-
-a.oss-sidebar-item:focus {
-  color: var(--sidebar-font-color);
 }
 
 .oss-sidebar-item {

--- a/app/styles/organisms/sidebar.less
+++ b/app/styles/organisms/sidebar.less
@@ -39,8 +39,7 @@
       max-height: 30px;
     }
 
-    .oss-sidebar-item:not(:hover),
-    .oss-sidebar-item.active:not(:hover) {
+    .oss-sidebar-item {
       background-color: transparent;
       border: 1px solid transparent;
     }


### PR DESCRIPTION
### What does this PR do?

Visual (logo size / active color) & group delay fixes:
- Upfluence logo is moving a bit when hovering it when workflow app is selected
- Improve group menu reactivity when collapsed
- There are weird color changes gray/blue when selecting an app. It doesn't seem consistent depending on if the app is in a group or not. This is also the case when the sidebar is collapsed with icon colors (come from the focus style)

### What are the observable changes?
<!-- This question could be adequate with multiple use cases, for example: -->

<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled
