### PR TITLE
WizardManager : Focus and display each step in between when changing step

### DIFF
--- a/addon/services/wizard-manager.ts
+++ b/addon/services/wizard-manager.ts
@@ -188,12 +188,19 @@ export default class WizardManager extends Service {
   }
 
   private focusStep(stepId: string): void {
-    const stepExists = this.sections.some((section: Section) => section.steps.some((step: Step) => step.id === stepId));
-    if (stepExists) {
-      set(this, 'focusedStepId', stepId);
+    const stepPosition: 'before' | 'after' =
+      this.findIndexOfStep(stepId) > this.findIndexOfStep(this.focusedStepId) ? 'after' : 'before';
+    const targetStep = stepPosition === 'after' ? this.nextStep : this.previousStep;
+    if (targetStep) {
+      set(this, 'focusedStepId', targetStep.id);
       this.setDisplayStates();
       next(this, () => {
         document.getElementById(stepId)?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+        if (stepId !== this.focusedStepId) {
+          next(this, () => {
+            this.focusStep(stepId);
+          });
+        }
       });
     }
   }

--- a/tests/unit/services/wizard-manager-test.ts
+++ b/tests/unit/services/wizard-manager-test.ts
@@ -130,7 +130,7 @@ module('Unit | Service | wizard-manager', function (hooks) {
 
       this.service.selectStep(step2Id, true);
       await settled();
-      assert.equal(this.service.focusedStepId, step1Id);
+      assert.equal(this.service.focusedStepId, step2Id);
       assert.true(this.validateStub.notCalled, 'validateStep was not called when bypassValidations is true');
     });
 


### PR DESCRIPTION
### What does this PR do?

The current wizard-manager service implemention of `focusStep` directly sets the target step passed in parameter as the visible one. This messes up some rendering when moving to steps far enough away that their sub-components are not rendered.

The following PR makes the `focusStep` method of the wizard-manager focus each step between the current step and the target one. Which means all steps in between (and the final one ofc) are set to visible at some point.
This fixes a rendering issue with our custom "step lifecycle hooks" but also fixes when scrolling over a big amount of sections. We would only see empty steps in between, now the previews are properly rendered.

### Good PR checklist
- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled