### PR TITLE
Smart immersive input: Handle suffix/prefix name block

### DIFF
--- a/addon/components/o-s-s/smart/immersive/input.hbs
+++ b/addon/components/o-s-s/smart/immersive/input.hbs
@@ -6,23 +6,35 @@
   ...attributes
 >
   <:input>
-    {{#if @loading}}
-      <div class="upf-input loading-placeholder fx-row fx-xalign-center">
-        <span class="smart_text_animated">{{@placeholder}}</span>
-      </div>
-    {{else}}
-      <div class="smart-immersive-input-sizer">
-        <span class="smart-immersive-span-placeholder">{{or @value @placeholder}}</span>
-        <Input
-          @value={{@value}}
-          @type={{this.type}}
-          placeholder={{this.placeholder}}
-          disabled={{@disabled}}
-          class="smart-immersive--input"
-          aria-label="input"
-          {{on "input" (fn this.onChange @value)}}
-        />
-      </div>
-    {{/if}}
+    <div class="smart-immersive--input-container">
+      {{#if (has-block "prefix")}}
+        <div class="prefix">
+          {{yield to="prefix"}}
+        </div>
+      {{/if}}
+      {{#if @loading}}
+        <div class="upf-input loading-placeholder fx-row fx-xalign-center">
+          <span class="smart_text_animated">{{@placeholder}}</span>
+        </div>
+      {{else}}
+        <div class="smart-immersive-input-sizer">
+          <span class="smart-immersive-span-placeholder">{{or @value @placeholder}}</span>
+          <Input
+            @value={{@value}}
+            @type={{this.type}}
+            placeholder={{this.placeholder}}
+            disabled={{@disabled}}
+            class="smart-immersive--input"
+            aria-label="input"
+            {{on "input" (fn this.onChange @value)}}
+          />
+        </div>
+      {{/if}}
+      {{#if (has-block "suffix")}}
+        <div class="suffix">
+          {{yield to="suffix"}}
+        </div>
+      {{/if}}
+    </div>
   </:input>
 </OSS::InputContainer>

--- a/addon/components/o-s-s/smart/immersive/input.stories.js
+++ b/addon/components/o-s-s/smart/immersive/input.stories.js
@@ -96,11 +96,41 @@ const defaultArgs = {
 
 const DefaultUsageTemplate = (args) => ({
   template: hbs`
-      <Smart::Immersive::Input @value={{this.value}} @disabled={{this.disabled}} @placeholder={{this.placeholder}} @type={{this.type}}
-                               @errorMessage={{this.errorMessage}} @onChange={{this.onChange}} />
+    <OSS::Smart::Immersive::Input @value={{this.value}} @disabled={{this.disabled}} @placeholder={{this.placeholder}} @type={{this.type}}
+                              @errorMessage={{this.errorMessage}} @onChange={{this.onChange}} />
   `,
   context: args
 });
 
 export const BasicUsage = DefaultUsageTemplate.bind({});
 BasicUsage.args = defaultArgs;
+
+const PrefixUsageTemplate = (args) => ({
+  template: hbs`
+      <OSS::Smart::Immersive::Input @value={{this.value}} @disabled={{this.disabled}} @placeholder={{this.placeholder}} @type={{this.type}}
+                               @errorMessage={{this.errorMessage}} @onChange={{this.onChange}}>
+        <:prefix>
+          <i class="fas fa-user" />
+        </:prefix>
+      </OSS::Smart::Immersive::Input>
+  `,
+  context: args
+});
+
+export const PrefixUsage = PrefixUsageTemplate.bind({});
+PrefixUsage.args = defaultArgs;
+
+const SuffixUsageTemplate = (args) => ({
+  template: hbs`
+      <OSS::Smart::Immersive::Input @value={{this.value}} @disabled={{this.disabled}} @placeholder={{this.placeholder}} @type={{this.type}}
+                               @errorMessage={{this.errorMessage}} @onChange={{this.onChange}}>
+        <:suffix>
+          <i class="fas fa-user" />
+        </:suffix>
+      </OSS::Smart::Immersive::Input>
+  `,
+  context: args
+});
+
+export const SuffixUsage = SuffixUsageTemplate.bind({});
+SuffixUsage.args = defaultArgs;

--- a/app/styles/atoms/smart/immersive-input.less
+++ b/app/styles/atoms/smart/immersive-input.less
@@ -18,17 +18,42 @@
     }
   }
 
+  .smart-immersive--input-container {
+    display: flex;
+    border: 1px dashed var(--color-gray-400);
+    border-radius: var(--border-radius-sm);
+    height: 32px;
+    overflow: hidden;
+
+    .prefix,
+    .suffix {
+      display: flex;
+      position: relative;
+      background-color: var(--color-gray-100);
+      color: var(--color-gray-500);
+    }
+
+    &:focus,
+    &:active,
+    &:hover {
+      border: 1px dashed var(--color-gray-600);
+      background-color: transparent;
+      box-shadow: none;
+    }
+  }
+
   &.oss-input-container {
     .smart-immersive--input,
     .loading-placeholder {
-      height: 32px;
+      height: 100%;
       min-width: 50px;
-      border: 1px dashed var(--color-gray-400);
+      border: 0;
+      border-radius: 0;
 
       &:focus,
       &:active,
       &:hover {
-        border: 1px dashed var(--color-gray-600);
+        border: 0;
         background-color: transparent;
         box-shadow: none;
       }
@@ -69,16 +94,19 @@
   }
 
   &.oss-input-container.smart-rotating-gradient {
-    .smart-immersive--input {
+    .smart-immersive--input-container {
       border: 1px dashed transparent;
     }
   }
 
   &--filled {
     &.oss-input-container {
-      .smart-immersive--input {
-        color: var(--color-primary-400);
+      .smart-immersive--input-container {
         border-color: var(--color-primary-400);
+
+        .smart-immersive--input {
+          color: var(--color-primary-400);
+        }
 
         &:focus,
         &:active {
@@ -86,15 +114,30 @@
         }
 
         &:hover:not(:focus, :active) {
-          color: var(--color-primary-300);
           border: 1px dashed var(--color-primary-300);
+
+          .smart-immersive--input {
+            color: var(--color-primary-300);
+          }
+
+          .prefix,
+          .suffix {
+            color: var(--color-primary-300);
+          }
+        }
+
+        .prefix,
+        .suffix {
+          background-color: var(--color-primary-50);
+          color: var(--color-primary-400);
         }
       }
     }
   }
+
   &--warning {
     &.oss-input-container {
-      .smart-immersive--input {
+      .smart-immersive--input-container {
         border-color: var(--color-warning-500);
 
         &:hover:not(:focus, :active),
@@ -108,7 +151,7 @@
 
   &--success {
     &.oss-input-container {
-      .smart-immersive--input {
+      .smart-immersive--input-container {
         border-color: var(--color-success-500);
 
         &:hover:not(:focus, :active),
@@ -123,7 +166,7 @@
   &--errored,
   &--error {
     &.oss-input-container {
-      .smart-immersive--input {
+      .smart-immersive--input-container {
         border-color: var(--color-error-500);
 
         &:hover:not(:focus, :active),

--- a/tests/dummy/app/templates/smart.hbs
+++ b/tests/dummy/app/templates/smart.hbs
@@ -167,7 +167,11 @@
     </div>
     <div class="fx-col fx-gap-px-24 fx-xalign-center">
       <OSS::Button @label="Toggle loading" {{on "click" this.toggleLoading}} />
-      <OSS::Smart::Immersive::Input @placeholder="Placeholder" @value={{this.value}} @loading={{this.loading}} />
+      <OSS::Smart::Immersive::Input @placeholder="Placeholder" @value={{this.value}} @loading={{this.loading}}>
+        <:suffix>
+          <i class="fas fa-user" />
+        </:suffix>
+      </OSS::Smart::Immersive::Input>
       <OSS::Smart::Immersive::Input
         @placeholder="Placeholder"
         @value={{this.value}}

--- a/tests/integration/components/o-s-s/smart/immersive/input-test.ts
+++ b/tests/integration/components/o-s-s/smart/immersive/input-test.ts
@@ -89,16 +89,74 @@ module('Integration | Component | o-s-s/smart/immersive/input', function (hooks)
       await renderComponent();
 
       const element = document.querySelector('.smart-immersive-input-container') as HTMLElement;
-      assert.equal(element.offsetWidth, 50);
+      assert.equal(element.offsetWidth, 52);
     });
 
     test('When input has value or placeholder, the size is based on input content', async function (assert) {
       await renderComponent();
 
       const element = document.querySelector('.smart-immersive-input-container') as HTMLElement;
-      assert.equal(element.offsetWidth, 102);
+      assert.equal(element.offsetWidth, 104);
       await typeIn('.smart-immersive-input-container input', 'more text');
-      assert.equal(element.offsetWidth, 156);
+      assert.equal(element.offsetWidth, 158);
+    });
+  });
+
+  module('Prefix name block', () => {
+    test('When no prefix is passed, prefix section is not displayed', async function (assert) {
+      await render(
+        hbs`<OSS::Smart::Immersive::Input @value={{this.value}} 
+                                        @placeholder={{this.placeholder}}
+                                        @loading={{this.loading}}
+                                        @onChange={{this.onChange}} />`
+      );
+
+      assert.dom('.smart-immersive-input-container .prefix').doesNotExist();
+    });
+
+    test('When a prefix is passed, prefix section is displayed properly', async function (assert) {
+      await render(
+        hbs`<OSS::Smart::Immersive::Input @value={{this.value}} 
+                                        @placeholder={{this.placeholder}}
+                                        @loading={{this.loading}}
+                                        @onChange={{this.onChange}}>
+            <:prefix>
+              <i class="fas fa-user" />
+            </:prefix>
+          </OSS::Smart::Immersive::Input>`
+      );
+
+      assert.dom('.smart-immersive-input-container .prefix').exists();
+      assert.dom('.smart-immersive-input-container .prefix i.fas.fa-user').exists();
+    });
+  });
+
+  module('Suffix name block', () => {
+    test('When no suffix is passed, suffix section is not displayed', async function (assert) {
+      await render(
+        hbs`<OSS::Smart::Immersive::Input @value={{this.value}} 
+                                        @placeholder={{this.placeholder}}
+                                        @loading={{this.loading}}
+                                        @onChange={{this.onChange}} />`
+      );
+
+      assert.dom('.smart-immersive-input-container .suffix').doesNotExist();
+    });
+
+    test('When a suffix is passed, suffix section is displayed properly', async function (assert) {
+      await render(
+        hbs`<OSS::Smart::Immersive::Input @value={{this.value}} 
+                                        @placeholder={{this.placeholder}}
+                                        @loading={{this.loading}}
+                                        @onChange={{this.onChange}}>
+            <:suffix>
+              <i class="fas fa-user" />
+            </:suffix>
+          </OSS::Smart::Immersive::Input>`
+      );
+
+      assert.dom('.smart-immersive-input-container .suffix').exists();
+      assert.dom('.smart-immersive-input-container .suffix i.fas.fa-user').exists();
     });
   });
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the context of this pull request and its purpose. -->

Related to: #[DRA-3557](https://linear.app/upfluence/issue/DRA-3557/publishr-admin-web-new-affiliatecommission-step)

### What are the observable changes?
<!-- This question could be adequate with multiple use cases, for example: -->
Allow prefix/suffix name block on OSS::Smart::Immersive::Input component
<img width="327" height="446" alt="Capture d’écran 2025-09-30 à 09 45 32" src="https://github.com/user-attachments/assets/ab4e55d3-afad-4647-af20-a4a0b4d43652" />

<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->

### Good PR checklist
- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled
