### PR TITLE
Added index on Power Select selected items

### DIFF
--- a/addon/components/o-s-s/power-select.hbs
+++ b/addon/components/o-s-s/power-select.hbs
@@ -9,8 +9,8 @@
   <div class="upf-power-select__array-container" role="button" {{on "click" this.toggleDropdown}}>
     <div class="array-input-container {{this.inputBorderStateClass}} fx-row padding-px-6 {{if this.isOpen 'active'}}">
       <div class="fx-row fx-xalign-center fx-1 padding-left-px-6 padding-right-px-24 fx-gap-px-6 fx-wrap">
-        {{#each @selectedItems as |selectedItem|}}
-          {{yield selectedItem to="selected-item"}}
+        {{#each @selectedItems as |selectedItem index|}}
+          {{yield selectedItem index to="selected-item"}}
         {{else}}
           <span class="text-size-5 text-color-default-light">
             {{this.placeholder}}

--- a/tests/integration/components/o-s-s/power-select-test.ts
+++ b/tests/integration/components/o-s-s/power-select-test.ts
@@ -133,6 +133,25 @@ module('Integration | Component | o-s-s/power-select', function (hooks) {
 
       assert.dom('.array-input-container').hasText('placeholder');
     });
+
+    test('each @selectedItems element has its index accessible for dynamic classes', async function (assert) {
+      this.selectedItems = ['value1', 'value2'];
+      await render(hbs`
+        <OSS::PowerSelect @selectedItems={{this.selectedItems}} @items={{this.items}}
+                          @onSearch={{this.onSearch}}>
+          <:selected-item as |selectedItem index|>
+            <span class="selected-item-{{index}}">{{selectedItem}}</span>
+          </:selected-item>
+          <:option-item as |item|>
+            {{item}}
+          </:option-item>
+        </OSS::PowerSelect>
+      `);
+
+      await click('.upf-power-select__array-container');
+      assert.dom('span.selected-item-0').hasText('value1');
+      assert.dom('span.selected-item-1').hasText('value2');
+    });
   });
 
   module('with @items', (hooks) => {
@@ -157,6 +176,24 @@ module('Integration | Component | o-s-s/power-select', function (hooks) {
       const domTags = findAll('.upf-infinite-select__item');
       assert.dom(domTags[0]).hasText('value1');
       assert.dom(domTags[1]).hasText('value2');
+    });
+
+    test('each @items element has its index accessible for dynamic classes', async function (assert) {
+      await render(hbs`
+        <OSS::PowerSelect @selectedItems={{this.selectedItems}} @items={{this.items}}
+                          @onSearch={{this.onSearch}}>
+          <:selected-item as |selectedItem|>
+            {{selectedItem}}
+          </:selected-item>
+          <:option-item as |item index|>
+            <span class="item-{{index}}">{{item}}</span>
+          </:option-item>
+        </OSS::PowerSelect>
+      `);
+
+      await click('.upf-power-select__array-container');
+      assert.dom('span.item-0').hasText('value1');
+      assert.dom('span.item-1').hasText('value2');
     });
   });
 


### PR DESCRIPTION
### What does this PR do?

Added index on Power Select selected items to allow parent component to access the index in the yielded options, so that we can have "dynamic" data-control-names based on this index.

Related to: #[dra-3748](https://linear.app/upfluence/issue/DRA-3748/settings-web-adding-missing-data-control-names-on-interactive)

### What are the observable changes?
<!-- This question could be adequate with multiple use cases, for example: -->

<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->

### Good PR checklist
- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled
