### PR TITLE
Allow to disable search and use InfiniteSelect::Option in CurrencyInput 

### DIFF
--- a/addon/components/o-s-s/currency-input.hbs
+++ b/addon/components/o-s-s/currency-input.hbs
@@ -11,8 +11,13 @@
     >
       <div class="fx-col">
         <div class="fx-row fx-gap-px-9">
-          <span>{{this.selectedCurrencySymbol}}</span>
-          {{#if @onlyCurrency}}
+          {{#if this.displayOnlyCurrencyPlaceholder}}
+            <span class="font-color-gray-400">{{@placeholder}}</span>
+          {{else}}
+            <span>{{this.selectedCurrencySymbol}}</span>
+          {{/if}}
+
+          {{#if (and @onlyCurrency (not this.displayOnlyCurrencyPlaceholder))}}
             <span class="margin-right-px-12">{{this.selectedCurrencyCode}}</span>
           {{/if}}
         </div>

--- a/addon/components/o-s-s/currency-input.hbs
+++ b/addon/components/o-s-s/currency-input.hbs
@@ -59,17 +59,20 @@
       @onSearch={{this.onSearch}}
       @onSelect={{this.onSelect}}
       @searchPlaceholder={{t "oss-components.currency-input.search"}}
+      @searchEnabled={{this.enabledSearch}}
       @enableKeyboard={{true}}
       {{on-click-outside this.hideCurrencySelector}}
     >
       <:option as |currency|>
-        <div class="fx-row fx-xalign-center {{if (eq this.selectedCurrency currency) 'row-selected'}}">
-          <span class="symbol text-color-default-light margin-left-xx-sm">{{currency.symbol}}</span>
-          <span class="text-color-default-light margin-left-xx-sm fx-1">{{currency.code}}</span>
-          {{#if (eq this.selectedCurrency currency)}}
-            <OSS::Icon @icon="fa-check" class="font-color-primary-500 padding-right-px-6" />
-          {{/if}}
-        </div>
+        <OSS::InfiniteSelect::Option
+          @title={{currency.code}}
+          @selected={{eq this.selectedCurrency currency}}
+          @onSelect={{fn this.onSelect currency}}
+        >
+          <:prefix>
+            <span class={{if (eq this.selectedCurrency currency) "font-color-primary-500"}}>{{currency.symbol}}</span>
+          </:prefix>
+        </OSS::InfiniteSelect::Option>
       </:option>
     </OSS::InfiniteSelect>
   {{/if}}

--- a/addon/components/o-s-s/currency-input.stories.js
+++ b/addon/components/o-s-s/currency-input.stories.js
@@ -118,7 +118,7 @@ export default {
       description: 'Configuration object for additional component options.',
       table: {
         type: {
-          summary: '{ allowSearch?: boolean }'
+          summary: '{ allowSearch?: boolean, allowEmpty?: boolean }'
         },
         defaultValue: { summary: 'undefined' }
       },
@@ -152,7 +152,8 @@ const defaultArgs = {
   placeholder: undefined,
   allowFloatValues: undefined,
   options: {
-    allowSearch: true
+    allowSearch: true,
+    allowEmpty: false
   }
 };
 

--- a/addon/components/o-s-s/currency-input.stories.js
+++ b/addon/components/o-s-s/currency-input.stories.js
@@ -113,6 +113,16 @@ export default {
         defaultValue: { summary: 'undefined' }
       },
       control: { type: 'boolean' }
+    },
+    options: {
+      description: 'Configuration object for additional component options.',
+      table: {
+        type: {
+          summary: '{ allowSearch?: boolean }'
+        },
+        defaultValue: { summary: 'undefined' }
+      },
+      control: { type: 'object' }
     }
   },
   parameters: {
@@ -140,7 +150,10 @@ const defaultArgs = {
   allowCurrencyUpdate: true,
   allowedCurrencies: undefined,
   placeholder: undefined,
-  allowFloatValues: undefined
+  allowFloatValues: undefined,
+  options: {
+    allowSearch: true
+  }
 };
 
 const Template = (args) => ({
@@ -149,7 +162,7 @@ const Template = (args) => ({
         <OSS::CurrencyInput @value={{this.value}} @currency={{this.currency}} @onChange={{this.onChange}}
                             @onlyCurrency={{this.onlyCurrency}} @errorMessage={{this.errorMessage}} @feedbackMessage={{this.feedbackMessage}}
                             @allowCurrencyUpdate={{this.allowCurrencyUpdate}} @allowedCurrencies={{this.allowedCurrencies}}
-                            @placeholder={{this.placeholder}} @disabled={{this.disabled}} @allowFloatValues={{this.allowFloatValues}} />
+                            @placeholder={{this.placeholder}} @disabled={{this.disabled}} @allowFloatValues={{this.allowFloatValues}} @options={{this.options}} />
       </div>
   `,
   context: args

--- a/addon/components/o-s-s/currency-input.ts
+++ b/addon/components/o-s-s/currency-input.ts
@@ -22,6 +22,9 @@ export interface OSSCurrencyInputArgs {
   feedbackMessage?: FeedbackMessage;
   allowedCurrencies?: Currency[];
   allowFloatValues?: boolean;
+  options?: {
+    allowSearch?: boolean;
+  };
 }
 
 const NUMERIC_ONLY = /^\d$/i;
@@ -117,6 +120,10 @@ export default class OSSCurrencyInput<T extends OSSCurrencyInputArgs> extends Co
 
   get disabled(): boolean {
     return this.args.disabled ?? false;
+  }
+
+  get enabledSearch(): boolean {
+    return this.args.options?.allowSearch ?? true;
   }
 
   get computedClasses(): string {

--- a/addon/components/o-s-s/currency-input.ts
+++ b/addon/components/o-s-s/currency-input.ts
@@ -223,7 +223,8 @@ export default class OSSCurrencyInput<T extends OSSCurrencyInputArgs> extends Co
   }
 
   @action
-  onSelect(value: Currency): void {
+  onSelect(value: Currency, _selected: boolean, event?: PointerEvent): void {
+    event?.stopPropagation();
     this.args.onChange(value.code, this.localValue);
     this.hideCurrencySelector();
   }

--- a/addon/components/o-s-s/currency-input.ts
+++ b/addon/components/o-s-s/currency-input.ts
@@ -24,6 +24,7 @@ export interface OSSCurrencyInputArgs {
   allowFloatValues?: boolean;
   options?: {
     allowSearch?: boolean;
+    allowEmpty?: boolean;
   };
 }
 
@@ -100,15 +101,19 @@ export default class OSSCurrencyInput<T extends OSSCurrencyInputArgs> extends Co
   }
 
   get selectedCurrencySymbol(): string {
-    return this.selectedCurrency.symbol || '—';
+    return this.selectedCurrency?.symbol || '—';
   }
 
   get selectedCurrencyCode(): string {
-    return this.selectedCurrency.code || '—';
+    return this.selectedCurrency?.code || '—';
   }
 
-  get selectedCurrency(): Currency {
+  get selectedCurrency(): Currency | undefined {
     if (isEmpty(this.args.currency)) {
+      if (this.args.options?.allowEmpty) {
+        return undefined;
+      }
+
       return this.currencies[0]!;
     }
     return this.currencies.find((currency: Currency) => currency.code === this.args.currency) ?? this.currencies[0]!;
@@ -124,6 +129,10 @@ export default class OSSCurrencyInput<T extends OSSCurrencyInputArgs> extends Co
 
   get enabledSearch(): boolean {
     return this.args.options?.allowSearch ?? true;
+  }
+
+  get displayOnlyCurrencyPlaceholder(): boolean {
+    return !this.selectedCurrency && !!this.args.onlyCurrency && !!this.args.placeholder;
   }
 
   get computedClasses(): string {
@@ -200,6 +209,7 @@ export default class OSSCurrencyInput<T extends OSSCurrencyInputArgs> extends Co
 
   @action
   notifyChanges(): void {
+    if (!this.selectedCurrency) return;
     this.args.onChange(this.selectedCurrency.code, this.localValue);
   }
 

--- a/addon/components/o-s-s/infinite-select/option.ts
+++ b/addon/components/o-s-s/infinite-select/option.ts
@@ -33,7 +33,7 @@ interface OSSInfiniteSelectOptionComponentSignature {
     selectionType?: 'multiple' | 'single';
     selected?: boolean;
     disabled?: boolean;
-    onSelect(value: boolean): void;
+    onSelect(value: boolean, event?: PointerEvent): void;
   };
 
   Blocks: {
@@ -89,8 +89,8 @@ export default class OSSInfiniteSelectOptionComponent extends Component<OSSInfin
   }
 
   @action
-  onSelect(value: boolean): void {
+  onSelect(value: boolean, event?: PointerEvent): void {
     if (this.args.disabled) return;
-    this.args.onSelect(value);
+    this.args.onSelect(value, event);
   }
 }

--- a/app/styles/currency-input.less
+++ b/app/styles/currency-input.less
@@ -46,6 +46,7 @@
       margin-right: 0;
       width: 100%;
       background-color: transparent;
+      color: var(--color-gray-900);
     }
 
     &.currency-input--active {
@@ -160,10 +161,15 @@
     margin-top: var(--spacing-px-6);
     max-width: 100%;
     min-width: 150px;
-    padding: var(--spacing-px-12);
+    padding: var(--spacing-px-6);
 
     .upf-infinite-select__item {
-      padding: var(--spacing-px-6) 0;
+      padding: 0;
+
+      &:hover,
+      &:focus {
+        background-color: transparent;
+      }
     }
 
     .row-selected span {
@@ -172,7 +178,6 @@
   }
 
   .symbol {
-    .font-weight-semibold;
     width: 22px;
   }
 }

--- a/app/styles/currency-input.less
+++ b/app/styles/currency-input.less
@@ -171,10 +171,6 @@
         background-color: transparent;
       }
     }
-
-    .row-selected span {
-      color: var(--color-gray-900);
-    }
   }
 
   .symbol {

--- a/tests/dummy/app/templates/input.hbs
+++ b/tests/dummy/app/templates/input.hbs
@@ -760,8 +760,9 @@
         <OSS::CurrencyInput
           @currency={{this.currencyOnly}}
           @onChange={{this.onCurrencyOnlyChange}}
+          @placeholder="Select a currency"
           @onlyCurrency={{true}}
-          @options={{hash allowSearch=false}}
+          @options={{hash allowSearch=false allowEmpty=true}}
         />
       </div>
       <div class="fx-row fx-gap-px-24 fx-xalign-start">

--- a/tests/dummy/app/templates/input.hbs
+++ b/tests/dummy/app/templates/input.hbs
@@ -743,6 +743,8 @@
           @onChange={{this.onCurrencyInputChange}}
           @allowedCurrencies={{this.allowedCurrencies}}
         />
+      </div>
+      <div class="fx-row fx-gap-px-24 fx-xalign-start">
         <OSS::CurrencyInput
           @currency={{this.currency}}
           @value={{this.currencyValue}}
@@ -754,6 +756,12 @@
           @onChange={{this.onCurrencyOnlyChange}}
           @onlyCurrency={{true}}
           @allowedCurrencies={{this.allowedCurrencies}}
+        />
+        <OSS::CurrencyInput
+          @currency={{this.currencyOnly}}
+          @onChange={{this.onCurrencyOnlyChange}}
+          @onlyCurrency={{true}}
+          @options={{hash allowSearch=false}}
         />
       </div>
       <div class="fx-row fx-gap-px-24 fx-xalign-start">

--- a/tests/integration/components/o-s-s/currency-input-test.ts
+++ b/tests/integration/components/o-s-s/currency-input-test.ts
@@ -382,6 +382,7 @@ module('Integration | Component | o-s-s/currency-input', function (hooks) {
   module('@options argument', () => {
     module('@options.allowSearch', () => {
       test('When no @options.allowSearch is passed, search is enabled by default', async function (assert) {
+        this.options = { allowSearch: true };
         await render(hbs`<OSS::CurrencyInput @onChange={{this.onChange}} />`);
         await click('.currency-selector');
 
@@ -403,6 +404,63 @@ module('Integration | Component | o-s-s/currency-input', function (hooks) {
       await click('.currency-selector');
 
       assert.dom('.upf-infinite-select input').doesNotExist();
+    });
+  });
+
+  module('@options.allowEmpty', () => {
+    test('When @options.allowEmpty is not passed, the first currency is selected by default', async function (assert) {
+      await render(hbs`<OSS::CurrencyInput @onChange={{this.onChange}} />`);
+      assert.dom('.currency-selector').hasText('$');
+    });
+
+    test('When @options.allowEmpty is true and no @currency is passed, no currency is selected in the dropdown', async function (assert) {
+      this.options = { allowEmpty: true };
+      await render(hbs`<OSS::CurrencyInput @onChange={{this.onChange}} @options={{this.options}} />`);
+      await click('.currency-selector');
+      assert.dom('.oss-infinite-select-option--selected').doesNotExist();
+    });
+
+    test('When @options.allowEmpty is true and a @currency is passed, it is marked as selected in the dropdown', async function (assert) {
+      this.options = { allowEmpty: true };
+      await render(hbs`<OSS::CurrencyInput @onChange={{this.onChange}} @currency="EUR" @options={{this.options}} />`);
+      await click('.currency-selector');
+      assert.dom('.oss-infinite-select-option--selected').exists({ count: 1 });
+      assert.dom('.oss-infinite-select-option--selected').containsText('EUR');
+    });
+
+    module('With @onlyCurrency', () => {
+      hooks.beforeEach(function () {
+        this.options = { allowEmpty: true };
+      });
+
+      test('When @options.allowEmpty is true and no @currency is passed, the placeholder is displayed', async function (assert) {
+        await render(
+          hbs`<OSS::CurrencyInput @onChange={{this.onChange}} @onlyCurrency={{true}} @placeholder="Select a currency" @options={{this.options}} />`
+        );
+        assert.dom('.currency-selector').hasText('Select a currency');
+      });
+
+      test('When @options.allowEmpty is true and no @currency is passed, the placeholder has the correct style', async function (assert) {
+        await render(
+          hbs`<OSS::CurrencyInput @onChange={{this.onChange}} @onlyCurrency={{true}} @placeholder="Select a currency" @options={{this.options}} />`
+        );
+        assert.dom('.currency-selector .font-color-gray-400').hasText('Select a currency');
+      });
+
+      test('When @options.allowEmpty is true and a @currency is passed, the currency is displayed instead of the placeholder', async function (assert) {
+        await render(
+          hbs`<OSS::CurrencyInput @onChange={{this.onChange}} @onlyCurrency={{true}} @currency="EUR" @placeholder="Select a currency" @options={{this.options}} />`
+        );
+        assert.dom('.currency-selector').hasText('€ EUR');
+        assert.dom('.currency-selector').doesNotContainText('Select a currency');
+      });
+
+      test('When @options.allowEmpty is true but no @placeholder is passed, the default — is displayed', async function (assert) {
+        await render(
+          hbs`<OSS::CurrencyInput @onChange={{this.onChange}} @onlyCurrency={{true}} @options={{this.options}} />`
+        );
+        assert.dom('.currency-selector').hasText('— —');
+      });
     });
   });
 });

--- a/tests/integration/components/o-s-s/currency-input-test.ts
+++ b/tests/integration/components/o-s-s/currency-input-test.ts
@@ -2,16 +2,7 @@ import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { setupIntl } from 'ember-intl/test-support';
-import {
-  render,
-  setupOnerror,
-  click,
-  findAll,
-  typeIn,
-  triggerKeyEvent,
-  triggerEvent,
-  fillIn
-} from '@ember/test-helpers';
+import { render, setupOnerror, click, findAll, typeIn, triggerKeyEvent, triggerEvent } from '@ember/test-helpers';
 import sinon from 'sinon';
 
 module('Integration | Component | o-s-s/currency-input', function (hooks) {
@@ -134,6 +125,34 @@ module('Integration | Component | o-s-s/currency-input', function (hooks) {
       await click('.currency-selector');
       const clickableRows = findAll('.upf-infinite-select__item');
       assert.equal(clickableRows.length, 2);
+    });
+
+    module('Selected currency highlighting', () => {
+      test('Selected currency has the selected class', async function (assert) {
+        await render(hbs`<OSS::CurrencyInput @currency="EUR" @value="" @onChange={{this.onChange}} />`);
+        await click('.currency-selector');
+
+        assert.dom('.oss-infinite-select-option--selected').exists({ count: 1 });
+        assert.dom('.oss-infinite-select-option--selected').containsText('EUR');
+      });
+
+      test('Selected currency has a check icon', async function (assert) {
+        await render(hbs`<OSS::CurrencyInput @currency="EUR" @value="" @onChange={{this.onChange}} />`);
+        await click('.currency-selector');
+
+        assert.dom('.oss-infinite-select-option--selected .fa-check').exists({ count: 1 });
+      });
+
+      test('Only the selected currency symbol is highlighted with primary color', async function (assert) {
+        await render(hbs`<OSS::CurrencyInput @currency="EUR" @value="" @onChange={{this.onChange}} />`);
+        await click('.currency-selector');
+
+        assert.dom('.oss-infinite-select-option--selected .font-color-primary-500');
+        assert.dom('.oss-infinite-select-option--selected .font-color-primary-500').hasText('€');
+        assert
+          .dom('.oss-infinite-select-option:not(.oss-infinite-select-option--selected) .font-color-primary-500')
+          .doesNotExist();
+      });
     });
   });
 
@@ -357,6 +376,33 @@ module('Integration | Component | o-s-s/currency-input', function (hooks) {
       });
 
       assert.dom('input').hasValue('12345.67');
+    });
+  });
+
+  module('@options argument', () => {
+    module('@options.allowSearch', () => {
+      test('When no @options.allowSearch is passed, search is enabled by default', async function (assert) {
+        await render(hbs`<OSS::CurrencyInput @onChange={{this.onChange}} />`);
+        await click('.currency-selector');
+
+        assert.dom('.upf-infinite-select input').exists();
+      });
+
+      test('When true @options.allowSearch is passed, search is enabled', async function (assert) {
+        this.options = { allowSearch: true };
+        await render(hbs`<OSS::CurrencyInput @onChange={{this.onChange}} @options={{this.options}} />`);
+        await click('.currency-selector');
+
+        assert.dom('.upf-infinite-select input').exists();
+      });
+    });
+
+    test('When false @options.allowSearch is passed, search is disabled', async function (assert) {
+      this.options = { allowSearch: false };
+      await render(hbs`<OSS::CurrencyInput @onChange={{this.onChange}} @options={{this.options}} />`);
+      await click('.currency-selector');
+
+      assert.dom('.upf-infinite-select input').doesNotExist();
     });
   });
 });

--- a/tests/integration/components/o-s-s/infinite-select/option-test.ts
+++ b/tests/integration/components/o-s-s/infinite-select/option-test.ts
@@ -128,7 +128,7 @@ module('Integration | Component | o-s-s/infinite-select/option', function (hooks
     test('it calls the onSelect action when clicked', async function (assert) {
       await render(hbs`<OSS::InfiniteSelect::Option @title={{this.title}} @onSelect={{this.onSelect}} />`);
       await click('.oss-infinite-select-option');
-      assert.ok(this.onSelect.calledOnceWithExactly(true));
+      assert.ok(this.onSelect.calledOnceWith(true, sinon.match.instanceOf(MouseEvent)));
     });
 
     test('if @selected is true, it calls the onSelect action with correct value', async function (assert) {
@@ -136,7 +136,7 @@ module('Integration | Component | o-s-s/infinite-select/option', function (hooks
         hbs`<OSS::InfiniteSelect::Option @title={{this.title}} @selected={{true}} @onSelect={{this.onSelect}} />`
       );
       await click('.oss-infinite-select-option');
-      assert.ok(this.onSelect.calledOnceWithExactly(false));
+      assert.ok(this.onSelect.calledOnceWith(false, sinon.match.instanceOf(MouseEvent)));
     });
 
     test("if @disabled is true, it doesn't call the onSelect action", async function (assert) {
@@ -153,7 +153,7 @@ module('Integration | Component | o-s-s/infinite-select/option', function (hooks
           hbs`<OSS::InfiniteSelect::Option @title={{this.title}} @selectionType="multiple" @onSelect={{this.onSelect}} />`
         );
         await click('.upf-checkbox input');
-        assert.ok(this.onSelect.calledOnceWithExactly(true));
+        assert.ok(this.onSelect.calledOnceWith(true));
       });
 
       test('if @selected is true, it calls the onSelect action with correct value', async function (assert) {
@@ -161,7 +161,7 @@ module('Integration | Component | o-s-s/infinite-select/option', function (hooks
           hbs`<OSS::InfiniteSelect::Option @title={{this.title}} @selectionType="multiple" @selected={{true}} @onSelect={{this.onSelect}} />`
         );
         await click('.upf-checkbox input');
-        assert.ok(this.onSelect.calledOnceWithExactly(false));
+        assert.ok(this.onSelect.calledOnceWith(false));
       });
     });
   });


### PR DESCRIPTION
### What does this PR do?

- Add an `options` argument to the `currency-input` component with an `allowSearch` parameter to conditionally display the search bar in the `infinite-select`
- Add an 'allowEmpty' param to 'options' arg to display placeholder in `onlyCurrency` input
- Harmonize `currency-input`'s styling using the `infinite-select/option` component in the `:options` named-block 
- Change input's value color to match other inputs
- Allow to handle 'stopPropagation' in `infinite-select/option` by passing the click event

Related to: #<!-- enter issue number here -->

### What are the observable changes?
<img width="443" height="317" alt="Capture d’écran 2026-03-23 à 11 15 49" src="https://github.com/user-attachments/assets/63d26176-f8ac-4adb-8f90-4ba9884f8a49" />

Allow empty + placeholder:
<img width="441" height="321" alt="Capture d’écran 2026-03-23 à 11 15 36" src="https://github.com/user-attachments/assets/6b39a658-e420-4dd4-95bf-a4388888411a" />


<!-- This question could be adequate with multiple use cases, for example: -->

<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [ ] Added/updated documentation with Figma design link. Don't forget to replace "design" by "file" in the URL. For example https://www.figma.com/file/example
- [ ] Migrated touched components to Glimmer Components
- [ ] Properly labeled
