### PR TITLE
feat: added smart skin to oss::select

### DIFF
--- a/addon/components/o-s-s/email-input.hbs
+++ b/addon/components/o-s-s/email-input.hbs
@@ -3,6 +3,7 @@
   @placeholder={{this.placeholder}}
   @errorMessage={{this.errorMessage}}
   @feedbackMessage={{@feedbackMessage}}
+  @autocomplete={{@autocomplete}}
   @onChange={{this.validateInput}}
   ...attributes
 />

--- a/addon/components/o-s-s/email-input.stories.js
+++ b/addon/components/o-s-s/email-input.stories.js
@@ -55,6 +55,16 @@ export default {
       },
       control: { type: 'boolean' }
     },
+    autocomplete: {
+      description: 'Whether or not to enable autocomplete for the email input',
+      table: {
+        type: {
+          summary: "'on' | 'off'"
+        },
+        defaultValue: { summary: 'on' }
+      },
+      control: { type: 'select', options: ['on', 'off'] }
+    },
     validates: {
       description: 'A callback that indicates whether or not the current input matches the regex',
       table: {
@@ -89,13 +99,14 @@ const defaultArgs = {
   errorMessage: undefined,
   feedbackMessage: undefined,
   validateFormat: false,
+  autocomplete: 'on',
   validates: action('validates')
 };
 
 const Template = (args) => ({
   template: hbs`
       <OSS::EmailInput @value={{this.value}} @placeholder={{this.placeholder}} @validateFormat={{this.validateFormat}}
-                       @validates={{this.validates}} @errorMessage={{this.errorMessage}} @feedbackMessage={{this.feedbackMessage}} />
+                       @validates={{this.validates}} @errorMessage={{this.errorMessage}} @feedbackMessage={{this.feedbackMessage}} @autocomplete={{this.autocomplete}} />
   `,
   context: args
 });

--- a/addon/components/o-s-s/email-input.ts
+++ b/addon/components/o-s-s/email-input.ts
@@ -11,6 +11,7 @@ interface OSSEmailInputArgs {
   feedbackMessage?: FeedbackMessage;
   errorMessage?: string;
   validateFormat?: boolean;
+  autocomplete?: 'on' | 'off';
   validates?(isPassing: boolean): void;
   onChange?(value: string | null): void;
 }

--- a/addon/components/o-s-s/infinite-select.ts
+++ b/addon/components/o-s-s/infinite-select.ts
@@ -197,7 +197,7 @@ export default class OSSInfiniteSelect extends Component<InfiniteSelectArgs> {
   }
 
   @action
-  handleItemHover(index: number, event: MouseEvent): void {
+  handleItemHover(index: number): void {
     if (document.activeElement === this.searchInput) {
       return;
     }

--- a/addon/components/o-s-s/input-container.ts
+++ b/addon/components/o-s-s/input-container.ts
@@ -46,7 +46,11 @@ export default class OSSInputContainer<T extends OSSInputContainerArgs> extends 
     return this.args.type ?? 'text';
   }
 
-  get autocomplete(): 'on' | 'off' {
+  get autocomplete(): 'on' | 'off' | 'new-password' {
+    if (this.args.autocomplete === 'off') {
+      return 'new-password';
+    }
+
     return AutocompleteValues.includes(this.args.autocomplete ?? '') ? this.args.autocomplete! : 'on';
   }
 

--- a/addon/components/o-s-s/layout/sidebar/group.hbs
+++ b/addon/components/o-s-s/layout/sidebar/group.hbs
@@ -34,39 +34,40 @@
         {{on "click" this.toggleCollapsed}}
       />
     {{/if}}
-
   </div>
 
-  <div
-    class={{concat
-      "oss-sidebar-group__items-container"
-      (if (or @expanded this.displayGroupList) " oss-sidebar-group__items-container--visible")
-    }}
-    {{on "mouseenter" this.handleGroupListEnter}}
-    {{on "mouseleave" this.handleGroupListLeave}}
-  >
-    {{#unless @expanded}}
-      <div class="group-name">
-        {{@label}}
+  {{#if this.hasItems}}
+    <div
+      class={{concat
+        "oss-sidebar-group__items-container"
+        (if (or @expanded this.displayGroupList) " oss-sidebar-group__items-container--visible")
+      }}
+      {{on "mouseenter" this.handleGroupListEnter}}
+      {{on "mouseleave" this.handleGroupListLeave}}
+    >
+      {{#unless @expanded}}
+        <div class="group-name">
+          {{@label}}
+        </div>
+      {{/unless}}
+      <div class="group-list">
+        {{#each this.items as |item|}}
+          <OSS::Layout::Sidebar::Item
+            @expanded={{or @expanded this.displayGroupList}}
+            @icon={{item.icon}}
+            @label={{item.label}}
+            @locked={{item.locked}}
+            @hasNotifications={{item.hasNotifications}}
+            @link={{item.link}}
+            @routePrefix={{item.routePrefix}}
+            @lockedAction={{item.lockedAction}}
+            @action={{item.action}}
+            @disableAutoActive={{item.disableAutoActive}}
+            data-control-name={{item.dataControlName}}
+            class={{if item.active "active"}}
+          />
+        {{/each}}
       </div>
-    {{/unless}}
-    <div class="group-list">
-      {{#each @items as |item|}}
-        <OSS::Layout::Sidebar::Item
-          @expanded={{or @expanded this.displayGroupList}}
-          @icon={{item.icon}}
-          @label={{item.label}}
-          @locked={{item.locked}}
-          @hasNotifications={{item.hasNotifications}}
-          @link={{item.link}}
-          @routePrefix={{item.routePrefix}}
-          @lockedAction={{item.lockedAction}}
-          @action={{item.action}}
-          @disableAutoActive={{item.disableAutoActive}}
-          data-control-name={{item.dataControlName}}
-          class={{if item.active "active"}}
-        />
-      {{/each}}
     </div>
-  </div>
+  {{/if}}
 </div>

--- a/addon/components/o-s-s/layout/sidebar/group.stories.js
+++ b/addon/components/o-s-s/layout/sidebar/group.stories.js
@@ -50,7 +50,8 @@ export default {
       table: {
         type: {
           summary: 'GroupItem[]'
-        }
+        },
+        defaultValue: { summary: 'undefined' }
       },
       control: { type: 'array' }
     }

--- a/addon/components/o-s-s/layout/sidebar/group.ts
+++ b/addon/components/o-s-s/layout/sidebar/group.ts
@@ -20,7 +20,7 @@ export type GroupItem = {
 interface OSSLayoutSidebarGroupComponentSignature {
   label: string;
   expanded: boolean;
-  items: GroupItem[];
+  items?: GroupItem[];
   icon?: string;
   collapsible?: boolean;
 }
@@ -48,12 +48,20 @@ export default class OSSLayoutSidebarGroupComponent extends Component<OSSLayoutS
     return this.args.collapsible ?? false;
   }
 
+  get items(): GroupItem[] {
+    return this.args.items ?? [];
+  }
+
+  get hasItems(): boolean {
+    return this.items.length > 0;
+  }
+
   get hasNotifications(): boolean {
-    return this.args.items.some((item) => item.hasNotifications);
+    return this.items.some((item) => item.hasNotifications);
   }
 
   get isActive(): boolean {
-    return !this.args.expanded && this.args.items.some((item) => item.active);
+    return !this.args.expanded && this.items.some((item) => item.active);
   }
 
   get computedClasses(): string {

--- a/addon/components/o-s-s/panel/row.hbs
+++ b/addon/components/o-s-s/panel/row.hbs
@@ -4,7 +4,7 @@
       <OSS::Icon @icon={{@icon}} />
     </div>
   {{/if}}
-  <span class="font-color-gray-500 oss-panel-content--row--text">
+  <span class="oss-panel-content--row--text">
     {{@label}}
   </span>
 </div>

--- a/addon/components/o-s-s/select.hbs
+++ b/addon/components/o-s-s/select.hbs
@@ -36,6 +36,7 @@
           @searchPlaceholder={{this.searchPlaceholder}}
           @enableKeyboard={{true}}
           @action={{this.actionArguments}}
+          @skin={{@skin}}
           id={{this.portalId}}
           class={{concat "margin-top-px-0 oss-select-container__dropdown " this.dropdownAddressableClass}}
           {{on-click-outside this.onClickOutside useCapture=@captureClickOutside}}
@@ -67,6 +68,7 @@
           @searchPlaceholder={{this.searchPlaceholder}}
           @enableKeyboard={{true}}
           @action={{this.actionArguments}}
+          @skin={{@skin}}
           id={{this.portalId}}
           class={{concat "margin-top-px-0 oss-select-container__dropdown " this.dropdownAddressableClass}}
           {{on-click-outside this.onClickOutside useCapture=@captureClickOutside}}

--- a/addon/components/o-s-s/select.stories.js
+++ b/addon/components/o-s-s/select.stories.js
@@ -1,6 +1,8 @@
 import { hbs } from 'ember-cli-htmlbars';
 import { action } from '@storybook/addon-actions';
 
+const SkinTypes = ['default', 'smart'];
+
 const FAKE_DATA = [
   { name: 'Batman', characters: 'Bruce Wayne' },
   { name: 'Superman', characters: 'Kal-El' },
@@ -133,6 +135,17 @@ export default {
         }
       },
       control: { type: 'object' }
+    },
+    skin: {
+      description: 'Adjust the skin of the dropdown',
+      table: {
+        type: {
+          summary: SkinTypes.join('|')
+        },
+        defaultValue: { summary: 'default' }
+      },
+      options: SkinTypes,
+      control: { type: 'select' }
     }
   },
   parameters: {
@@ -159,6 +172,7 @@ const defaultArgs = {
   errorMessage: undefined,
   successMessage: undefined,
   addressableAs: undefined,
+  skin: 'default',
   action: {
     skin: 'tertiary',
     label: 'Add Hero',
@@ -176,7 +190,23 @@ const Template = (args) => ({
     <OSS::Select
       @items={{this.items}} @value={{this.value}} @targetLabel={{this.targetLabel}} @placeholder={{this.placeholder}}
       @disabled={{this.disabled}} @errorMessage={{this.errorMessage}} @successMessage={{this.successMessage}}
-      @onSearch={{this.onSearch}} @onChange={{this.onChange}} @action={{this.action}} @hasError={{this.hasError}}>
+      @onSearch={{this.onSearch}} @onChange={{this.onChange}} @action={{this.action}} @hasError={{this.hasError}}
+      @skin={{this.skin}}>
+      <:option as |item|>
+        {{item.name}}
+      </:option>
+    </OSS::Select>
+  </div>
+  `,
+  context: args
+});
+
+const SmartSkinTemplate = (args) => ({
+  template: hbs`
+  <div style="width: 250px">
+    <OSS::Select
+      @items={{this.items}} @value={{this.value}} @targetLabel={{this.targetLabel}} @placeholder={{this.placeholder}}
+      @onSearch={{this.onSearch}} @onChange={{this.onChange}} @skin="smart">
       <:option as |item|>
         {{item.name}}
       </:option>
@@ -229,6 +259,9 @@ const WithEmptyStateNamedBlockTemplate = (args) => ({
 
 export const Default = Template.bind({});
 Default.args = defaultArgs;
+
+export const SmartSkin = SmartSkinTemplate.bind({});
+SmartSkin.args = defaultArgs;
 
 export const WithSelectedNamedBlock = WithSelectedNamedBlockTemplate.bind({});
 WithSelectedNamedBlock.args = defaultArgs;

--- a/addon/components/o-s-s/select.ts
+++ b/addon/components/o-s-s/select.ts
@@ -20,6 +20,7 @@ interface OSSSelectArgs extends BaseDropdownArgs {
   successMessage?: string;
   addressableAs?: string;
   action?: InfiniteSelectAction;
+  skin?: 'default' | 'smart';
   onChange(value: any): void;
   onSearch?(keyword: string): void;
 }

--- a/app/styles/organisms/panel.less
+++ b/app/styles/organisms/panel.less
@@ -14,19 +14,21 @@
     display: inline-flex;
     align-items: center;
     cursor: pointer;
-    height: 36px;
+    height: 30px;
     width: 100%;
     padding: var(--spacing-px-9) var(--spacing-px-12);
     gap: var(--spacing-px-9);
     flex-shrink: 0;
     background: var(--color-white);
+    color: var(--color-gray-600);
+    border-radius: var(--border-radius-sm);
 
     &-disabled {
       cursor: not-allowed;
 
       &:hover {
         background-color: var(--color-gray-50);
-        transition: background-color 0.3s ease;
+        transition: background-color 300ms ease-in-out;
 
         .oss-panel-content--row--icon-wrapper i,
         .oss-panel-content--row--text {
@@ -40,17 +42,14 @@
       }
     }
 
-    .far {
-      color: var(--color-gray-400);
-    }
-
     &:hover {
-      background-color: var(--color-gray-50);
-      transition: background-color 300ms ease;
-      .far,
-      span {
-        color: var(--color-primary-500);
-        transition: color 300ms ease;
+      background-color: var(--color-primary-50);
+      transition: background-color 300ms ease-in-out;
+
+      .oss-panel-content--row--icon-wrapper i,
+      .oss-panel-content--row--text {
+        color: var(--color-gray-900);
+        transition: color 300ms ease-in-out;
       }
     }
 
@@ -64,6 +63,7 @@
     border-top: 1px solid var(--color-border-default);
     width: 100%;
   }
+
   .oss-panel-content--row--icon-wrapper {
     display: flex;
     justify-content: left;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@upfluence/oss-components",
-  "version": "3.92.1",
+  "version": "3.92.2",
   "description": "The default blueprint for ember-cli addons.",
   "keywords": [
     "ember-addon"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@upfluence/oss-components",
-  "version": "3.92.2",
+  "version": "3.92.3",
   "description": "The default blueprint for ember-cli addons.",
   "keywords": [
     "ember-addon"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@upfluence/oss-components",
-  "version": "3.92.3",
+  "version": "3.92.4",
   "description": "The default blueprint for ember-cli addons.",
   "keywords": [
     "ember-addon"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@upfluence/oss-components",
-  "version": "3.92.4",
+  "version": "3.92.5",
   "description": "The default blueprint for ember-cli addons.",
   "keywords": [
     "ember-addon"

--- a/tests/dummy/app/templates/input.hbs
+++ b/tests/dummy/app/templates/input.hbs
@@ -71,7 +71,17 @@
             {{item}}
           </:option>
         </OSS::Select>
-
+        <OSS::Select
+          @value={{this.selectedItem}}
+          @items={{this.items}}
+          @onChange={{this.onSelect}}
+          @skin="smart"
+          class="fx-1"
+        >
+          <:option as |item|>
+            {{item.name}}
+          </:option>
+        </OSS::Select>
         <OSS::Select
           @value={{this.selectedItem}}
           @items={{this.superHeroes}}

--- a/tests/integration/components/o-s-s/input-container-test.ts
+++ b/tests/integration/components/o-s-s/input-container-test.ts
@@ -93,7 +93,7 @@ module('Integration | Component | o-s-s/input-container', function (hooks) {
     test('Passing a @autocomplete parameter works', async function (assert) {
       this.autocomplete = 'off';
       await renderComponentWithParameters();
-      assert.dom('.upf-input').hasAttribute('autocomplete', 'off');
+      assert.dom('.upf-input').hasAttribute('autocomplete', 'new-password');
     });
   });
 

--- a/tests/integration/components/o-s-s/input-group-test.ts
+++ b/tests/integration/components/o-s-s/input-group-test.ts
@@ -34,7 +34,7 @@ module('Integration | Component | o-s-s/input-group', function (hooks) {
 
   test('Passing a @autocomplete parameter works', async function (assert) {
     await render(hbs`<OSS::InputGroup @prefix="email" @suffix="@domain.com" @autocomplete="off"/>`);
-    assert.dom('.upf-input').hasAttribute('autocomplete', 'off');
+    assert.dom('.upf-input').hasAttribute('autocomplete', 'new-password');
   });
 
   test('Passing the @errorMessage parameter displays the error message', async function (assert) {

--- a/tests/integration/components/o-s-s/layout/sidebar/group-test.ts
+++ b/tests/integration/components/o-s-s/layout/sidebar/group-test.ts
@@ -181,6 +181,32 @@ module('Integration | Component | o-s-s/layout/sidebar/group', function (hooks) 
     });
   });
 
+  module('@items is empty', function (hooks) {
+    hooks.beforeEach(function () {
+      this.items = [];
+      this.expanded = true;
+    });
+
+    test('the group renders without items', async function (assert) {
+      await renderComponent();
+      assert.dom('.oss-sidebar-group').exists();
+      assert.dom('.oss-sidebar-group__items-container').doesNotExist();
+    });
+
+    test('the group has no notification dot', async function (assert) {
+      await renderComponent();
+      assert.dom('.oss-sidebar-group .oss-sidebar-item__notification').doesNotExist();
+    });
+
+    test('hovering the group does not display an empty popup', async function (assert) {
+      this.expanded = false;
+      await renderComponent();
+
+      await triggerEvent('.oss-sidebar-group > div .oss-sidebar-item', 'mouseenter');
+      assert.dom('.oss-sidebar-group__items-container').doesNotExist();
+    });
+  });
+
   module('icon named-block', function () {
     test('it renders the icon named block instead of the icon argument when present', async function (assert) {
       await render(hbs`

--- a/tests/integration/components/o-s-s/select-test.ts
+++ b/tests/integration/components/o-s-s/select-test.ts
@@ -408,6 +408,38 @@ module('Integration | Component | o-s-s/select', function (hooks) {
     });
   });
 
+  module('@skin argument', function () {
+    test('when @skin is not passed, the dropdown defaults to the default skin', async function (assert) {
+      await render(
+        hbs`
+          <OSS::Select @onChange={{this.onChange}} @items={{this.items}} @value={{this.value}}>
+            <:option as |item|>
+              {{item.name}}
+            </:option>
+          </OSS::Select>
+        `
+      );
+
+      await click('.upf-input div');
+      assert.dom('.upf-infinite-select').hasClass('upf-infinite-select--default');
+    });
+
+    test('when @skin="smart" is passed, the dropdown has the smart skin class', async function (assert) {
+      await render(
+        hbs`
+          <OSS::Select @onChange={{this.onChange}} @items={{this.items}} @value={{this.value}} @skin="smart">
+            <:option as |item|>
+              {{item.name}}
+            </:option>
+          </OSS::Select>
+        `
+      );
+
+      await click('.upf-input div');
+      assert.dom('.upf-infinite-select').hasClass('upf-infinite-select--smart');
+    });
+  });
+
   module('Error management', function () {
     test('it throws an error if no @onChange arg is passed', async function (assert) {
       setupOnerror((err: Error) => {


### PR DESCRIPTION
### What does this PR do?
<img width="240" height="151" alt="Capture d’écran 2026-04-01 à 11 43 09" src="https://github.com/user-attachments/assets/804d08cf-5c43-42a7-9ca2-e00a4c83697f" />

Needed for multi currency project, no breaking changes as undefined fallsback onto the default skin when not specified in infiniteSelect. 

Adds the possibility to access the skin arg of infinite select through OSS::Select

Related to: #<!-- enter issue number here -->

### What are the observable changes?

<!-- This question could be adequate with multiple use cases, for example: -->

<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [ ] Added/updated documentation with Figma design link. Don't forget to replace "design" by "file" in the URL. For example https://www.figma.com/file/example
- [ ] Migrated touched components to Glimmer Components
- [ ] Properly labeled
