### PR TITLE
[Groundwork] [OSS-Components] Add an animation to the `OSS::Copy` button

### DIFF
--- a/addon/components/o-s-s/copy.hbs
+++ b/addon/components/o-s-s/copy.hbs
@@ -1,7 +1,7 @@
 {{#if this.accessibleClipboard}}
   {{#if this.inline}}
     <OSS::Icon
-      @icon={{if this.showCheckmark "fas fa-check" this.icon}}
+      @icon={{this.icon}}
       class="oss-copy--inline {{if this.showCheckmark 'oss-copy--animation'}}"
       {{on "click" this.copy}}
       {{on "animationend" this.resetCheckmarkOnAnimationEnd}}
@@ -11,7 +11,7 @@
     />
   {{else}}
     <OSS::Button
-      @icon={{if this.showCheckmark "fas fa-check" this.icon}}
+      @icon={{this.icon}}
       @square={{true}}
       @size="sm"
       {{on "click" this.copy}}

--- a/addon/components/o-s-s/copy.hbs
+++ b/addon/components/o-s-s/copy.hbs
@@ -1,21 +1,24 @@
 {{#if this.accessibleClipboard}}
   {{#if this.inline}}
     <OSS::Icon
-      @icon={{this.icon}}
-      class="oss-copy--inline"
+      @icon={{if this.showCheckmark "fas fa-check" this.icon}}
+      class="oss-copy--inline {{if this.showCheckmark 'oss-copy--animation'}}"
       {{on "click" this.copy}}
+      {{on "animationend" this.resetCheckmarkOnAnimationEnd}}
       {{enable-tooltip placement="top" title=this.tooltip trigger="hover"}}
       data-control-name="copy-content-button"
       ...attributes
     />
   {{else}}
     <OSS::Button
-      @icon={{this.icon}}
+      @icon={{if this.showCheckmark "fas fa-check" this.icon}}
       @square={{true}}
       @size="sm"
       {{on "click" this.copy}}
+      {{on "animationend" this.resetCheckmarkOnAnimationEnd}}
       {{enable-tooltip placement="top" title=this.tooltip trigger="hover"}}
       data-control-name="copy-content-button"
+      class="{{if this.showCheckmark 'oss-copy--animation'}}"
       ...attributes
     />
   {{/if}}

--- a/addon/components/o-s-s/copy.stories.js
+++ b/addon/components/o-s-s/copy.stories.js
@@ -48,7 +48,7 @@ export default {
       },
       control: { type: 'text' }
     },
-    withAnimation: {
+    animated: {
       type: { name: 'boolean' },
       description: 'Enable green checkmark animation on click (3 second, no toast)',
       table: {
@@ -75,43 +75,16 @@ const defaultArgs = {
   inline: false,
   icon: undefined,
   tooltip: undefined,
-  withAnimation: false
+  animated: false
 };
 
 const BasicUsageTemplate = (args) => ({
   template: hbs`
     <div class="fx-col">
-      <OSS::Copy @value={{this.value}} @inline={{this.inline}} @icon={{this.icon}} @tooltip={{this.tooltip}} @withAnimation={{this.withAnimation}} />
+      <OSS::Copy @value={{this.value}} @inline={{this.inline}} @icon={{this.icon}} @tooltip={{this.tooltip}} @animated={{this.animated}} />
     </div>`,
   context: args
 });
 
 export const Default = BasicUsageTemplate.bind({});
 Default.args = defaultArgs;
-
-export const WithAnimation = BasicUsageTemplate.bind({});
-WithAnimation.args = {
-  ...defaultArgs,
-  withAnimation: true
-};
-WithAnimation.parameters = {
-  docs: {
-    description: {
-      story: 'Shows the green checkmark animation on click for 3 seconds. No toast notification is displayed.'
-    }
-  }
-};
-
-export const InlineWithAnimation = BasicUsageTemplate.bind({});
-InlineWithAnimation.args = {
-  ...defaultArgs,
-  inline: true,
-  withAnimation: true
-};
-InlineWithAnimation.parameters = {
-  docs: {
-    description: {
-      story: 'Inline version with the green checkmark animation on click.'
-    }
-  }
-};

--- a/addon/components/o-s-s/copy.stories.js
+++ b/addon/components/o-s-s/copy.stories.js
@@ -50,7 +50,8 @@ export default {
     },
     animated: {
       type: { name: 'boolean' },
-      description: 'Enable green checkmark animation on click (3 second, no toast)',
+      description:
+        'Enables a green checkmark animation (3 seconds) when the user clicks on the button. It also disables the success feedback toast.',
       table: {
         type: {
           summary: 'boolean'

--- a/addon/components/o-s-s/copy.stories.js
+++ b/addon/components/o-s-s/copy.stories.js
@@ -47,6 +47,17 @@ export default {
         defaultValue: { summary: 'Copy' }
       },
       control: { type: 'text' }
+    },
+    withAnimation: {
+      type: { name: 'boolean' },
+      description: 'Enable green checkmark animation on click (3 second, no toast)',
+      table: {
+        type: {
+          summary: 'boolean'
+        },
+        defaultValue: { summary: false }
+      },
+      control: { type: 'boolean' }
     }
   },
   parameters: {
@@ -63,16 +74,44 @@ const defaultArgs = {
   value: 'Your copied value',
   inline: false,
   icon: undefined,
-  tooltip: undefined
+  tooltip: undefined,
+  withAnimation: false
 };
 
 const BasicUsageTemplate = (args) => ({
   template: hbs`
     <div class="fx-col">
-      <OSS::Copy @value={{this.value}} @inline={{this.inline}} @icon={{this.icon}} @tooltip={{this.tooltip}} />
+      <OSS::Copy @value={{this.value}} @inline={{this.inline}} @icon={{this.icon}} @tooltip={{this.tooltip}} @withAnimation={{this.withAnimation}} />
     </div>`,
   context: args
 });
 
 export const Default = BasicUsageTemplate.bind({});
 Default.args = defaultArgs;
+
+export const WithAnimation = BasicUsageTemplate.bind({});
+WithAnimation.args = {
+  ...defaultArgs,
+  withAnimation: true
+};
+WithAnimation.parameters = {
+  docs: {
+    description: {
+      story: 'Shows the green checkmark animation on click for 3 seconds. No toast notification is displayed.'
+    }
+  }
+};
+
+export const InlineWithAnimation = BasicUsageTemplate.bind({});
+InlineWithAnimation.args = {
+  ...defaultArgs,
+  inline: true,
+  withAnimation: true
+};
+InlineWithAnimation.parameters = {
+  docs: {
+    description: {
+      story: 'Inline version with the green checkmark animation on click.'
+    }
+  }
+};

--- a/addon/components/o-s-s/copy.ts
+++ b/addon/components/o-s-s/copy.ts
@@ -12,6 +12,7 @@ interface OSSCopyArgs {
   inline?: boolean;
   icon?: string;
   tooltip?: string;
+  withAnimation?: boolean;
 }
 
 export default class OSSCopy extends Component<OSSCopyArgs> {
@@ -20,6 +21,8 @@ export default class OSSCopy extends Component<OSSCopyArgs> {
 
   @tracked accessibleClipboard: boolean = false;
   @tracked inline: boolean = this.args.inline ?? false;
+  @tracked withAnimation: boolean = this.args.withAnimation ?? false;
+  @tracked showCheckmark: boolean = false;
 
   constructor(owner: unknown, args: OSSCopyArgs) {
     super(owner, args);
@@ -52,6 +55,11 @@ export default class OSSCopy extends Component<OSSCopyArgs> {
     navigator.clipboard
       .writeText(this.args.value)
       .then(() => {
+        if (this.withAnimation) {
+          this.showCheckmark = true;
+          return;
+        }
+
         this.toast.info(
           this.intl.t('oss-components.copy.success.subtitle'),
           this.intl.t('oss-components.copy.success.title')
@@ -63,5 +71,10 @@ export default class OSSCopy extends Component<OSSCopyArgs> {
           this.intl.t('oss-components.copy.error.title')
         );
       });
+  }
+
+  @action
+  resetCheckmarkOnAnimationEnd() {
+    this.showCheckmark = false;
   }
 }

--- a/addon/components/o-s-s/copy.ts
+++ b/addon/components/o-s-s/copy.ts
@@ -12,7 +12,7 @@ interface OSSCopyArgs {
   inline?: boolean;
   icon?: string;
   tooltip?: string;
-  withAnimation?: boolean;
+  animated?: boolean;
 }
 
 export default class OSSCopy extends Component<OSSCopyArgs> {
@@ -20,12 +20,15 @@ export default class OSSCopy extends Component<OSSCopyArgs> {
   @service declare toast: ToastService;
 
   @tracked accessibleClipboard: boolean = false;
-  @tracked inline: boolean = this.args.inline ?? false;
-  @tracked withAnimation: boolean = this.args.withAnimation ?? false;
+  @tracked inline: boolean;
+  @tracked animated: boolean;
   @tracked showCheckmark: boolean = false;
 
   constructor(owner: unknown, args: OSSCopyArgs) {
     super(owner, args);
+
+    this.inline = this.args.inline ?? false;
+    this.animated = this.args.animated ?? false;
 
     if (!(window as any).chrome && !isTesting()) {
       this.accessibleClipboard = true;
@@ -49,13 +52,13 @@ export default class OSSCopy extends Component<OSSCopyArgs> {
   }
 
   @action
-  copy(event: PointerEvent) {
+  copy(event: PointerEvent): void {
     event.stopPropagation();
 
     navigator.clipboard
       .writeText(this.args.value)
       .then(() => {
-        if (this.withAnimation) {
+        if (this.animated) {
           this.showCheckmark = true;
           return;
         }
@@ -74,7 +77,7 @@ export default class OSSCopy extends Component<OSSCopyArgs> {
   }
 
   @action
-  resetCheckmarkOnAnimationEnd() {
+  resetCheckmarkOnAnimationEnd(): void {
     this.showCheckmark = false;
   }
 }

--- a/addon/components/o-s-s/copy.ts
+++ b/addon/components/o-s-s/copy.ts
@@ -44,6 +44,8 @@ export default class OSSCopy extends Component<OSSCopyArgs> {
   }
 
   get icon(): string {
+    if (this.showCheckmark) return 'far fa-check';
+
     return this.args.icon ?? 'far fa-copy';
   }
 

--- a/app/styles/atoms/copy.less
+++ b/app/styles/atoms/copy.less
@@ -19,6 +19,7 @@
 .oss-copy--animation {
   --animation-duration: 3s;
   will-change: color, opacity;
+
   &,
   & i {
     animation: checkmark var(--animation-duration);

--- a/app/styles/atoms/copy.less
+++ b/app/styles/atoms/copy.less
@@ -15,3 +15,31 @@
     box-shadow: none;
   }
 }
+
+.oss-copy--animation {
+  --animation-duration: 3s;
+  will-change: color, opacity;
+  &,
+  & i {
+    animation: checkmark var(--animation-duration);
+  }
+}
+
+@keyframes checkmark {
+  0% {
+    opacity: 0.6;
+    color: var(--color-success-500);
+  }
+
+  20% {
+    opacity: 1;
+  }
+
+  90% {
+    color: var(--color-success-500);
+  }
+
+  100% {
+    opacity: 0.9;
+  }
+}

--- a/tests/dummy/app/templates/visual.hbs
+++ b/tests/dummy/app/templates/visual.hbs
@@ -363,8 +363,8 @@
       <OSS::Copy @value="I am the value copied" @tooltip="Custom tooltip" />
       <OSS::Copy @value="I am the value copied" @icon="far fa-jedi" />
       <OSS::Copy @value="I am the value copied" @icon="fa fa-empire" @inline={{true}} />
-      <OSS::Copy @value="I am the value copied" @withAnimation={{true}} />
-      <OSS::Copy @value="I am the value copied" @withAnimation={{true}} @inline={{true}} />
+      <OSS::Copy @value="I am the value copied" @animated={{true}} />
+      <OSS::Copy @value="I am the value copied" @animated={{true}} @inline={{true}} />
     </div>
   </div>
 

--- a/tests/dummy/app/templates/visual.hbs
+++ b/tests/dummy/app/templates/visual.hbs
@@ -358,11 +358,13 @@
       Copy button
     </div>
     <div class="fx-row fx-gap-px-24 fx-xalign-center">
-      <OSS::Copy @value="I am the value copied" @inline={{true}} />
       <OSS::Copy @value="I am the value copied" />
+      <OSS::Copy @value="I am the value copied" @inline={{true}} />
       <OSS::Copy @value="I am the value copied" @tooltip="Custom tooltip" />
       <OSS::Copy @value="I am the value copied" @icon="far fa-jedi" />
-      <OSS::Copy @value="I am the value copied" @icon="fab fa-empire" @inline={{true}} />
+      <OSS::Copy @value="I am the value copied" @icon="fa fa-empire" @inline={{true}} />
+      <OSS::Copy @value="I am the value copied" @withAnimation={{true}} />
+      <OSS::Copy @value="I am the value copied" @withAnimation={{true}} @inline={{true}} />
     </div>
   </div>
 

--- a/tests/integration/components/o-s-s/copy-test.ts
+++ b/tests/integration/components/o-s-s/copy-test.ts
@@ -71,7 +71,7 @@ module('Integration | Component | o-s-s/copy', function (hooks) {
     test('nothing is rendered', async function (assert) {
       await render(hbs`<OSS::Copy />`);
 
-      assert.ok(this.permissionQueryStub.calledOnceWithExactly({ name: 'clipboard-write' as PermissionName }));
+      assert.ok(this.permissionQueryStub.calledOnceWithExactly({ name: 'clipboard-write' }));
       assert.dom('.oss-copy--inline').doesNotExist();
       assert.dom('.upf-btn--default').doesNotExist();
     });
@@ -90,8 +90,8 @@ module('Integration | Component | o-s-s/copy', function (hooks) {
 
       assert.true(
         this.toastInfoStub.calledOnceWithExactly(
-          this.intl.t('upfluence.oss-components.copy.success-message'),
-          this.intl.t('upfluence.oss-components.copy.success-title')
+          this.intl.t('oss-components.copy.success.subtitle'),
+          this.intl.t('oss-components.copy.success.title')
         )
       );
     });
@@ -104,8 +104,8 @@ module('Integration | Component | o-s-s/copy', function (hooks) {
 
       assert.true(
         this.toastErrorStub.calledOnceWithExactly(
-          this.intl.t('upfluence.oss-components.copy.error-message'),
-          this.intl.t('upfluence.oss-components.copy.error-title')
+          this.intl.t('oss-components.copy.error.subtitle'),
+          this.intl.t('oss-components.copy.error.title')
         )
       );
     });
@@ -132,8 +132,8 @@ module('Integration | Component | o-s-s/copy', function (hooks) {
 
         assert.true(
           this.toastInfoStub.calledOnceWithExactly(
-            this.intl.t('upfluence.oss-components.copy.success-message'),
-            this.intl.t('upfluence.oss-components.copy.success-title')
+            this.intl.t('oss-components.copy.success.subtitle'),
+            this.intl.t('oss-components.copy.success.title')
           )
         );
       });

--- a/tests/integration/components/o-s-s/copy-test.ts
+++ b/tests/integration/components/o-s-s/copy-test.ts
@@ -56,6 +56,7 @@ module('Integration | Component | o-s-s/copy', function (hooks) {
 
     test('nothing is rendered', async function (assert) {
       await render(hbs`<OSS::Copy />`);
+
       assert.dom('.upf-btn--default').exists();
     });
   });
@@ -86,8 +87,8 @@ module('Integration | Component | o-s-s/copy', function (hooks) {
       sinon.stub(navigator.clipboard, 'writeText').resolves();
 
       await render(hbs`<OSS::Copy @value="test" />`);
-      await click('.upf-btn--default');
 
+      await click('.upf-btn--default');
       assert.true(
         this.toastInfoStub.calledOnceWithExactly(
           this.intl.t('oss-components.copy.success.subtitle'),
@@ -100,8 +101,8 @@ module('Integration | Component | o-s-s/copy', function (hooks) {
       sinon.stub(navigator.clipboard, 'writeText').rejects();
 
       await render(hbs`<OSS::Copy @value="test" />`);
-      await click('.upf-btn--default');
 
+      await click('.upf-btn--default');
       assert.true(
         this.toastErrorStub.calledOnceWithExactly(
           this.intl.t('oss-components.copy.error.subtitle'),
@@ -112,12 +113,11 @@ module('Integration | Component | o-s-s/copy', function (hooks) {
 
     test('the clipboard writeText method is called', async function (assert) {
       const writeTextStub = sinon.stub(navigator.clipboard, 'writeText').resolves();
-
       this.textForCopy = 'test';
 
       await render(hbs`<OSS::Copy @value={{this.textForCopy}} />`);
-      await click('.upf-btn--default');
 
+      await click('.upf-btn--default');
       assert.true(writeTextStub.calledOnceWithExactly(this.textForCopy));
     });
 
@@ -128,8 +128,8 @@ module('Integration | Component | o-s-s/copy', function (hooks) {
 
       test('when animation is disabled, info toast is rendered', async function (assert) {
         await render(hbs`<OSS::Copy @value="test" @animated={{false}} />`);
-        await click('.upf-btn--default');
 
+        await click('.upf-btn--default');
         assert.true(
           this.toastInfoStub.calledOnceWithExactly(
             this.intl.t('oss-components.copy.success.subtitle'),
@@ -140,8 +140,8 @@ module('Integration | Component | o-s-s/copy', function (hooks) {
 
       test('when animation is enabled, no toast is rendered', async function (assert) {
         await render(hbs`<OSS::Copy @value="test" @animated={{true}} />`);
-        await click('.upf-btn--default');
 
+        await click('.upf-btn--default');
         assert.true(this.toastInfoStub.notCalled);
       });
 
@@ -149,9 +149,7 @@ module('Integration | Component | o-s-s/copy', function (hooks) {
         await render(hbs`<OSS::Copy @value="test" @animated={{true}} />`);
 
         assert.dom('i.fa-check').doesNotExist();
-
         await click('.upf-btn--default');
-
         assert.dom('i.fa-check').exists();
       });
 
@@ -159,9 +157,7 @@ module('Integration | Component | o-s-s/copy', function (hooks) {
         await render(hbs`<OSS::Copy @value="test" @animated={{true}} />`);
 
         assert.dom('[data-control-name="copy-content-button"].oss-copy--animation').doesNotExist();
-
         await click('[data-control-name="copy-content-button"]');
-
         assert.dom('[data-control-name="copy-content-button"].oss-copy--animation').exists();
       });
 
@@ -169,9 +165,7 @@ module('Integration | Component | o-s-s/copy', function (hooks) {
         await render(hbs`<OSS::Copy @value="test" @inline={{true}} @animated={{true}} />`);
 
         assert.dom('i.fa-check').doesNotExist();
-
         await click('[data-control-name="copy-content-button"]');
-
         assert.dom('i.fa-check').exists();
       });
     });

--- a/tests/integration/components/o-s-s/copy-test.ts
+++ b/tests/integration/components/o-s-s/copy-test.ts
@@ -89,7 +89,10 @@ module('Integration | Component | o-s-s/copy', function (hooks) {
       await click('.upf-btn--default');
 
       assert.true(
-        this.toastInfoStub.calledOnceWithExactly('Successfully copied to your clipboard.', 'Copied to clipboard')
+        this.toastInfoStub.calledOnceWithExactly(
+          this.intl.t('upfluence.oss-components.copy.success-message'),
+          this.intl.t('upfluence.oss-components.copy.success-title')
+        )
       );
     });
 
@@ -100,13 +103,16 @@ module('Integration | Component | o-s-s/copy', function (hooks) {
       await click('.upf-btn--default');
 
       assert.true(
-        this.toastErrorStub.calledOnceWithExactly('Failed to copy to your clipboard. Please try again.', 'Error')
+        this.toastErrorStub.calledOnceWithExactly(
+          this.intl.t('upfluence.oss-components.copy.error-message'),
+          this.intl.t('upfluence.oss-components.copy.error-title')
+        )
       );
     });
 
     test('the clipboard writeText method is called', async function (assert) {
       const writeTextStub = sinon.stub(navigator.clipboard, 'writeText').resolves();
-      this.toastInfoStub.resolves();
+
       this.textForCopy = 'test';
 
       await render(hbs`<OSS::Copy @value={{this.textForCopy}} />`);
@@ -115,29 +121,32 @@ module('Integration | Component | o-s-s/copy', function (hooks) {
       assert.true(writeTextStub.calledOnceWithExactly(this.textForCopy));
     });
 
-    module('with @withAnimation', function (hooks) {
+    module('with @animated', function (hooks) {
       hooks.beforeEach(function () {
         sinon.stub(navigator.clipboard, 'writeText').resolves();
       });
 
       test('when animation is disabled, info toast is rendered', async function (assert) {
-        await render(hbs`<OSS::Copy @value="test" @withAnimation={{false}} />`);
+        await render(hbs`<OSS::Copy @value="test" @animated={{false}} />`);
         await click('.upf-btn--default');
 
         assert.true(
-          this.toastInfoStub.calledOnceWithExactly('Successfully copied to your clipboard.', 'Copied to clipboard')
+          this.toastInfoStub.calledOnceWithExactly(
+            this.intl.t('upfluence.oss-components.copy.success-message'),
+            this.intl.t('upfluence.oss-components.copy.success-title')
+          )
         );
       });
 
       test('when animation is enabled, no toast is rendered', async function (assert) {
-        await render(hbs`<OSS::Copy @value="test" @withAnimation={{true}} />`);
+        await render(hbs`<OSS::Copy @value="test" @animated={{true}} />`);
         await click('.upf-btn--default');
 
-        assert.false(this.toastInfoStub.called);
+        assert.true(this.toastInfoStub.notCalled);
       });
 
       test('when animation is enabled, checkmark icon is displayed', async function (assert) {
-        await render(hbs`<OSS::Copy @value="test" @withAnimation={{true}} />`);
+        await render(hbs`<OSS::Copy @value="test" @animated={{true}} />`);
 
         assert.dom('i.fa-check').doesNotExist();
 
@@ -147,7 +156,7 @@ module('Integration | Component | o-s-s/copy', function (hooks) {
       });
 
       test('when animation is enabled, button has animation class during animation', async function (assert) {
-        await render(hbs`<OSS::Copy @value="test" @withAnimation={{true}} />`);
+        await render(hbs`<OSS::Copy @value="test" @animated={{true}} />`);
 
         assert.dom('[data-control-name="copy-content-button"].oss-copy--animation').doesNotExist();
 
@@ -157,7 +166,7 @@ module('Integration | Component | o-s-s/copy', function (hooks) {
       });
 
       test('when animation is enabled on inline copy, checkmark is displayed', async function (assert) {
-        await render(hbs`<OSS::Copy @value="test" @inline={{true}} @withAnimation={{true}} />`);
+        await render(hbs`<OSS::Copy @value="test" @inline={{true}} @animated={{true}} />`);
 
         assert.dom('i.fa-check').doesNotExist();
 

--- a/tests/integration/components/o-s-s/copy-test.ts
+++ b/tests/integration/components/o-s-s/copy-test.ts
@@ -114,5 +114,57 @@ module('Integration | Component | o-s-s/copy', function (hooks) {
 
       assert.true(writeTextStub.calledOnceWithExactly(this.textForCopy));
     });
+
+    module('with @withAnimation', function (hooks) {
+      hooks.beforeEach(function () {
+        sinon.stub(navigator.clipboard, 'writeText').resolves();
+      });
+
+      test('when animation is disabled, info toast is rendered', async function (assert) {
+        await render(hbs`<OSS::Copy @value="test" @withAnimation={{false}} />`);
+        await click('.upf-btn--default');
+
+        assert.true(
+          this.toastInfoStub.calledOnceWithExactly('Successfully copied to your clipboard.', 'Copied to clipboard')
+        );
+      });
+
+      test('when animation is enabled, no toast is rendered', async function (assert) {
+        await render(hbs`<OSS::Copy @value="test" @withAnimation={{true}} />`);
+        await click('.upf-btn--default');
+
+        assert.false(this.toastInfoStub.called);
+      });
+
+      test('when animation is enabled, checkmark icon is displayed', async function (assert) {
+        await render(hbs`<OSS::Copy @value="test" @withAnimation={{true}} />`);
+
+        assert.dom('i.fa-check').doesNotExist();
+
+        await click('.upf-btn--default');
+
+        assert.dom('i.fa-check').exists();
+      });
+
+      test('when animation is enabled, button has animation class during animation', async function (assert) {
+        await render(hbs`<OSS::Copy @value="test" @withAnimation={{true}} />`);
+
+        assert.dom('[data-control-name="copy-content-button"].oss-copy--animation').doesNotExist();
+
+        await click('[data-control-name="copy-content-button"]');
+
+        assert.dom('[data-control-name="copy-content-button"].oss-copy--animation').exists();
+      });
+
+      test('when animation is enabled on inline copy, checkmark is displayed', async function (assert) {
+        await render(hbs`<OSS::Copy @value="test" @inline={{true}} @withAnimation={{true}} />`);
+
+        assert.dom('i.fa-check').doesNotExist();
+
+        await click('[data-control-name="copy-content-button"]');
+
+        assert.dom('i.fa-check').exists();
+      });
+    });
   });
 });


### PR DESCRIPTION
### What does this PR do?

Add an opt-in animation to OSS::Copy for improved feedback while preserving legacy behavior by default.

Related to: [#DRA-4998](<https://linear.app/upfluence/issue/DRA-4998/groundwork-oss-components-add-an-animation-to-the-osscopy-button>)

### What are the observable changes?

* OSS::Copy now supports @withAnimation to show a success checkmark animation after a successful copy.
* When @withAnimation is enabled, no success toast is shown.
* Storybook examples and tests were updated for the animated behavior.

### Developpers heads up

I can't find the related figma file in the [design system](<https://www.figma.com/design/N7SDuH9mvC9zTlsLN49N4L/2.0-UI-Kit-%F0%9F%92%A0?node-id=6118-14594&p=f&t=UrKVkfLbSoIp9G91-0>) so I couldn't update the component with the figma link. 🤷<br><br>For reviewers: to test either start the "dummy app" (`make start`) and/or start storybook (`pnpm storybook`)

### Good PR checklist

- [X] Title makes sense
- [X] Is against the correct branch
- [X] Only addresses one issue
- [X] Properly assigned
- [X] Added/updated tests
- [ ] Added/updated documentation with Figma design link. Don't forget to replace "design" by "file" in the URL. For example [https://www.figma.com/file/example](<https://www.figma.com/file/example>)
- [ ] Migrated touched components to Glimmer Components
- [X] Properly labeled