### PR TITLE
Updated: country code dictionary entries

### DIFF
--- a/addon/utils/country-codes.ts
+++ b/addon/utils/country-codes.ts
@@ -5537,6 +5537,14 @@ export const countries: CountryData[] = [
     name: 'Suriname'
   },
   {
+    id: 'SS',
+    alpha2: 'SS',
+    alpha3: 'SSD',
+    countryCallingCodes: ['+211'],
+    currencies: ['SSP'],
+    name: 'South Sudan'
+  },
+  {
     id: 'ST',
     alpha2: 'ST',
     alpha3: 'STP',
@@ -6113,6 +6121,14 @@ export const countries: CountryData[] = [
     countryCallingCodes: ['685'],
     currencies: ['WST'],
     name: 'Samoa'
+  },
+  {
+    id: 'XK',
+    alpha2: 'XK',
+    alpha3: 'XXK',
+    countryCallingCodes: ['+383'],
+    currencies: ['EUR'],
+    name: 'Kosovo, Republic of'
   },
   {
     id: 'YE',


### PR DESCRIPTION
### What does this PR do?

Adds `Kosovo` and `South sudan` entries to the country code dictionary.
Note: yes they do in fact have their matching flags ✅ 

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [ ] Added/updated tests
- [ ] Added/updated documentation with Figma design link. Don't forget to replace "design" by "file" in the URL. For example https://www.figma.com/file/example
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled