### PR TITLE
Add feedbackMessage to PasswordInput

### DIFF
--- a/addon/components/o-s-s/password-input.hbs
+++ b/addon/components/o-s-s/password-input.hbs
@@ -7,7 +7,7 @@
         disabled={{@disabled}}
         placeholder={{this.placeholder}}
         autocomplete={{this.autocomplete}}
-        {{on "keyup" this.validateInput}}
+        {{on "input" this.validateInput}}
       />
     </:input>
     <:suffix>

--- a/addon/components/o-s-s/password-input.hbs
+++ b/addon/components/o-s-s/password-input.hbs
@@ -1,5 +1,5 @@
 <div class="fx-col fx-1 fx-gap-px-6">
-  <OSS::InputContainer @errorMessage={{this.errorMessage}} ...attributes>
+  <OSS::InputContainer @feedbackMessage={{@feedbackMessage}} @errorMessage={{this.errorMessage}} ...attributes>
     <:input>
       <Input
         @value={{@value}}
@@ -14,8 +14,12 @@
       {{#if @disabled}}
         <OSS::Icon class="font-color-gray-500" @icon={{this.visibilityIcon}} />
       {{else}}
-        <OSS::Button class="margin-px-6" @icon={{this.visibilityIcon}} @square={{true}}
-                     {{on "click" this.toggleVisibility}} />
+        <OSS::Button
+          class="margin-px-6"
+          @icon={{this.visibilityIcon}}
+          @square={{true}}
+          {{on "click" this.toggleVisibility}}
+        />
       {{/if}}
     </:suffix>
   </OSS::InputContainer>
@@ -23,13 +27,18 @@
     <div class="fx-row fx-gap-px-12" data-control-name="password-input-validators">
       {{#each this.inputValidators as |inputValidator|}}
         {{#let (this.validatorAttributes type=inputValidator) as |validator|}}
-          <div class="password-input-validator fx-row fx-gap-px-6"
-               data-control-name="password-input-validator-{{inputValidator}}">
+          <div
+            class="password-input-validator fx-row fx-gap-px-6"
+            data-control-name="password-input-validator-{{inputValidator}}"
+          >
             <div class="validator-icon-container">
               {{#each this.validationIcons as |validationIcon|}}
-                <OSS::Icon @icon={{validationIcon.icon}}
-                           class="validator-icon {{validator.iconClass}}
-                                  {{this.validationIconVisibility validator=validator state=validationIcon.state}}" />
+                <OSS::Icon
+                  @icon={{validationIcon.icon}}
+                  class="validator-icon
+                    {{validator.iconClass}}
+                    {{this.validationIconVisibility validator=validator state=validationIcon.state}}"
+                />
               {{/each}}
             </div>
             <span class={{validator.labelClass}}>{{t validator.labelKey}}</span>

--- a/addon/components/o-s-s/password-input.hbs
+++ b/addon/components/o-s-s/password-input.hbs
@@ -24,7 +24,7 @@
     </:suffix>
   </OSS::InputContainer>
   {{#if @validates}}
-    <div class="fx-row fx-gap-px-12" data-control-name="password-input-validators">
+    <div class="fx-row fx-gap-px-12 fx-wrap" data-control-name="password-input-validators">
       {{#each this.inputValidators as |inputValidator|}}
         {{#let (this.validatorAttributes type=inputValidator) as |validator|}}
           <div

--- a/addon/components/o-s-s/password-input.hbs
+++ b/addon/components/o-s-s/password-input.hbs
@@ -6,7 +6,7 @@
         @type={{this.visibility}}
         disabled={{@disabled}}
         placeholder={{this.placeholder}}
-        autocomplete="current-password"
+        autocomplete={{this.autocomplete}}
         {{on "keyup" this.validateInput}}
       />
     </:input>

--- a/addon/components/o-s-s/password-input.stories.js
+++ b/addon/components/o-s-s/password-input.stories.js
@@ -46,12 +46,13 @@ export default {
       control: { type: 'object' }
     },
     autocomplete: {
-      description: 'Whether or not the input should have autocomplete enabled.',
+      description:
+        'Whether or not the input should have autocomplete enabled. If set to "off", it will use "new-password" to prevent browsers from filling in the password. It can be set to any custom value if needed.',
       table: {
         type: {
-          summary: 'on | off'
+          summary: 'on | off | string'
         },
-        defaultValue: { summary: 'undefined' }
+        defaultValue: { summary: 'current-password' }
       },
       control: { type: 'text' }
     },

--- a/addon/components/o-s-s/password-input.stories.js
+++ b/addon/components/o-s-s/password-input.stories.js
@@ -35,6 +35,16 @@ export default {
       },
       control: { type: 'text' }
     },
+    feedbackMessage: {
+      description: 'A success, warning or error message that will be displayed below the input-group.',
+      table: {
+        type: {
+          summary: '{ type: string, value: string }'
+        },
+        defaultValue: { summary: 'undefined' }
+      },
+      control: { type: 'object' }
+    },
     disabled: {
       description: 'Whether or not the input is disabled',
       table: {

--- a/addon/components/o-s-s/password-input.stories.js
+++ b/addon/components/o-s-s/password-input.stories.js
@@ -45,6 +45,16 @@ export default {
       },
       control: { type: 'object' }
     },
+    autocomplete: {
+      description: 'Whether or not the input should have autocomplete enabled.',
+      table: {
+        type: {
+          summary: 'on | off'
+        },
+        defaultValue: { summary: 'undefined' }
+      },
+      control: { type: 'text' }
+    },
     disabled: {
       description: 'Whether or not the input is disabled',
       table: {
@@ -89,6 +99,7 @@ const defaultArgs = {
   disabled: false,
   placeholder: '*****',
   errorMessage: undefined,
+  autocomplete: undefined,
   validates: action('validates'),
   validatorSet: undefined
 };
@@ -96,7 +107,7 @@ const defaultArgs = {
 const DefaultUsageTemplate = (args) => ({
   template: hbs`
       <OSS::PasswordInput @value={{this.value}} @placeholder={{this.placeholder}} @validates={{this.validates}}
-                          @disabled={{this.disabled}} @validatorSet={{this.validatorSet}} />
+                          @autocomplete={{this.autocomplete}} @disabled={{this.disabled}} @validatorSet={{this.validatorSet}} />
   `,
   context: args
 });

--- a/addon/components/o-s-s/password-input.ts
+++ b/addon/components/o-s-s/password-input.ts
@@ -125,11 +125,12 @@ export default class OSSPasswordInput extends Component<OSSPasswordInputArgs> {
   );
 
   @action
-  validateInput(): void {
+  validateInput(event: InputEvent): void {
+    const value = (event?.target as HTMLInputElement)?.value;
     this.regexError = '';
-    if (!this.runValidation || !this.args.value) {
+    if (!this.runValidation || !value) {
       this.args.validates?.(true);
-    } else if (!this.testAllValidators()) {
+    } else if (!this.testAllValidators(value)) {
       this.regexError = this.intl.t('oss-components.password-input.regex_error');
       this.args.validates?.(false);
     } else {
@@ -142,10 +143,10 @@ export default class OSSPasswordInput extends Component<OSSPasswordInputArgs> {
     this.visibility = this.visibility === 'password' ? 'text' : 'password';
   }
 
-  private testAllValidators(): boolean {
+  private testAllValidators(value: string): boolean {
     return this.inputValidators.every((key: InputValidator) => {
       if (!this.validatorSet[key]) return false;
-      return this.validatorSet[key]!.regex.test(this.args.value!);
+      return this.validatorSet[key]!.regex.test(value!);
     });
   }
 

--- a/addon/components/o-s-s/password-input.ts
+++ b/addon/components/o-s-s/password-input.ts
@@ -20,6 +20,7 @@ interface OSSPasswordInputArgs {
   errorMessage?: string;
   feedbackMessage?: FeedbackMessage;
   disabled?: boolean;
+  autocomplete?: 'on' | 'off';
   validates?(isPassing: boolean): void;
   validatorSet?: ValidatorSet;
 }
@@ -94,6 +95,14 @@ export default class OSSPasswordInput extends Component<OSSPasswordInputArgs> {
         icon: STATE_ICON_MAPPING[state]
       };
     });
+  }
+
+  get autocomplete(): string {
+    if (this.args.autocomplete === 'off') {
+      return 'new-password';
+    }
+
+    return 'current-password';
   }
 
   validatorAttributes = helper((_, { type }: { type: InputValidator }): ValidationTemplateAttributes => {

--- a/addon/components/o-s-s/password-input.ts
+++ b/addon/components/o-s-s/password-input.ts
@@ -5,6 +5,7 @@ import Component from '@glimmer/component';
 import { assert } from '@ember/debug';
 import { isEmpty } from '@ember/utils';
 import { helper } from '@ember/component/helper';
+import type { FeedbackMessage } from './input-container';
 
 export type ValidatorSet = Record<string, { labelKey: string; regex: RegExp }>;
 export const INPUT_VALIDATORS: ValidatorSet = {
@@ -17,6 +18,7 @@ interface OSSPasswordInputArgs {
   value: string | null;
   placeholder?: string;
   errorMessage?: string;
+  feedbackMessage?: FeedbackMessage;
   disabled?: boolean;
   validates?(isPassing: boolean): void;
   validatorSet?: ValidatorSet;

--- a/addon/components/o-s-s/password-input.ts
+++ b/addon/components/o-s-s/password-input.ts
@@ -20,7 +20,7 @@ interface OSSPasswordInputArgs {
   errorMessage?: string;
   feedbackMessage?: FeedbackMessage;
   disabled?: boolean;
-  autocomplete?: 'on' | 'off';
+  autocomplete?: 'on' | 'off' | string;
   validates?(isPassing: boolean): void;
   validatorSet?: ValidatorSet;
 }
@@ -101,6 +101,7 @@ export default class OSSPasswordInput extends Component<OSSPasswordInputArgs> {
     if (this.args.autocomplete === 'off') {
       return 'new-password';
     }
+    if (this.args.autocomplete) return this.args.autocomplete;
 
     return 'current-password';
   }

--- a/app/styles/layouts/_split-settings.less
+++ b/app/styles/layouts/_split-settings.less
@@ -8,7 +8,7 @@
   &__info {
     flex: 1;
     padding-right: var(--spacing-px-60);
-    padding-bottom: var(--spacing-px-24);
+    padding-bottom: var(--spacing-px-18);
 
     .title {
       .text-size-6;

--- a/app/styles/organisms/modal-dialog.less
+++ b/app/styles/organisms/modal-dialog.less
@@ -74,7 +74,7 @@
 
 @media screen and (max-device-width: 480px) and (orientation: portrait) {
   .oss-modal-dialog {
-    height: 90vh;
+    max-height: 90vh;
     border-bottom-left-radius: 0;
     border-bottom-right-radius: 0;
     position: fixed;

--- a/app/styles/organisms/modal-dialog.less
+++ b/app/styles/organisms/modal-dialog.less
@@ -81,7 +81,7 @@
     bottom: 0;
 
     @supports (height: 90dvh) {
-      height: 90dvh;
+      max-height: 90dvh;
     }
 
     footer {

--- a/tests/integration/components/o-s-s/password-input-test.ts
+++ b/tests/integration/components/o-s-s/password-input-test.ts
@@ -168,6 +168,31 @@ module('Integration | Component | o-s-s/password-input', function (hooks) {
     });
   });
 
+  module('feedbackMessage', () => {
+    test('Passing an error @feedbackMessage displays the message and sets the border to red', async function (assert) {
+      await render(
+        hbs`<OSS::PasswordInput @value="" @feedbackMessage={{hash type="error" value="This is an error message"}} />`
+      );
+      assert.dom('.oss-input-container').hasClass('oss-input-container--error');
+      assert.dom('.font-color-error-500').hasText('This is an error message');
+    });
+
+    test('Passing a @feedbackMessage without a value only applies the container state class', async function (assert) {
+      await render(hbs`<OSS::PasswordInput @value="" @feedbackMessage={{hash type="success"}} />`);
+      assert.dom('.oss-input-container').hasClass('oss-input-container--success');
+      assert.dom('.font-color-success-500').doesNotExist();
+    });
+
+    test('@errorMessage takes precedence over @feedbackMessage', async function (assert) {
+      await render(
+        hbs`<OSS::PasswordInput @value="" @errorMessage="Error takes priority" @feedbackMessage={{hash type="success" value="Success message"}} />`
+      );
+      assert.dom('.oss-input-container').hasClass('oss-input-container--errored');
+      assert.dom('.text-color-error').hasText('Error takes priority');
+      assert.dom('.font-color-success-500').doesNotExist();
+    });
+  });
+
   test('it throws an error when the @value parameter is missing', async function (assert) {
     setupOnerror((err: any) => {
       assert.equal(err.message, 'Assertion Failed: [component][OSS::PasswordInput] The @value parameter is mandatory');

--- a/tests/integration/components/o-s-s/password-input-test.ts
+++ b/tests/integration/components/o-s-s/password-input-test.ts
@@ -193,6 +193,23 @@ module('Integration | Component | o-s-s/password-input', function (hooks) {
     });
   });
 
+  module('autocomplete', () => {
+    test('defaults to current-password autocomplete', async function (assert) {
+      await render(hbs`<OSS::PasswordInput @value="" />`);
+      assert.dom('input').hasAttribute('autocomplete', 'current-password');
+    });
+
+    test('@autocomplete="on" sets autocomplete to current-password', async function (assert) {
+      await render(hbs`<OSS::PasswordInput @value="" @autocomplete="on" />`);
+      assert.dom('input').hasAttribute('autocomplete', 'current-password');
+    });
+
+    test('@autocomplete="off" sets autocomplete to new-password', async function (assert) {
+      await render(hbs`<OSS::PasswordInput @value="" @autocomplete="off" />`);
+      assert.dom('input').hasAttribute('autocomplete', 'new-password');
+    });
+  });
+
   test('it throws an error when the @value parameter is missing', async function (assert) {
     setupOnerror((err: any) => {
       assert.equal(err.message, 'Assertion Failed: [component][OSS::PasswordInput] The @value parameter is mandatory');

--- a/tests/integration/components/o-s-s/password-input-test.ts
+++ b/tests/integration/components/o-s-s/password-input-test.ts
@@ -199,9 +199,9 @@ module('Integration | Component | o-s-s/password-input', function (hooks) {
       assert.dom('input').hasAttribute('autocomplete', 'current-password');
     });
 
-    test('@autocomplete="on" sets autocomplete to current-password', async function (assert) {
-      await render(hbs`<OSS::PasswordInput @value="" @autocomplete="on" />`);
-      assert.dom('input').hasAttribute('autocomplete', 'current-password');
+    test('@autocomplete="yes-please" sets autocomplete to passed value', async function (assert) {
+      await render(hbs`<OSS::PasswordInput @value="" @autocomplete="yes-please" />`);
+      assert.dom('input').hasAttribute('autocomplete', 'yes-please');
     });
 
     test('@autocomplete="off" sets autocomplete to new-password', async function (assert) {


### PR DESCRIPTION
### What does this PR do?
`OSS::PasswordInput` now supports a `feedbackMessage` argument. The component can now handle an error state with error message coming from a form validation. 

Tests and stories have been updated accordingly.
<!-- A brief description of the context of this pull request and its purpose. -->

Related to: #<!-- enter issue number here -->

### What are the observable changes?
<img width="452" height="123" alt="Capture d’écran 2026-05-06 à 15 31 57" src="https://github.com/user-attachments/assets/59611645-d519-402d-af7e-b0d56e83c7b4" />

<!-- This question could be adequate with multiple use cases, for example: -->

<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [x] Added/updated documentation with Figma design link. Don't forget to replace "design" by "file" in the URL. For example https://www.figma.com/file/example
- [ ] Migrated touched components to Glimmer Components
- [ ] Properly labeled
