### PR TITLE
add autocomplete arg to passwordInput

### DIFF
--- a/addon/components/o-s-s/password-input.hbs
+++ b/addon/components/o-s-s/password-input.hbs
@@ -7,7 +7,7 @@
         disabled={{@disabled}}
         placeholder={{this.placeholder}}
         autocomplete={{this.autocomplete}}
-        {{on "keyup" this.validateInput}}
+        {{on "input" this.validateInput}}
       />
     </:input>
     <:suffix>

--- a/addon/components/o-s-s/password-input.hbs
+++ b/addon/components/o-s-s/password-input.hbs
@@ -6,7 +6,7 @@
         @type={{this.visibility}}
         disabled={{@disabled}}
         placeholder={{this.placeholder}}
-        autocomplete="current-password"
+        autocomplete={{this.autocomplete}}
         {{on "keyup" this.validateInput}}
       />
     </:input>

--- a/addon/components/o-s-s/password-input.stories.js
+++ b/addon/components/o-s-s/password-input.stories.js
@@ -46,12 +46,13 @@ export default {
       control: { type: 'object' }
     },
     autocomplete: {
-      description: 'Whether or not the input should have autocomplete enabled.',
+      description:
+        'Whether or not the input should have autocomplete enabled. If set to "off", it will use "new-password" to prevent browsers from filling in the password. It can be set to any custom value if needed.',
       table: {
         type: {
-          summary: 'on | off'
+          summary: 'on | off | string'
         },
-        defaultValue: { summary: 'undefined' }
+        defaultValue: { summary: 'current-password' }
       },
       control: { type: 'text' }
     },

--- a/addon/components/o-s-s/password-input.stories.js
+++ b/addon/components/o-s-s/password-input.stories.js
@@ -45,6 +45,16 @@ export default {
       },
       control: { type: 'object' }
     },
+    autocomplete: {
+      description: 'Whether or not the input should have autocomplete enabled.',
+      table: {
+        type: {
+          summary: 'on | off'
+        },
+        defaultValue: { summary: 'undefined' }
+      },
+      control: { type: 'text' }
+    },
     disabled: {
       description: 'Whether or not the input is disabled',
       table: {
@@ -89,6 +99,7 @@ const defaultArgs = {
   disabled: false,
   placeholder: '*****',
   errorMessage: undefined,
+  autocomplete: undefined,
   validates: action('validates'),
   validatorSet: undefined
 };
@@ -96,7 +107,7 @@ const defaultArgs = {
 const DefaultUsageTemplate = (args) => ({
   template: hbs`
       <OSS::PasswordInput @value={{this.value}} @placeholder={{this.placeholder}} @validates={{this.validates}}
-                          @disabled={{this.disabled}} @validatorSet={{this.validatorSet}} />
+                          @autocomplete={{this.autocomplete}} @disabled={{this.disabled}} @validatorSet={{this.validatorSet}} />
   `,
   context: args
 });

--- a/addon/components/o-s-s/password-input.ts
+++ b/addon/components/o-s-s/password-input.ts
@@ -125,11 +125,12 @@ export default class OSSPasswordInput extends Component<OSSPasswordInputArgs> {
   );
 
   @action
-  validateInput(): void {
+  validateInput(event: InputEvent): void {
+    const value = (event?.target as HTMLInputElement)?.value;
     this.regexError = '';
-    if (!this.runValidation || !this.args.value) {
+    if (!this.runValidation || !value) {
       this.args.validates?.(true);
-    } else if (!this.testAllValidators()) {
+    } else if (!this.testAllValidators(value)) {
       this.regexError = this.intl.t('oss-components.password-input.regex_error');
       this.args.validates?.(false);
     } else {
@@ -142,10 +143,10 @@ export default class OSSPasswordInput extends Component<OSSPasswordInputArgs> {
     this.visibility = this.visibility === 'password' ? 'text' : 'password';
   }
 
-  private testAllValidators(): boolean {
+  private testAllValidators(value: string): boolean {
     return this.inputValidators.every((key: InputValidator) => {
       if (!this.validatorSet[key]) return false;
-      return this.validatorSet[key]!.regex.test(this.args.value!);
+      return this.validatorSet[key]!.regex.test(value!);
     });
   }
 

--- a/addon/components/o-s-s/password-input.ts
+++ b/addon/components/o-s-s/password-input.ts
@@ -20,6 +20,7 @@ interface OSSPasswordInputArgs {
   errorMessage?: string;
   feedbackMessage?: FeedbackMessage;
   disabled?: boolean;
+  autocomplete?: 'on' | 'off';
   validates?(isPassing: boolean): void;
   validatorSet?: ValidatorSet;
 }
@@ -94,6 +95,14 @@ export default class OSSPasswordInput extends Component<OSSPasswordInputArgs> {
         icon: STATE_ICON_MAPPING[state]
       };
     });
+  }
+
+  get autocomplete(): string {
+    if (this.args.autocomplete === 'off') {
+      return 'new-password';
+    }
+
+    return 'current-password';
   }
 
   validatorAttributes = helper((_, { type }: { type: InputValidator }): ValidationTemplateAttributes => {

--- a/addon/components/o-s-s/password-input.ts
+++ b/addon/components/o-s-s/password-input.ts
@@ -20,7 +20,7 @@ interface OSSPasswordInputArgs {
   errorMessage?: string;
   feedbackMessage?: FeedbackMessage;
   disabled?: boolean;
-  autocomplete?: 'on' | 'off';
+  autocomplete?: 'on' | 'off' | string;
   validates?(isPassing: boolean): void;
   validatorSet?: ValidatorSet;
 }
@@ -101,6 +101,7 @@ export default class OSSPasswordInput extends Component<OSSPasswordInputArgs> {
     if (this.args.autocomplete === 'off') {
       return 'new-password';
     }
+    if (this.args.autocomplete) return this.args.autocomplete;
 
     return 'current-password';
   }

--- a/tests/integration/components/o-s-s/password-input-test.ts
+++ b/tests/integration/components/o-s-s/password-input-test.ts
@@ -193,6 +193,23 @@ module('Integration | Component | o-s-s/password-input', function (hooks) {
     });
   });
 
+  module('autocomplete', () => {
+    test('defaults to current-password autocomplete', async function (assert) {
+      await render(hbs`<OSS::PasswordInput @value="" />`);
+      assert.dom('input').hasAttribute('autocomplete', 'current-password');
+    });
+
+    test('@autocomplete="on" sets autocomplete to current-password', async function (assert) {
+      await render(hbs`<OSS::PasswordInput @value="" @autocomplete="on" />`);
+      assert.dom('input').hasAttribute('autocomplete', 'current-password');
+    });
+
+    test('@autocomplete="off" sets autocomplete to new-password', async function (assert) {
+      await render(hbs`<OSS::PasswordInput @value="" @autocomplete="off" />`);
+      assert.dom('input').hasAttribute('autocomplete', 'new-password');
+    });
+  });
+
   test('it throws an error when the @value parameter is missing', async function (assert) {
     setupOnerror((err: any) => {
       assert.equal(err.message, 'Assertion Failed: [component][OSS::PasswordInput] The @value parameter is mandatory');

--- a/tests/integration/components/o-s-s/password-input-test.ts
+++ b/tests/integration/components/o-s-s/password-input-test.ts
@@ -199,9 +199,9 @@ module('Integration | Component | o-s-s/password-input', function (hooks) {
       assert.dom('input').hasAttribute('autocomplete', 'current-password');
     });
 
-    test('@autocomplete="on" sets autocomplete to current-password', async function (assert) {
-      await render(hbs`<OSS::PasswordInput @value="" @autocomplete="on" />`);
-      assert.dom('input').hasAttribute('autocomplete', 'current-password');
+    test('@autocomplete="yes-please" sets autocomplete to passed value', async function (assert) {
+      await render(hbs`<OSS::PasswordInput @value="" @autocomplete="yes-please" />`);
+      assert.dom('input').hasAttribute('autocomplete', 'yes-please');
     });
 
     test('@autocomplete="off" sets autocomplete to new-password', async function (assert) {


### PR DESCRIPTION
### What does this PR do?
`OSS::PasswordInput` now supports a new `autocomplete` optional arg, being set either to `on` or `off`. It allows the input to disable its default autocompletion.
<!-- A brief description of the context of this pull request and its purpose. -->

Related to: #<!-- enter issue number here -->

### What are the observable changes?
With `autocomplete` undefined
<img width="633" height="371" alt="Capture d’écran 2026-05-20 à 11 24 08" src="https://github.com/user-attachments/assets/c6ed0d8d-ce6f-408a-a550-8c01e0157ed1" />

With `autocomplete="off"`
<img width="633" height="371" alt="Capture d’écran 2026-05-20 à 11 24 17" src="https://github.com/user-attachments/assets/ba034bd0-e783-4355-bcf6-9c28219fadd8" />

<!-- This question could be adequate with multiple use cases, for example: -->

<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [ ] Added/updated tests
- [x] Added/updated documentation with Figma design link. Don't forget to replace "design" by "file" in the URL. For example https://www.figma.com/file/example
- [ ] Migrated touched components to Glimmer Components
- [ ] Properly labeled
