### PR TITLE
Handle 'pending' skin in progress-bar

### DIFF
--- a/addon/components/o-s-s/progress-bar.stories.js
+++ b/addon/components/o-s-s/progress-bar.stories.js
@@ -1,6 +1,6 @@
 import { hbs } from 'ember-cli-htmlbars';
 
-const ProgressBarSkins = ['warning', 'success', 'danger'];
+const ProgressBarSkins = ['pending', 'warning', 'success', 'danger'];
 const ProgressBarSizes = ['xs', 'sm'];
 
 export default {

--- a/app/styles/molecules/progress-bar.less
+++ b/app/styles/molecules/progress-bar.less
@@ -17,6 +17,11 @@
   }
 
   &--secondary-skin {
+    &--pending {
+      .oss-progress-bar__outer {
+        background-color: var(--color-primary-500);
+      }
+    }
     &--warning {
       .oss-progress-bar__outer {
         background-color: var(--color-warning-500);
@@ -30,6 +35,18 @@
     &--danger {
       .oss-progress-bar__outer {
         background-color: var(--color-error-500);
+      }
+    }
+  }
+
+  &--pending {
+    .oss-progress-bar__inner {
+      background-color: var(--color-primary-500);
+    }
+
+    &.oss-progress-bar--colored-background {
+      .oss-progress-bar__outer {
+        background-color: var(--color-primary-100);
       }
     }
   }
@@ -103,6 +120,11 @@
 
     &.oss-progress-bar__inner--initial {
       animation: oss-progress-bar-animation 1s ease;
+    }
+
+    &--pending {
+      background-color: var(--color-primary-500);
+      border-radius: 0;
     }
 
     &--warning {


### PR DESCRIPTION
### What does this PR do?

The `pending` skin was declared in the `ProgressBarSkins` type but had no corresponding css rules. It worked only by side effect: the absence of an override let the default `--color-primary-500` from the base `&__inner` selector apply. This made `pending` an implicit special case.

This PR makes `pending` an explicit skin, handled the same way as `warning`, `success`, and `danger`

Related to: #<!-- enter issue number here -->

### What are the observable changes?

<!-- This question could be adequate with multiple use cases, for example: -->

<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [ ] Added/updated tests
- [ ] Added/updated documentation with Figma design link. Don't forget to replace "design" by "file" in the URL. For example https://www.figma.com/file/example
- [ ] Migrated touched components to Glimmer Components
- [ ] Properly labeled
