### PR TITLE
Add an ellipsis on upf-select

### DIFF
--- a/addon/components/o-s-s/select.hbs
+++ b/addon/components/o-s-s/select.hbs
@@ -22,7 +22,9 @@
         <span
           class={{concat "upf-input--placeholder" (if @placeholderEllipsis " text-ellipsis")}}
           {{enable-tooltip title=this.placeholder placement="top" displayOnlyOnOverflow=true}}
-        >{{this.placeholder}}</span>
+        >
+          {{this.placeholder}}
+        </span>
       {{/if}}
       <OSS::Icon @icon="fa-chevron-{{if this.isOpen 'up' 'down'}}" class="margin-left-px-6" />
     </div>

--- a/addon/components/o-s-s/select.hbs
+++ b/addon/components/o-s-s/select.hbs
@@ -19,7 +19,10 @@
           <span class="text-ellipsis">{{get @value this.targetValue}}</span>
         {{/if}}
       {{else}}
-        <span class="upf-input--placeholder">{{this.placeholder}}</span>
+        <span
+          class={{concat "upf-input--placeholder" (if @placeholderEllipsis " text-ellipsis")}}
+          {{enable-tooltip title=this.placeholder placement="top" displayOnlyOnOverflow=true}}
+        >{{this.placeholder}}</span>
       {{/if}}
       <OSS::Icon @icon="fa-chevron-{{if this.isOpen 'up' 'down'}}" class="margin-left-px-6" />
     </div>

--- a/addon/components/o-s-s/select.stories.js
+++ b/addon/components/o-s-s/select.stories.js
@@ -157,6 +157,27 @@ export default {
         defaultValue: { summary: false }
       },
       control: { type: 'boolean' }
+    },
+    dropdownWidth: {
+      description: 'The width of the dropdown in pixels. By default, the dropdown width matches the input width.',
+      table: {
+        type: {
+          summary: 'number'
+        },
+        defaultValue: { summary: 'input width' }
+      },
+      control: { type: 'number' }
+    },
+    dropdownPlacementOptions: {
+      description:
+        'Options to be passed to the floating-ui library to control the dropdown placement. For more information, see https://github.com/upfluence/oss-components/blob/master/addon/utils/attach-dropdown.ts#L26',
+      type: { name: 'object' },
+      table: {
+        type: {
+          summary: 'AttachmentOptions'
+        }
+      },
+      control: { type: 'object' }
     }
   },
   parameters: {
@@ -184,6 +205,8 @@ const defaultArgs = {
   successMessage: undefined,
   addressableAs: undefined,
   placeholderEllipsis: false,
+  dropdownWidth: undefined,
+  dropdownPlacementOptions: undefined,
   skin: 'default',
   action: {
     skin: 'tertiary',
@@ -203,7 +226,7 @@ const Template = (args) => ({
       @items={{this.items}} @value={{this.value}} @targetLabel={{this.targetLabel}} @placeholder={{this.placeholder}}
       @disabled={{this.disabled}} @errorMessage={{this.errorMessage}} @successMessage={{this.successMessage}}
       @onSearch={{this.onSearch}} @onChange={{this.onChange}} @action={{this.action}} @hasError={{this.hasError}}
-      @skin={{this.skin}} @placeholderEllipsis={{this.placeholderEllipsis}}>
+      @skin={{this.skin}} @placeholderEllipsis={{this.placeholderEllipsis}} @dropdownWidth={{this.dropdownWidth}} @dropdownPlacementOptions={{this.dropdownPlacementOptions}}>
       <:option as |item|>
         {{item.name}}
       </:option>

--- a/addon/components/o-s-s/select.stories.js
+++ b/addon/components/o-s-s/select.stories.js
@@ -146,6 +146,17 @@ export default {
       },
       options: SkinTypes,
       control: { type: 'select' }
+    },
+    placeholderEllipsis: {
+      description:
+        'When enabled, the placeholder text is truncated with an ellipsis and a tooltip is shown on overflow.',
+      table: {
+        type: {
+          summary: 'boolean'
+        },
+        defaultValue: { summary: false }
+      },
+      control: { type: 'boolean' }
     }
   },
   parameters: {
@@ -172,6 +183,7 @@ const defaultArgs = {
   errorMessage: undefined,
   successMessage: undefined,
   addressableAs: undefined,
+  placeholderEllipsis: false,
   skin: 'default',
   action: {
     skin: 'tertiary',
@@ -191,7 +203,7 @@ const Template = (args) => ({
       @items={{this.items}} @value={{this.value}} @targetLabel={{this.targetLabel}} @placeholder={{this.placeholder}}
       @disabled={{this.disabled}} @errorMessage={{this.errorMessage}} @successMessage={{this.successMessage}}
       @onSearch={{this.onSearch}} @onChange={{this.onChange}} @action={{this.action}} @hasError={{this.hasError}}
-      @skin={{this.skin}}>
+      @skin={{this.skin}} @placeholderEllipsis={{this.placeholderEllipsis}}>
       <:option as |item|>
         {{item.name}}
       </:option>

--- a/addon/components/o-s-s/select.ts
+++ b/addon/components/o-s-s/select.ts
@@ -21,6 +21,7 @@ interface OSSSelectArgs extends BaseDropdownArgs {
   addressableAs?: string;
   action?: InfiniteSelectAction;
   skin?: 'default' | 'smart';
+  placeholderEllipsis?: boolean;
   onChange(value: any): void;
   onSearch?(keyword: string): void;
 }

--- a/addon/components/o-s-s/select.ts
+++ b/addon/components/o-s-s/select.ts
@@ -6,7 +6,7 @@ import { isEmpty } from '@ember/utils';
 import { scheduleOnce } from '@ember/runloop';
 
 import type IntlService from 'ember-intl/services/intl';
-import attachDropdown from '@upfluence/oss-components/utils/attach-dropdown';
+import attachDropdown, { type AttachmentOptions } from '@upfluence/oss-components/utils/attach-dropdown';
 import BaseDropdown, { type BaseDropdownArgs } from './private/base-dropdown';
 import type { InfiniteSelectAction } from './infinite-select';
 
@@ -22,6 +22,8 @@ interface OSSSelectArgs extends BaseDropdownArgs {
   action?: InfiniteSelectAction;
   skin?: 'default' | 'smart';
   placeholderEllipsis?: boolean;
+  dropdownWidth?: number;
+  dropdownPlacementOptions?: AttachmentOptions;
   onChange(value: any): void;
   onSearch?(keyword: string): void;
 }
@@ -150,11 +152,18 @@ export default class OSSSelect extends BaseDropdown<OSSSelectArgs> {
     const referenceTarget = this.container.querySelector('.upf-input');
     const floatingTarget = document.querySelector(`#${this.portalId}`);
 
+    const attachDropdownOptions: AttachmentOptions = {
+      maxHeight: 300,
+      ...(this.args.dropdownWidth ? { width: this.args.dropdownWidth } : {}),
+      ...(this.args.dropdownPlacementOptions ?? { placementStrategy: 'auto' })
+    };
+    if (this.args.dropdownWidth) attachDropdownOptions.width = this.args.dropdownWidth;
+
     if (referenceTarget && floatingTarget) {
       this.cleanupDrodpownAutoplacement = attachDropdown(
         referenceTarget as HTMLElement,
         floatingTarget as HTMLElement,
-        { maxHeight: 300, placementStrategy: 'auto' }
+        attachDropdownOptions
       );
     }
   }

--- a/tests/integration/components/o-s-s/select-test.ts
+++ b/tests/integration/components/o-s-s/select-test.ts
@@ -364,6 +364,86 @@ module('Integration | Component | o-s-s/select', function (hooks) {
     });
   });
 
+  module('with @dropdownPlacementOptions', () => {
+    test('the dropdown placement options are used when passed', async function (assert) {
+      await render(
+        hbs`
+          <OSS::Select
+            @onChange={{this.onChange}}
+            @items={{this.items}}
+            @value={{this.value}}
+            @dropdownPlacementOptions={{hash maxHeight=123}}
+          >
+            <:option as |item|>
+              {{item.name}}
+            </:option>
+          </OSS::Select>
+        `
+      );
+
+      await click('.upf-input div');
+      const dropdown = document.querySelector('.upf-infinite-select') as HTMLElement;
+      assert.strictEqual(dropdown.style.maxHeight, '123px');
+      assert.strictEqual(dropdown.style.getPropertyValue('--floating-max-height'), '123px');
+    });
+
+    test('if the dropdown placement options are not passed, the dropdown is displayed with the default placement options', async function (assert) {
+      await render(
+        hbs`
+          <OSS::Select
+            @onChange={{this.onChange}}
+            @items={{this.items}}
+            @value={{this.value}}
+          >
+            <:option as |item|>
+              {{item.name}}
+            </:option>
+          </OSS::Select>
+        `
+      );
+
+      await click('.upf-input div');
+      const dropdown = document.querySelector('.upf-infinite-select') as HTMLElement;
+      assert.strictEqual(dropdown.style.maxHeight, '300px');
+      assert.strictEqual(dropdown.style.getPropertyValue('--floating-max-height'), '300px');
+    });
+  });
+
+  module('@dropdownWidth argument', function () {
+    test('the dropdown width is applied when @dropdownWidth is passed', async function (assert) {
+      await render(
+        hbs`
+          <OSS::Select @onChange={{this.onChange}} @items={{this.items}} @value={{this.value}} @dropdownWidth=400>
+            <:option as |item|>
+              {{item.name}}
+            </:option>
+          </OSS::Select>
+        `
+      );
+
+      await click('.upf-input div');
+      const dropdown = document.querySelector('.upf-infinite-select') as HTMLElement;
+      assert.strictEqual(dropdown.style.width, '400px');
+    });
+
+    test('the dropdown width defaults to the reference element width when @dropdownWidth is not passed', async function (assert) {
+      await render(
+        hbs`
+          <OSS::Select @onChange={{this.onChange}} @items={{this.items}} @value={{this.value}}>
+            <:option as |item|>
+              {{item.name}}
+            </:option>
+          </OSS::Select>
+        `
+      );
+
+      await click('.upf-input div');
+      const dropdown = document.querySelector('.upf-infinite-select') as HTMLElement | null;
+      const reference = document.querySelector('.upf-input') as HTMLElement | null;
+      assert.strictEqual(dropdown?.style.width, `${reference?.offsetWidth}px`);
+    });
+  });
+
   module('Action argument', function (hooks) {
     hooks.beforeEach(function () {
       this.onActionClick = sinon.stub();

--- a/tests/integration/components/o-s-s/select-test.ts
+++ b/tests/integration/components/o-s-s/select-test.ts
@@ -171,6 +171,53 @@ module('Integration | Component | o-s-s/select', function (hooks) {
     });
   });
 
+  module('@placeholderEllipsis argument', function () {
+    test('when @placeholderEllipsis is not passed, the placeholder does not have the text-ellipsis class', async function (assert) {
+      this.value = null;
+      await render(
+        hbs`
+          <OSS::Select @onChange={{this.onChange}} @items={{this.items}} @value={{this.value}} @placeholder="my placeholder">
+            <:option as |item|>
+              {{item.name}}
+            </:option>
+          </OSS::Select>
+        `
+      );
+
+      assert.dom('.upf-input--placeholder').doesNotHaveClass('text-ellipsis');
+    });
+
+    test('when @placeholderEllipsis={{true}}, the placeholder has the text-ellipsis class', async function (assert) {
+      this.value = null;
+      await render(
+        hbs`
+          <OSS::Select @onChange={{this.onChange}} @items={{this.items}} @value={{this.value}} @placeholder="my placeholder" @placeholderEllipsis={{true}}>
+            <:option as |item|>
+              {{item.name}}
+            </:option>
+          </OSS::Select>
+        `
+      );
+
+      assert.dom('.upf-input--placeholder').hasClass('text-ellipsis');
+    });
+
+    test('when @placeholderEllipsis={{false}}, the placeholder does not have the text-ellipsis class', async function (assert) {
+      this.value = null;
+      await render(
+        hbs`
+          <OSS::Select @onChange={{this.onChange}} @items={{this.items}} @value={{this.value}} @placeholder="my placeholder" @placeholderEllipsis={{false}}>
+            <:option as |item|>
+              {{item.name}}
+            </:option>
+          </OSS::Select>
+        `
+      );
+
+      assert.dom('.upf-input--placeholder').doesNotHaveClass('text-ellipsis');
+    });
+  });
+
   module('disabled state', function () {
     test('the dropdown does not open when the select is clicked', async function (assert) {
       await render(


### PR DESCRIPTION
### What does this PR do?

Add a parameter to enable ellipsis and tooltip in select input

<img width="500" alt="Capture d’écran 2026-06-05 à 16 28 00" src="https://github.com/user-attachments/assets/3b0b4abb-2e3a-4ee6-b39a-fddead1151cb" />

### What are the observable changes?

<!-- This question could be adequate with multiple use cases, for example: -->

<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [ ] Added/updated documentation with Figma design link. Don't forget to replace "design" by "file" in the URL. For example https://www.figma.com/file/example
- [ ] Migrated touched components to Glimmer Components
- [ ] Properly labeled
