### PR TITLE
Updated OSS::Alert component

### DIFF
--- a/addon/components/o-s-s/alert.hbs
+++ b/addon/components/o-s-s/alert.hbs
@@ -1,24 +1,25 @@
-<div class={{concat "upf-alert " this.skinClass}} {{did-insert this.initSelf}} ...attributes>
-  <div class="indicator"></div>
-  <div class="main-container {{if this.plain 'main-container--plain'}}">
-    <span class="icon">
-      <OSS::Icon @icon={{this.iconClass}} />
-    </span>
-    <div class="text-container">
-      {{#if @title}}
-        <span class="title">{{@title}}</span>
-      {{/if}}
-      {{#if @subtitle}}
-        <span class="subtitle">{{@subtitle}}</span>
-      {{/if}}
-      {{#if (has-block "extra-content")}}
-        {{yield to="extra-content"}}
-      {{/if}}
-    </div>
-    {{#if @closable}}
-      <div class="fx-col">
-        <i role="button" class="far fa-times" {{on "click" this.removeSelf}}></i>
-      </div>
+<div
+  class={{concat "upf-alert " this.skinClass (if this.plain " upf-alert--plain")}}
+  {{did-insert this.initSelf}}
+  ...attributes
+>
+  <span class="icon">
+    <OSS::Icon @icon={{this.iconClass}} />
+  </span>
+  <div class="text-container">
+    {{#if @title}}
+      <span class="title">{{@title}}</span>
+    {{/if}}
+    {{#if @subtitle}}
+      <span class="subtitle">{{@subtitle}}</span>
+    {{/if}}
+    {{#if (has-block "extra-content")}}
+      {{yield to="extra-content"}}
     {{/if}}
   </div>
+  {{#if @closable}}
+    <div class="fx-col">
+      <i role="button" class="far fa-times" {{on "click" this.removeSelf}}></i>
+    </div>
+  {{/if}}
 </div>

--- a/addon/components/o-s-s/alert.hbs
+++ b/addon/components/o-s-s/alert.hbs
@@ -14,15 +14,13 @@
     {{/if}}
   </div>
   {{#if @closable}}
-    <div class="fx-col">
-      <OSS::Button
-        class="upf-alert-close-button"
-        @size="sm"
-        @icon="fa-times"
-        @square={{true}}
-        {{on "click" this.removeSelf}}
-        data-control-name="upf-alert-close-button"
-      />
-    </div>
+    <OSS::Button
+      class="upf-alert-close-button"
+      @size="sm"
+      @icon="fa-times"
+      @square={{true}}
+      {{on "click" this.removeSelf}}
+      data-control-name="upf-alert-close-button"
+    />
   {{/if}}
 </div>

--- a/addon/components/o-s-s/alert.hbs
+++ b/addon/components/o-s-s/alert.hbs
@@ -1,8 +1,4 @@
-<div
-  class={{concat "upf-alert " this.skinClass (if this.plain " upf-alert--plain")}}
-  {{did-insert this.initSelf}}
-  ...attributes
->
+<div class={{concat "upf-alert " this.skinClass}} {{did-insert this.initSelf}} ...attributes>
   <span class="icon">
     <OSS::Icon @icon={{this.iconClass}} />
   </span>
@@ -19,7 +15,7 @@
   </div>
   {{#if @closable}}
     <div class="fx-col">
-      <i role="button" class="far fa-times" {{on "click" this.removeSelf}}></i>
+      <OSS::Button @size="sm" @icon="fa-times" @square={{true}} {{on "click" this.removeSelf}} />
     </div>
   {{/if}}
 </div>

--- a/addon/components/o-s-s/alert.hbs
+++ b/addon/components/o-s-s/alert.hbs
@@ -15,7 +15,14 @@
   </div>
   {{#if @closable}}
     <div class="fx-col">
-      <OSS::Button @size="sm" @icon="fa-times" @square={{true}} {{on "click" this.removeSelf}} />
+      <OSS::Button
+        class="upf-alert-close-button"
+        @size="sm"
+        @icon="fa-times"
+        @square={{true}}
+        {{on "click" this.removeSelf}}
+        data-control-name="upf-alert-close-button"
+      />
     </div>
   {{/if}}
 </div>

--- a/addon/components/o-s-s/alert.stories.js
+++ b/addon/components/o-s-s/alert.stories.js
@@ -39,7 +39,8 @@ export default {
       control: { type: 'text' }
     },
     plain: {
-      description: 'When plain is true, a gray background color is displayed, otherwise a white one',
+      description:
+        'When plain is true (or undefined), a colored background is displayed; when false, the background is gray',
       table: {
         type: { summary: 'boolean' },
         defaultValue: { summary: 'true' }
@@ -93,7 +94,7 @@ const defaultArgs = {
 
 const Template = (args) => ({
   template: hbs`
-      <OSS::Alert @skin={{this.skin}} @title={{this.title}} @subtitle={{this.subtitle}} @plain={{this.plain}} 
+      <OSS::Alert @skin={{this.skin}} @title={{this.title}} @subtitle={{this.subtitle}} @plain={{this.plain}}
                   @closable={{this.closable}} />
   `,
   context: args
@@ -101,7 +102,7 @@ const Template = (args) => ({
 
 const ExtraContentTemplate = (args) => ({
   template: hbs`
-      <OSS::Alert @skin={{this.skin}} @title={{this.title}} @subtitle={{this.subtitle}} @plain={{this.plain}} 
+      <OSS::Alert @skin={{this.skin}} @title={{this.title}} @subtitle={{this.subtitle}} @plain={{this.plain}}
                   @closable={{this.closable}}>
         <:extra-content>
           <div class="fx-row fx-gap-px-12">

--- a/addon/components/o-s-s/alert.stories.js
+++ b/addon/components/o-s-s/alert.stories.js
@@ -95,7 +95,7 @@ const defaultArgs = {
 const Template = (args) => ({
   template: hbs`
       <OSS::Alert @skin={{this.skin}} @title={{this.title}} @subtitle={{this.subtitle}} @plain={{this.plain}}
-                  @closable={{this.closable}} />
+                  @closable={{this.closable}} @onClose={{this.onClose}} />
   `,
   context: args
 });
@@ -103,7 +103,7 @@ const Template = (args) => ({
 const ExtraContentTemplate = (args) => ({
   template: hbs`
       <OSS::Alert @skin={{this.skin}} @title={{this.title}} @subtitle={{this.subtitle}} @plain={{this.plain}}
-                  @closable={{this.closable}}>
+                  @closable={{this.closable}} @onClose={{this.onClose}}>
         <:extra-content>
           <div class="fx-row fx-gap-px-12">
             <OSS::Link @label="Link1" />

--- a/addon/components/o-s-s/alert.stories.js
+++ b/addon/components/o-s-s/alert.stories.js
@@ -38,17 +38,6 @@ export default {
       },
       control: { type: 'text' }
     },
-    plain: {
-      description:
-        'When plain is true (or undefined), a colored background is displayed; when false, the background is gray',
-      table: {
-        type: { summary: 'boolean' },
-        defaultValue: { summary: 'true' }
-      },
-      control: {
-        type: 'boolean'
-      }
-    },
     closable: {
       description: 'When enabled, the alert can be closed by clicking on the cross icon',
       table: {
@@ -87,14 +76,13 @@ const defaultArgs = {
   skin: 'info',
   title: 'Title',
   subtitle: 'I am a subtitle in the alert',
-  plain: true,
   closable: false,
   onClose: action('onClose')
 };
 
 const Template = (args) => ({
   template: hbs`
-      <OSS::Alert @skin={{this.skin}} @title={{this.title}} @subtitle={{this.subtitle}} @plain={{this.plain}}
+      <OSS::Alert @skin={{this.skin}} @title={{this.title}} @subtitle={{this.subtitle}}
                   @closable={{this.closable}} @onClose={{this.onClose}} />
   `,
   context: args
@@ -102,7 +90,7 @@ const Template = (args) => ({
 
 const ExtraContentTemplate = (args) => ({
   template: hbs`
-      <OSS::Alert @skin={{this.skin}} @title={{this.title}} @subtitle={{this.subtitle}} @plain={{this.plain}}
+      <OSS::Alert @skin={{this.skin}} @title={{this.title}} @subtitle={{this.subtitle}}
                   @closable={{this.closable}} @onClose={{this.onClose}}>
         <:extra-content>
           <div class="fx-row fx-gap-px-12">

--- a/addon/components/o-s-s/alert.ts
+++ b/addon/components/o-s-s/alert.ts
@@ -17,12 +17,14 @@ interface OSSAlertArgs {
 export default class OSSAlert extends Component<OSSAlertArgs> {
   private declare _DOMElement: HTMLElement;
 
-  get skinClass(): string {
-    return `upf-alert--${this.args.skin || DEFAULT_SKIN}`;
-  }
-
   get plain(): boolean {
     return this.args.plain ?? true;
+  }
+
+  get skinClass(): string {
+    let skinClass = `upf-alert--${this.args.skin || DEFAULT_SKIN}`;
+    this.plain ? (skinClass += ' upf-alert--plain') : null;
+    return skinClass;
   }
 
   get iconClass(): string {

--- a/addon/components/o-s-s/alert.ts
+++ b/addon/components/o-s-s/alert.ts
@@ -9,7 +9,6 @@ interface OSSAlertArgs {
   skin?: skinType;
   title?: string;
   subtitle?: string;
-  plain?: boolean;
   closable?: boolean;
   onClose?(): void;
 }
@@ -17,14 +16,8 @@ interface OSSAlertArgs {
 export default class OSSAlert extends Component<OSSAlertArgs> {
   private declare _DOMElement: HTMLElement;
 
-  get plain(): boolean {
-    return this.args.plain ?? true;
-  }
-
   get skinClass(): string {
-    let skinClass = `upf-alert--${this.args.skin || DEFAULT_SKIN}`;
-    this.plain ? (skinClass += ' upf-alert--plain') : null;
-    return skinClass;
+    return `upf-alert--${this.args.skin || DEFAULT_SKIN}`;
   }
 
   get iconClass(): string {

--- a/app/styles/alert.less
+++ b/app/styles/alert.less
@@ -6,7 +6,7 @@
   border: 1px solid var(--color-border-default);
   border-radius: var(--border-radius-md);
   padding: var(--spacing-px-9);
-  gap: var(--spacing-px-12);
+  gap: var(--spacing-px-6);
   background-color: var(--color-gray-50);
 
   .text-container {
@@ -24,6 +24,12 @@
       a {
         color: var(--color-blue-600);
       }
+    }
+  }
+
+  .icon {
+    i {
+      width: 19px;
     }
   }
 

--- a/app/styles/alert.less
+++ b/app/styles/alert.less
@@ -8,6 +8,7 @@
   padding: var(--spacing-px-9);
   gap: var(--spacing-px-6);
   background-color: var(--color-gray-50);
+  height: fit-content;
 
   .text-container {
     display: flex;
@@ -24,6 +25,13 @@
       a {
         color: var(--color-blue-600);
       }
+    }
+  }
+
+  &:has(.upf-alert-close-button) {
+    > .icon:has(+ .text-container > :only-child),
+    > .text-container:has(> :only-child) {
+      align-self: center;
     }
   }
 

--- a/app/styles/alert.less
+++ b/app/styles/alert.less
@@ -7,7 +7,6 @@
   border-radius: var(--border-radius-md);
   padding: var(--spacing-px-9);
   gap: var(--spacing-px-6);
-  background-color: var(--color-gray-50);
   height: fit-content;
 
   .text-container {
@@ -47,11 +46,8 @@
   }
 
   &--success {
+    background-color: var(--color-success-50);
     border-color: var(--color-success-100);
-
-    &.upf-alert--plain {
-      background-color: var(--color-success-50);
-    }
 
     .icon {
       color: var(--color-success-500);
@@ -64,11 +60,8 @@
   }
 
   &--error {
+    background-color: var(--color-error-50);
     border-color: var(--color-error-100);
-
-    &.upf-alert--plain {
-      background-color: var(--color-error-50);
-    }
 
     .icon {
       color: var(--color-error-500);
@@ -81,11 +74,8 @@
   }
 
   &--warning {
+    background-color: var(--color-warning-50);
     border-color: var(--color-warning-100);
-
-    &.upf-alert--plain {
-      background-color: var(--color-warning-50);
-    }
 
     .icon {
       color: var(--color-warning-500);
@@ -98,11 +88,8 @@
   }
 
   &--info {
+    background-color: var(--color-blue-50);
     border-color: var(--color-blue-100);
-
-    &.upf-alert--plain {
-      background-color: var(--color-blue-50);
-    }
 
     .icon {
       color: var(--color-blue-500);

--- a/app/styles/alert.less
+++ b/app/styles/alert.less
@@ -33,7 +33,7 @@
     }
   }
 
-  .upf-square-btn.upf-btn--default.upf-square-btn--sm {
+  .upf-alert-close-button {
     background-color: transparent;
     border: none;
   }

--- a/app/styles/alert.less
+++ b/app/styles/alert.less
@@ -5,81 +5,93 @@
   overflow: hidden;
   border: 1px solid var(--color-border-default);
   border-radius: var(--border-radius-md);
-
-  .main-container {
-    display: flex;
-    flex-direction: row;
-    flex: 1;
-    padding: var(--spacing-px-9);
-    gap: var(--spacing-px-12);
-    background-color: var(--color-white);
-
-    &--plain {
-      background-color: var(--color-gray-50);
-    }
-  }
+  padding: var(--spacing-px-9);
+  gap: var(--spacing-px-12);
+  background-color: var(--color-gray-50);
 
   .text-container {
     display: flex;
     flex-direction: column;
     flex: 1;
     gap: 3px;
-    .text-size-5;
+    font-size: var(--font-size-sm);
 
     .title {
       .text-style-semibold;
     }
 
     .subtitle {
-      color: var(--color-gray-500);
-
       a {
         color: var(--color-blue-600);
       }
     }
   }
 
-  .indicator {
-    width: 3px;
-  }
-
   &--success {
+    border-color: var(--color-success-100);
+
+    &.upf-alert--plain {
+      background-color: var(--color-success-50);
+    }
+
     .icon {
       color: var(--color-success-500);
     }
 
-    .indicator {
-      background-color: var(--color-success-500);
+    .title,
+    .subtitle {
+      color: var(--color-success-900);
     }
   }
 
   &--error {
+    border-color: var(--color-error-100);
+
+    &.upf-alert--plain {
+      background-color: var(--color-error-50);
+    }
+
     .icon {
       color: var(--color-error-500);
     }
 
-    .indicator {
-      background-color: var(--color-error-500);
+    .title,
+    .subtitle {
+      color: var(--color-error-900);
     }
   }
 
   &--warning {
+    border-color: var(--color-warning-100);
+
+    &.upf-alert--plain {
+      background-color: var(--color-warning-50);
+    }
+
     .icon {
       color: var(--color-warning-500);
     }
 
-    .indicator {
-      background-color: var(--color-warning-500);
+    .title,
+    .subtitle {
+      color: var(--color-warning-900);
     }
   }
 
   &--info {
-    .icon {
-      color: var(--color-primary-500);
+    border-color: var(--color-blue-100);
+
+    &.upf-alert--plain {
+      background-color: var(--color-blue-50);
     }
 
-    .indicator {
-      background-color: var(--color-primary-500);
+    .icon {
+      color: var(--color-blue-500);
+    }
+
+    .title,
+    .subtitle {
+      color: var(--color-blue-900);
     }
   }
 }

--- a/app/styles/alert.less
+++ b/app/styles/alert.less
@@ -27,6 +27,11 @@
     }
   }
 
+  .upf-square-btn.upf-btn--default.upf-square-btn--sm {
+    background-color: transparent;
+    border: none;
+  }
+
   &--success {
     border-color: var(--color-success-100);
 

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -100,6 +100,14 @@
         <OSS::Alert @skin="success" @title="Title" />
         <OSS::Alert @skin="warning" @subtitle="Subtitle" @closable={{true}} />
       </div>
+      <div class="fx-row fx-gap-px-12">
+        <OSS::Alert
+          @skin="error"
+          @title="Title"
+          @subtitle="Lorem ipsum dolor sit amet consectetur adipisicing elit. At cum ex corrupti dignissimos voluptate incidunt provident adipisci! Enim, perferendis. Odit, cupiditate. Architecto dignissimos numquam animi quam. Sed commodi ipsam eos. Soluta incidunt assumenda porro velit natus eveniet dolorem sed esse error dolores explicabo aspernatur dignissimos eum ut, autem ex iste modi neque eius ratione recusandae quo unde? Quis, ducimus eaque."
+          @closable={{true}}
+        />
+      </div>
     </div>
   </div>
 

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -85,13 +85,20 @@
         </OSS::Alert>
       </div>
       <div class="fx-row fx-gap-px-12">
-        <OSS::Alert @title="TitleTest" @subtitle="SubtitleTest" @plain={{false}} @closable={{true}} />
-        <OSS::Alert @title="Title" @subtitle="Subtitle" />
-        <OSS::Alert @skin="error" @title="Title" @subtitle="Subtitle" />
+        <OSS::Alert @title="Title" @subtitle="Subtitle" @closable={{true}} />
+        <OSS::Alert @skin="info" @title="Title" @subtitle="Subtitle" @plain={{false}} />
+        <OSS::Alert @skin="error" @title="Title" @subtitle="Subtitle" @closable={{true}} />
+        <OSS::Alert @skin="error" @title="Title" @subtitle="Subtitle" @plain={{false}} />
+      </div>
+      <div class="fx-row fx-gap-px-12">
+        <OSS::Alert @skin="success" @title="Title" @subtitle="Subtitle" />
+        <OSS::Alert @skin="success" @title="Title" @subtitle="Subtitle" @plain={{false}} @closable={{true}} />
+        <OSS::Alert @skin="warning" @title="Title" @subtitle="Subtitle" />
+        <OSS::Alert @skin="warning" @title="Title" @subtitle="Subtitle" @plain={{false}} @closable={{true}} />
       </div>
       <div class="fx-row fx-gap-px-12">
         <OSS::Alert @skin="success" @title="Title" />
-        <OSS::Alert @skin="warning" @subtitle="Subtitle" />
+        <OSS::Alert @skin="warning" @subtitle="Subtitle" @closable={{true}} />
       </div>
     </div>
   </div>

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -86,15 +86,9 @@
       </div>
       <div class="fx-row fx-gap-px-12">
         <OSS::Alert @title="Title" @subtitle="Subtitle" @closable={{true}} />
-        <OSS::Alert @skin="info" @title="Title" @subtitle="Subtitle" @plain={{false}} />
+        <OSS::Alert @skin="success" @title="Title" @subtitle="Subtitle" @plain={{false}} />
         <OSS::Alert @skin="error" @title="Title" @subtitle="Subtitle" @closable={{true}} />
-        <OSS::Alert @skin="error" @title="Title" @subtitle="Subtitle" @plain={{false}} />
-      </div>
-      <div class="fx-row fx-gap-px-12">
-        <OSS::Alert @skin="success" @title="Title" @subtitle="Subtitle" />
-        <OSS::Alert @skin="success" @title="Title" @subtitle="Subtitle" @plain={{false}} @closable={{true}} />
-        <OSS::Alert @skin="warning" @title="Title" @subtitle="Subtitle" />
-        <OSS::Alert @skin="warning" @title="Title" @subtitle="Subtitle" @plain={{false}} @closable={{true}} />
+        <OSS::Alert @skin="warning" @title="Title" @subtitle="Subtitle" @plain={{false}} />
       </div>
       <div class="fx-row fx-gap-px-12">
         <OSS::Alert @skin="success" @title="Title" />

--- a/tests/integration/components/o-s-s/alert-test.ts
+++ b/tests/integration/components/o-s-s/alert-test.ts
@@ -31,34 +31,14 @@ module('Integration | Component | o-s-s/alert', function (hooks) {
     test(`it renders ${skin} skin correctly`, async function (assert) {
       this.skin = skin;
       await render(
-        hbs`<OSS::Alert @skin={{this.skin}} @title={{concat "Title " this.skin}} @subtitle={{concat "Subitle " this.skin}} />`
+        hbs`<OSS::Alert @skin={{this.skin}} @title={{concat "Title " this.skin}} @subtitle={{concat "Subtitle " this.skin}} />`
       );
 
       assert.dom('.upf-alert .icon i').hasClass('far');
       assert.dom('.upf-alert .icon i').hasClass(`${ICONS[skin]}`);
       assert.dom('.upf-alert .title').hasText(`Title ${skin}`);
-      assert.dom('.upf-alert .subtitle').hasText(`Subitle ${skin}`);
+      assert.dom('.upf-alert .subtitle').hasText(`Subtitle ${skin}`);
       assert.dom('.upf-alert').hasClass(`upf-alert--${skin}`);
-    });
-  });
-
-  module('@plain parameter', function () {
-    test('if true, the background-color is colored', async function (assert) {
-      await render(hbs`<OSS::Alert @plain={{true}} />`);
-
-      assert.dom('.upf-alert').hasClass('upf-alert--plain');
-    });
-
-    test('if false, the background-color is gray', async function (assert) {
-      await render(hbs`<OSS::Alert @plain={{false}} />`);
-
-      assert.dom('.upf-alert').hasNoClass('upf-alert--plain');
-    });
-
-    test('if undefined, the background-color is colored', async function (assert) {
-      await render(hbs`<OSS::Alert />`);
-
-      assert.dom('.upf-alert').hasClass('upf-alert--plain');
     });
   });
 

--- a/tests/integration/components/o-s-s/alert-test.ts
+++ b/tests/integration/components/o-s-s/alert-test.ts
@@ -38,6 +38,7 @@ module('Integration | Component | o-s-s/alert', function (hooks) {
       assert.dom('.upf-alert .icon i').hasClass(`${ICONS[skin]}`);
       assert.dom('.upf-alert .title').hasText(`Title ${skin}`);
       assert.dom('.upf-alert .subtitle').hasText(`Subitle ${skin}`);
+      assert.dom('.upf-alert').hasClass(`upf-alert--${skin}`);
     });
   });
 
@@ -62,37 +63,39 @@ module('Integration | Component | o-s-s/alert', function (hooks) {
   });
 
   module('@closable parameter', function () {
-    test('if true, display the cross icon which delete alert when you click on it', async function (assert) {
+    test('if true, displays the close button which removes the alert when you click on it', async function (assert) {
       await render(hbs`<div><OSS::Alert @closable={{true}} /></div>`);
 
       assert.dom('.upf-alert').exists();
-      assert.dom('.upf-alert .fx-col i').exists();
-      assert.dom('.upf-alert .fx-col i').hasClass('fa-times');
+      assert.dom('.upf-alert .upf-alert-close-button').exists();
+      assert.dom('.upf-alert .upf-alert-close-button i').hasClass('fa-times');
 
-      await click('.upf-alert .fx-col i');
+      await click('.upf-alert .upf-alert-close-button');
 
       assert.dom('.upf-alert').doesNotExist();
     });
 
-    test('if false, the cross icon is not displayed', async function (assert) {
+    test('if false, the close button is not displayed', async function (assert) {
       await render(hbs`<OSS::Alert @closable={{false}} />`);
 
       assert.dom('.upf-alert').exists();
-      assert.dom('.upf-alert .fx-col i').doesNotExist();
+      assert.dom('.upf-alert .upf-alert-close-button').doesNotExist();
     });
 
-    test('if undefined, the cross icon is not displayed', async function (assert) {
+    test('if undefined, the close button is not displayed', async function (assert) {
       await render(hbs`<OSS::Alert />`);
 
       assert.dom('.upf-alert').exists();
-      assert.dom('.upf-alert .fx-col i').doesNotExist();
+      assert.dom('.upf-alert .upf-alert-close-button').doesNotExist();
     });
 
-    test('clicking the cross icon also calls the onClose argument provided', async function (assert) {
+    test('clicking the close button also calls the onClose argument provided', async function (assert) {
       this.onClose = sinon.stub();
       await render(hbs`<div><OSS::Alert @closable={{true}} @onClose={{this.onClose}} /></div>`);
 
-      await click('.upf-alert .fx-col i');
+      assert.ok(this.onClose.notCalled);
+
+      await click('.upf-alert .upf-alert-close-button');
 
       assert.ok(this.onClose.calledOnce);
       assert.dom('.upf-alert').doesNotExist();

--- a/tests/integration/components/o-s-s/alert-test.ts
+++ b/tests/integration/components/o-s-s/alert-test.ts
@@ -42,22 +42,22 @@ module('Integration | Component | o-s-s/alert', function (hooks) {
   });
 
   module('@plain parameter', function () {
-    test('if true, the background-color is grey', async function (assert) {
+    test('if true, the background-color is colored', async function (assert) {
       await render(hbs`<OSS::Alert @plain={{true}} />`);
 
-      assert.dom('.upf-alert .main-container').hasClass('main-container--plain');
+      assert.dom('.upf-alert').hasClass('upf-alert--plain');
     });
 
-    test('if false, the background-color is white', async function (assert) {
+    test('if false, the background-color is gray', async function (assert) {
       await render(hbs`<OSS::Alert @plain={{false}} />`);
 
-      assert.dom('.upf-alert .main-container').hasNoClass('main-container--plain');
+      assert.dom('.upf-alert').hasNoClass('upf-alert--plain');
     });
 
-    test('if undefined, the background-color is grey', async function (assert) {
+    test('if undefined, the background-color is colored', async function (assert) {
       await render(hbs`<OSS::Alert />`);
 
-      assert.dom('.upf-alert .main-container').hasClass('main-container--plain');
+      assert.dom('.upf-alert').hasClass('upf-alert--plain');
     });
   });
 
@@ -66,10 +66,10 @@ module('Integration | Component | o-s-s/alert', function (hooks) {
       await render(hbs`<div><OSS::Alert @closable={{true}} /></div>`);
 
       assert.dom('.upf-alert').exists();
-      assert.dom('.upf-alert .main-container .fx-col i').exists();
-      assert.dom('.upf-alert .main-container .fx-col i').hasClass('fa-times');
+      assert.dom('.upf-alert .fx-col i').exists();
+      assert.dom('.upf-alert .fx-col i').hasClass('fa-times');
 
-      await click('.upf-alert .main-container .fx-col i');
+      await click('.upf-alert .fx-col i');
 
       assert.dom('.upf-alert').doesNotExist();
     });
@@ -78,20 +78,22 @@ module('Integration | Component | o-s-s/alert', function (hooks) {
       await render(hbs`<OSS::Alert @closable={{false}} />`);
 
       assert.dom('.upf-alert').exists();
-      assert.dom('.upf-alert .main-container .fx-col i').doesNotExist();
+      assert.dom('.upf-alert .fx-col i').doesNotExist();
     });
 
     test('if undefined, the cross icon is not displayed', async function (assert) {
       await render(hbs`<OSS::Alert />`);
 
       assert.dom('.upf-alert').exists();
-      assert.dom('.upf-alert .main-container .fx-col i').doesNotExist();
+      assert.dom('.upf-alert .fx-col i').doesNotExist();
     });
 
     test('clicking the cross icon also calls the onClose argument provided', async function (assert) {
       this.onClose = sinon.stub();
       await render(hbs`<div><OSS::Alert @closable={{true}} @onClose={{this.onClose}} /></div>`);
-      await click('.upf-alert .main-container .fx-col i');
+
+      await click('.upf-alert .fx-col i');
+
       assert.ok(this.onClose.calledOnce);
       assert.dom('.upf-alert').doesNotExist();
     });


### PR DESCRIPTION
### What does this PR do?

Updated `OSS::Alert` component to fit the new design.
Mainly removed colored indicator on the left, and modified colors.
Updated tests.

Related to: #[dra-5252](https://linear.app/upfluence/issue/DRA-5252/groundworkoss-components-update-alert-component)

### What are the observable changes?

<img width="1342" height="433" alt="Capture d’écran 2026-06-10 à 10 07 34" src="https://github.com/user-attachments/assets/30fa41e1-406b-423a-9b05-c744eae76245" />

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [x] Added/updated documentation with Figma design link. Don't forget to replace "design" by "file" in the URL. For example https://www.figma.com/file/example
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled
