### PR TITLE
OSS::ProgressBar: Add support for attention skin

### DIFF
--- a/addon/components/o-s-s/progress-bar.stories.js
+++ b/addon/components/o-s-s/progress-bar.stories.js
@@ -1,6 +1,6 @@
 import { hbs } from 'ember-cli-htmlbars';
 
-const ProgressBarSkins = ['warning', 'success', 'danger'];
+const ProgressBarSkins = ['attention', 'warning', 'success', 'danger'];
 const ProgressBarSizes = ['xs', 'sm'];
 
 export default {

--- a/addon/components/o-s-s/progress-bar.ts
+++ b/addon/components/o-s-s/progress-bar.ts
@@ -3,7 +3,7 @@ import { assert } from '@ember/debug';
 import { htmlSafe } from '@ember/template';
 import { helper } from '@ember/component/helper';
 
-export type ProgressBarSkins = 'pending' | 'warning' | 'success' | 'danger';
+export type ProgressBarSkins = 'pending' | 'attention' | 'warning' | 'success' | 'danger';
 
 type ProgressBarSizes = 'xs' | 'sm';
 

--- a/addon/components/o-s-s/progress-bar.ts
+++ b/addon/components/o-s-s/progress-bar.ts
@@ -3,7 +3,8 @@ import { assert } from '@ember/debug';
 import { htmlSafe } from '@ember/template';
 import { helper } from '@ember/component/helper';
 
-export type ProgressBarSkins = 'pending' | 'attention' | 'warning' | 'success' | 'danger';
+export const PROGRESS_BAR_SKINS = ['pending', 'attention', 'warning', 'success', 'danger'] as const;
+export type ProgressBarSkins = (typeof PROGRESS_BAR_SKINS)[number];
 
 type ProgressBarSizes = 'xs' | 'sm';
 

--- a/addon/components/o-s-s/progress-bar.ts
+++ b/addon/components/o-s-s/progress-bar.ts
@@ -5,6 +5,7 @@ import { helper } from '@ember/component/helper';
 
 export const PROGRESS_BAR_SKINS = ['pending', 'attention', 'warning', 'success', 'danger'] as const;
 export type ProgressBarSkins = (typeof PROGRESS_BAR_SKINS)[number];
+export type ProgressBarSkin = ProgressBarSkins;
 
 type ProgressBarSizes = 'xs' | 'sm';
 
@@ -37,7 +38,7 @@ export default class OSSProgressBar extends Component<OSSProgressBarArgs> {
     }
   }
 
-  getSegmentValue = helper((_, { skin }: { skin: ProgressBarSkins }): number => {
+  getSegmentValue = helper((_, { skin }: { skin: ProgressBarSkin }): number => {
     return this.skins[skin] ?? 0;
   });
 
@@ -46,7 +47,7 @@ export default class OSSProgressBar extends Component<OSSProgressBarArgs> {
     return htmlSafe(styles.join(';'));
   });
 
-  getSegmentClasses = helper((_, { skin }: { skin: ProgressBarSkins }): string => {
+  getSegmentClasses = helper((_, { skin }: { skin: ProgressBarSkin }): string => {
     const classes = ['oss-progress-bar__inner', `oss-progress-bar__inner--${skin}`, 'oss-progress-bar__inner--initial'];
     return classes.join(' ');
   });
@@ -55,8 +56,8 @@ export default class OSSProgressBar extends Component<OSSProgressBarArgs> {
     return !!this.args.skins && Object.keys(this.args.skins).length > 0;
   }
 
-  get progressSegments(): ProgressBarSkins[] {
-    return Object.keys(this.skins) as ProgressBarSkins[];
+  get progressSegments(): ProgressBarSkin[] {
+    return Object.keys(this.skins) as ProgressBarSkin[];
   }
 
   get computedStyles(): string {
@@ -85,7 +86,7 @@ export default class OSSProgressBar extends Component<OSSProgressBarArgs> {
     return this.hasSkins ? Object.values(this.skins).reduce((sum, v) => sum + v, 0) : this.args.value;
   }
 
-  private get skins(): Partial<Record<ProgressBarSkins, number>> {
+  private get skins(): Partial<Record<ProgressBarSkin, number>> {
     return this.args.skins!;
   }
 }

--- a/app/styles/molecules/progress-bar.less
+++ b/app/styles/molecules/progress-bar.less
@@ -1,3 +1,15 @@
+.generate-progress-bar-variant(@variant, @shade: 500) {
+  .oss-progress-bar__inner {
+    background-color: var(~'--color-@{variant}-@{shade}');
+  }
+
+  &.oss-progress-bar--colored-background {
+    .oss-progress-bar__outer {
+      background-color: var(~'--color-@{variant}-100');
+    }
+  }
+}
+
 .oss-progress-bar {
   display: flex;
   width: 100%;
@@ -34,40 +46,20 @@
     }
   }
 
-  &--warning {
-    .oss-progress-bar__inner {
-      background-color: var(--color-warning-500);
-    }
+  &--attention {
+    .generate-progress-bar-variant(yellow, 400);
+  }
 
-    &.oss-progress-bar--colored-background {
-      .oss-progress-bar__outer {
-        background-color: var(--color-warning-100);
-      }
-    }
+  &--warning {
+    .generate-progress-bar-variant(warning);
   }
 
   &--success {
-    .oss-progress-bar__inner {
-      background-color: var(--color-success-500);
-    }
-
-    &.oss-progress-bar--colored-background {
-      .oss-progress-bar__outer {
-        background-color: var(--color-success-100);
-      }
-    }
+    .generate-progress-bar-variant(success);
   }
 
   &--danger {
-    .oss-progress-bar__inner {
-      background-color: var(--color-error-500);
-    }
-
-    &.oss-progress-bar--colored-background {
-      .oss-progress-bar__outer {
-        background-color: var(--color-error-100);
-      }
-    }
+    .generate-progress-bar-variant(error);
   }
 
   &__label {

--- a/tests/integration/components/o-s-s/progress-bar-test.ts
+++ b/tests/integration/components/o-s-s/progress-bar-test.ts
@@ -111,6 +111,12 @@ module('Integration | Component | o-s-s/progress-bar', function (hooks) {
   });
 
   module('@skin arg behaviour', function () {
+    test('if the value is "attention", the progress bar has the correct class', async function (assert) {
+      await render(hbs`<OSS::ProgressBar @value={{this.checkedValue}} @skin="attention" />`);
+
+      assert.dom('.oss-progress-bar').hasClass('oss-progress-bar--attention');
+    });
+
     test('if the value is "warning", the progress bar has the correct class', async function (assert) {
       await render(hbs`<OSS::ProgressBar @value={{this.checkedValue}} @skin="warning" />`);
 

--- a/tests/integration/components/o-s-s/progress-bar-test.ts
+++ b/tests/integration/components/o-s-s/progress-bar-test.ts
@@ -2,6 +2,7 @@ import { hbs } from 'ember-cli-htmlbars';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render, setupOnerror } from '@ember/test-helpers';
+import { PROGRESS_BAR_SKINS } from '@upfluence/oss-components/components/o-s-s/progress-bar';
 
 module('Integration | Component | o-s-s/progress-bar', function (hooks) {
   setupRenderingTest(hooks);
@@ -111,28 +112,13 @@ module('Integration | Component | o-s-s/progress-bar', function (hooks) {
   });
 
   module('@skin arg behaviour', function () {
-    test('if the value is "attention", the progress bar has the correct class', async function (assert) {
-      await render(hbs`<OSS::ProgressBar @value={{this.checkedValue}} @skin="attention" />`);
+    PROGRESS_BAR_SKINS.forEach((skin) => {
+      test(`if the value is "${skin}", the progress bar has the correct class`, async function (assert) {
+        this.skin = skin;
+        await render(hbs`<OSS::ProgressBar @value={{this.checkedValue}} @skin={{this.skin}} />`);
 
-      assert.dom('.oss-progress-bar').hasClass('oss-progress-bar--attention');
-    });
-
-    test('if the value is "warning", the progress bar has the correct class', async function (assert) {
-      await render(hbs`<OSS::ProgressBar @value={{this.checkedValue}} @skin="warning" />`);
-
-      assert.dom('.oss-progress-bar').hasClass('oss-progress-bar--warning');
-    });
-
-    test('if the value is "success", the progress bar has the correct class', async function (assert) {
-      await render(hbs`<OSS::ProgressBar @value={{this.checkedValue}} @skin="success" />`);
-
-      assert.dom('.oss-progress-bar').hasClass('oss-progress-bar--success');
-    });
-
-    test('if the value is "danger", the progress bar has the correct class', async function (assert) {
-      await render(hbs`<OSS::ProgressBar @value={{this.checkedValue}} @skin="danger" />`);
-
-      assert.dom('.oss-progress-bar').hasClass('oss-progress-bar--danger');
+        assert.dom('.oss-progress-bar').hasClass(`oss-progress-bar--${skin}`);
+      });
     });
 
     test('if the value is unspecified, the progress bar has the correct class', async function (assert) {
@@ -163,22 +149,13 @@ module('Integration | Component | o-s-s/progress-bar', function (hooks) {
   });
 
   module('@secondarySkin arg behaviour', function () {
-    test('if the value is "warning", the progress bar has the correct secondary class', async function (assert) {
-      await render(hbs`<OSS::ProgressBar @value={{this.checkedValue}} @secondarySkin="warning" />`);
+    PROGRESS_BAR_SKINS.forEach((skin) => {
+      test(`if the value is "${skin}", the progress bar has the correct secondary class`, async function (assert) {
+        this.skin = skin;
+        await render(hbs`<OSS::ProgressBar @value={{this.checkedValue}} @secondarySkin={{this.skin}} />`);
 
-      assert.dom('.oss-progress-bar').hasClass('oss-progress-bar--secondary-skin--warning');
-    });
-
-    test('if the value is "success", the progress bar has the correct secondary class', async function (assert) {
-      await render(hbs`<OSS::ProgressBar @value={{this.checkedValue}} @secondarySkin="success" />`);
-
-      assert.dom('.oss-progress-bar').hasClass('oss-progress-bar--secondary-skin--success');
-    });
-
-    test('if the value is "danger", the progress bar has the correct secondary class', async function (assert) {
-      await render(hbs`<OSS::ProgressBar @value={{this.checkedValue}} @secondarySkin="danger" />`);
-
-      assert.dom('.oss-progress-bar').hasClass('oss-progress-bar--secondary-skin--danger');
+        assert.dom('.oss-progress-bar').hasClass(`oss-progress-bar--secondary-skin--${skin}`);
+      });
     });
 
     test('if the value is unspecified, the progress bar does not have a secondary class', async function (assert) {


### PR DESCRIPTION
### What does this PR do?

OSS::ProgressBar: Add support for attention skin

### What are the observable changes?

<img width="236" height="40" alt="Screenshot 2026-06-12 at 14 36 42" src="https://github.com/user-attachments/assets/adde0c55-8e0c-44eb-bae1-bbbfe2b081a5" />
<img width="267" height="48" alt="Screenshot 2026-06-12 at 14 36 58" src="https://github.com/user-attachments/assets/8ff0704a-8522-4e19-b057-6d04336c2a8a" />


<!-- This question could be adequate with multiple use cases, for example: -->

<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [x] Added/updated documentation with Figma design link. Don't forget to replace "design" by "file" in the URL. For example https://www.figma.com/file/example
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled
