### PR TITLE
Avoid class duplication for text-size-x

### DIFF
--- a/app/styles/shims/_all.less
+++ b/app/styles/shims/_all.less
@@ -113,18 +113,45 @@
 // Text Size Utility classes
 // --------------------------------------------------
 
-.text-size(@id, @size) {
-  .text-size-@{id} {
-    font-size: @size / @rem;
-  }
+.text-size-1 {
+  font-size: 8 / @rem;
 }
 
-@text-sizes: 8, 10, 12, 14, 16, 18, 24, 30, 36, 42;
+.text-size-2 {
+  font-size: 10 / @rem;
+}
 
-.for(@text-sizes, {
-  .text-size(@i, @value);
-});
-.text-size(normal, @font-size-body);
+.text-size-3 {
+  font-size: 12 / @rem;
+}
+
+.text-size-4 {
+  font-size: 14 / @rem;
+}
+
+.text-size-5 {
+  font-size: 16 / @rem;
+}
+
+.text-size-6 {
+  font-size: 18 / @rem;
+}
+
+.text-size-7 {
+  font-size: 24 / @rem;
+}
+
+.text-size-8 {
+  font-size: 30 / @rem;
+}
+
+.text-size-9 {
+  font-size: 36 / @rem;
+}
+
+.text-size-10 {
+  font-size: 42 / @rem;
+}
 
 @default-radius: 4px;
 @input-size-default: 36px;

--- a/app/styles/shims/_all.less
+++ b/app/styles/shims/_all.less
@@ -113,28 +113,17 @@
 // Text Size Utility classes
 // --------------------------------------------------
 
-@min_font_size: 8;
-@breaking_size: 18; // size after what the step is 6px
-
 .text-size(@id, @size) {
   .text-size-@{id} {
     font-size: @size / @rem;
   }
 }
 
-.text-size-loop(@counter, @size, @max) when (@counter < @max) {
-  & when (@size >= @breaking_size) {
-    .text-size-loop(@counter+1, @size+6, @max);
-  }
+@text-sizes: 8, 10, 12, 14, 16, 18, 24, 30, 36, 42;
 
-  & when (@size < @breaking_size) {
-    .text-size-loop(@counter+1, @size+2, @max);
-  }
-
-  .text-size(@counter+1, @size);
-}
-
-.text-size-loop(0, @min_font_size, 10);
+.for(@text-sizes, {
+  .text-size(@i, @value);
+});
 .text-size(normal, @font-size-body);
 
 @default-radius: 4px;


### PR DESCRIPTION
### What does this PR do?

Avoid class duplication for text-size-x

New compiled less file size:
2.1M packages/upfluence-web/dist/assets/upfluence-web.css 84 166 lignes (without fix)
1.9M packages/upfluence-web/dist/assets/upfluence-web.css 75 344 lignes (upfluence-web fix)
1.6M packages/upfluence-web/dist/assets/upfluence-web.css 51 276 lignes (upfluence-web + oss fixes)

### What are the observable changes?

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [ ] Added/updated tests
- [ ] Added/updated documentation with Figma design link. Don't forget to replace "design" by "file" in the URL. For example https://www.figma.com/file/example
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled
