### PR TITLE
Add `--font-family-smart` CSS variable for the New SmartConversation::Panel::JaiceApproval component

### DIFF
--- a/app/styles/atoms/smart-feedback.less
+++ b/app/styles/atoms/smart-feedback.less
@@ -20,7 +20,7 @@
   &__content {
     color: var(--color-primary-400);
     font-size: var(--font-size-md);
-    font-family: 'Reddit Sans', sans-serif;
+    font-family: var(--font-family-smart);
 
     &__text {
       display: inline-block;

--- a/app/styles/core/_typography.less
+++ b/app/styles/core/_typography.less
@@ -19,6 +19,7 @@
   --font-family-stack: Inter, 'Helvetica Neue', Helvetica, sans-serif;
   --font-family-mono: 'Roboto Mono', monospace;
   --font-family-fa: 'Font Awesome 7 Pro';
+  --font-family-smart: 'Reddit Sans', sans-serif;
 }
 
 .font-size-xs {

--- a/app/styles/core/_typography.less
+++ b/app/styles/core/_typography.less
@@ -65,3 +65,7 @@
 .font-family-mono {
   font-family: var(--font-family-mono);
 }
+
+.font-family-smart {
+  font-family: var(--font-family-smart);
+}


### PR DESCRIPTION
### What does this PR do?

Refactors the smart feedback font family to use a CSS variable instead of a hardcoded value.

Related to: [#DRA-5427](https://linear.app/upfluence/issue/DRA-5427/ember-identity-new-smartconversationpaneljaiceapproval-component)

### What are the observable changes?

No visual change expected — the smart feedback component now references the shared typography CSS variable for its font family.

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [ ] Added/updated tests
- [ ] Added/updated documentation with Figma design link. Don't forget to replace "design" by "file" in the URL. For example https://www.figma.com/file/example
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled
