### PR TITLE
Fix calculated height to avoid extra scrollbar for OSS::Select

### DIFF
--- a/app/styles/molecules/select.less
+++ b/app/styles/molecules/select.less
@@ -83,7 +83,9 @@
     overflow: hidden;
 
     .upf-infinite-select__items-container {
-      --input-height-and-padding-and-gap: calc(var(--spacing-px-36) + var(--spacing-px-12) + var(--spacing-px-12));
+      --input-height-and-padding-and-gap: calc(
+        var(--spacing-px-36) + var(--spacing-px-12) + var(--spacing-px-9) + var(--spacing-px-9) + var(--spacing-px-6)
+      );
       max-height: calc(var(--floating-max-height) - var(--input-height-and-padding-and-gap));
     }
   }
@@ -92,7 +94,9 @@
     overflow: hidden;
 
     .upf-infinite-select__items-container {
-      --button-height-and-padding-and-gap: calc(var(--spacing-px-24) + var(--spacing-px-12) + var(--spacing-px-12));
+      --button-height-and-padding-and-gap: calc(
+        var(--spacing-px-24) + var(--spacing-px-12) + var(--spacing-px-12) + var(--spacing-px-12)
+      );
       max-height: calc(var(--floating-max-height) - var(--button-height-and-padding-and-gap));
     }
   }
@@ -102,7 +106,8 @@
 
     .upf-infinite-select__items-container {
       --input-height-and-button-height-and-padding-and-gap: calc(
-        var(--spacing-px-36) + var(--spacing-px-24) + var(--spacing-px-12) + var(--spacing-px-12) + var(--spacing-px-12)
+        var(--spacing-px-36) + var(--spacing-px-24) + var(--spacing-px-12) + var(--spacing-px-12) +
+          var(--spacing-px-12) + var(--spacing-px-12) + var(--spacing-px-3)
       );
       max-height: calc(var(--floating-max-height) - var(--input-height-and-button-height-and-padding-and-gap));
     }
@@ -112,7 +117,7 @@
     padding: 0;
 
     .item-wrapper {
-      padding: var(--spacing-px-6) var(--spacing-px-6);
+      padding: var(--spacing-px-6) var(--spacing-px-12);
       border-radius: var(--border-radius-sm);
     }
   }


### PR DESCRIPTION
### What does this PR do?

Fixes the max-height calculation of the items list in `OSS::Select`. The CSS variables used to subtract the input/button height, padding, and gap from the floating panel height were underestimating the real spacing, so the items container ended up taller than the available space.  This created a second, inner scrollbar on top of the floating panel's own scrollbar.

### What are the observable changes?

<img width="702" height="633" alt="Screenshot from 2026-07-20 11-28-40" src="https://github.com/user-attachments/assets/4fbafeef-e543-4de4-8077-5c7eb210ffcf" />
<img width="702" height="633" alt="Screenshot from 2026-07-20 11-24-51" src="https://github.com/user-attachments/assets/35df8796-dc9d-4fa6-8b08-7be07d1bc468" />
<img width="702" height="633" alt="Screenshot from 2026-07-20 11-24-47" src="https://github.com/user-attachments/assets/b1d82f30-c442-4949-9545-9c4d5507cc35" />
<img width="702" height="633" alt="Screenshot from 2026-07-20 11-22-23" src="https://github.com/user-attachments/assets/476e1a75-24c6-427c-b763-aaebb88e9a23" />

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [ ] Added/updated tests
- [ ] Added/updated documentation with Figma design link. Don't forget to replace "design" by "file" in the URL. For example https://www.figma.com/file/example
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled
