### PR TITLE
Add cleanup and deduplication logic to modifier/required-input

### DIFF
--- a/addon/modifiers/required-input.ts
+++ b/addon/modifiers/required-input.ts
@@ -1,4 +1,5 @@
-import Modifier from 'ember-modifier';
+import Modifier, { type ArgsFor } from 'ember-modifier';
+import { registerDestructor } from '@ember/destroyable';
 
 interface RequiredInputSignature {
   Element: HTMLElement;
@@ -6,14 +7,28 @@ interface RequiredInputSignature {
 
 export default class RegisterFormField extends Modifier<RequiredInputSignature> {
   declare targetElement: HTMLElement;
+  markerElement?: HTMLSpanElement;
+
+  constructor(owner: unknown, args: ArgsFor<RequiredInputSignature>) {
+    super(owner, args);
+    registerDestructor(this, () => this.cleanup());
+  }
 
   modify(element: HTMLElement): void {
     this.targetElement = element;
 
+    this.cleanup();
+
     const span = document.createElement('span');
     span.classList.add('font-color-error-500');
     span.textContent = '*';
+    this.markerElement = span;
 
     element.appendChild(span);
+  }
+
+  private cleanup(): void {
+    this.markerElement?.remove();
+    this.markerElement = undefined;
   }
 }

--- a/tests/integration/helpers/required-input-test.ts
+++ b/tests/integration/helpers/required-input-test.ts
@@ -47,4 +47,21 @@ module('Integration | Helper | required-input', function (hooks) {
     assert.dom('label span.existing.font-color-error-500').doesNotExist();
     assert.dom('label span.font-color-error-500').exists();
   });
+
+  test('it keeps one asterisk when the modifier is removed and re-added in the same render cycle', async function (assert) {
+    this.isRequired = true;
+
+    await render(hbs`
+      <label {{(if this.isRequired (modifier "required-input"))}}>Conditionally required</label>
+    `);
+    assert.dom('label span.font-color-error-500').exists({ count: 1 });
+
+    this.set('isRequired', false);
+    await settled();
+    assert.dom('label span.font-color-error-500').doesNotExist();
+
+    this.set('isRequired', true);
+    await settled();
+    assert.dom('label span.font-color-error-500').exists({ count: 1 });
+  });
 });


### PR DESCRIPTION
### What does this PR do?

We had unstable behavior when the modifier was removed and added again on the same label.

The modifier now cleans up when when destroyed and removes its old * before adding a new one

Related to: #vel-6847

### What are the observable changes?

https://github.com/user-attachments/assets/52b20906-7155-46a7-9933-ac21ebd94bc5

<!-- This question could be adequate with multiple use cases, for example: -->

<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [ ] Added/updated documentation with Figma design link. Don't forget to replace "design" by "file" in the URL. For example https://www.figma.com/file/example
- [ ] Migrated touched components to Glimmer Components
- [ ] Properly labeled
