### PR TITLE
[OSS::Avatar] Add new skin argument

### DIFF
--- a/addon/components/o-s-s/avatar.stories.js
+++ b/addon/components/o-s-s/avatar.stories.js
@@ -55,7 +55,7 @@ export default {
       description: 'Adjust the skin of the avatar component',
       table: {
         type: {
-          summary: SkinType.join('|')
+          summary: SkinType.join(' | ')
         },
         defaultValue: { summary: undefined }
       },

--- a/addon/components/o-s-s/avatar.stories.js
+++ b/addon/components/o-s-s/avatar.stories.js
@@ -1,7 +1,16 @@
 import { hbs } from 'ember-cli-htmlbars';
 
 const SizeTypes = ['xs', 'sm', 'md', 'lg'];
-const SkinType = ['danger', 'xtd-orange', 'xtd-violet-light', 'xtd-violet', 'xtd-lime', 'primary', 'primary-light', 'xtd-cyan'];
+const SkinType = [
+  'danger',
+  'xtd-orange',
+  'xtd-violet-light',
+  'xtd-violet',
+  'xtd-lime',
+  'primary',
+  'primary-light',
+  'xtd-cyan'
+];
 
 export default {
   title: 'Components/OSS::Avatar',

--- a/addon/components/o-s-s/avatar.stories.js
+++ b/addon/components/o-s-s/avatar.stories.js
@@ -1,6 +1,7 @@
 import { hbs } from 'ember-cli-htmlbars';
 
 const SizeTypes = ['xs', 'sm', 'md', 'lg'];
+const SkinType = ['danger', 'xtd-orange', 'xtd-violet-light', 'xtd-violet', 'xtd-lime', 'primary', 'primary-light', 'xtd-cyan'];
 
 export default {
   title: 'Components/OSS::Avatar',
@@ -41,6 +42,17 @@ export default {
         type: 'text'
       }
     },
+    skin: {
+      description: 'Adjust the skin of the avatar component',
+      table: {
+        type: {
+          summary: SkinType.join('|')
+        },
+        defaultValue: { summary: undefined }
+      },
+      options: [undefined, ...SkinType],
+      control: { type: 'select' }
+    },
     loading: {
       description: 'Display loading state',
       table: {
@@ -70,12 +82,13 @@ const defaultArgs = {
   size: 'md',
   image: undefined,
   initials: undefined,
-  loading: false
+  loading: false,
+  skin: undefined
 };
 
 const Template = (args) => ({
   template: hbs`
-    <OSS::Avatar @image={{this.image}} @initials={{this.initials}} @size={{this.size}} @loading={{this.loading}} />
+    <OSS::Avatar @image={{this.image}} @initials={{this.initials}} @size={{this.size}} @loading={{this.loading}} @skin={{this.skin}}/>
   `,
   context: args
 });

--- a/addon/components/o-s-s/avatar.ts
+++ b/addon/components/o-s-s/avatar.ts
@@ -12,11 +12,25 @@ export const SizeDefinition: SizeDefType = {
   lg: 'upf-avatar--lg'
 };
 
+export const AvatarSkins = [
+  'danger',
+  'xtd-orange',
+  'xtd-violet-light',
+  'xtd-violet',
+  'xtd-lime',
+  'primary',
+  'primary-light',
+  'xtd-cyan'
+] as const;
+
+export type SkinType = (typeof AvatarSkins)[number];
+
 export interface OSSAvatarArgs {
   image?: string;
   initials?: string;
   size?: SizeType;
   loading?: boolean;
+  skin?: SkinType;
 }
 
 export const DEFAULT_IMAGE_URL: string = '/@upfluence/oss-components/assets/images/avatar-placeholder.svg';
@@ -42,6 +56,14 @@ export default class OSSAvatar extends Component<OSSAvatarArgs> {
 
     if (this.args.loading) {
       classes = classes.concat('upf-avatar--loading ');
+    }
+
+    if (this.args.skin) {
+      assert(
+        `[component][OSS::Avatar] Unknown skin. Available skins are: ${AvatarSkins.join(', ')}`,
+        AvatarSkins.includes(this.args.skin as SkinType)
+      );
+      classes = classes.concat(`upf-avatar--skin upf-avatar--skin-${this.args.skin} `);
     }
 
     assert(

--- a/addon/components/o-s-s/avatar.ts
+++ b/addon/components/o-s-s/avatar.ts
@@ -51,11 +51,11 @@ export default class OSSAvatar extends Component<OSSAvatarArgs> {
   }
 
   get computedClass(): string {
-    let classes = 'upf-avatar ';
+    const classes = ['upf-avatar'];
     const size: SizeType = this.args.size || 'md';
 
     if (this.args.loading) {
-      classes = classes.concat('upf-avatar--loading ');
+      classes.push('upf-avatar--loading');
     }
 
     if (this.args.skin) {
@@ -63,7 +63,7 @@ export default class OSSAvatar extends Component<OSSAvatarArgs> {
         `[component][OSS::Avatar] Unknown skin. Available skins are: ${AvatarSkins.join(', ')}`,
         AvatarSkins.includes(this.args.skin as SkinType)
       );
-      classes = classes.concat(`upf-avatar--skin upf-avatar--skin-${this.args.skin} `);
+      classes.push('upf-avatar--skin', `upf-avatar--skin-${this.args.skin}`);
     }
 
     assert(
@@ -71,7 +71,8 @@ export default class OSSAvatar extends Component<OSSAvatarArgs> {
       Object.keys(SizeDefinition).includes(size as SizeType)
     );
 
-    return classes.concat(SizeDefinition[size as SizeType]);
+    classes.push(SizeDefinition[size as SizeType])
+    return classes.join(' ')
   }
 
   @action

--- a/app/styles/atoms/avatar.less
+++ b/app/styles/atoms/avatar.less
@@ -70,4 +70,41 @@
     .upf-skeleton-effect;
     .border-radius-round;
   }
+
+  &--skin {
+    color: var(--color-white);
+    border: 1px solid var(--color-white);
+
+    &-danger {
+      background-color: var(--color-error-400);
+    }
+
+    &-xtd-orange {
+      background-color: var(--color-orange-400);
+    }
+
+    &-xtd-violet-light {
+      background-color: var(--color-violet-400);
+    }
+
+    &-xtd-violet {
+      background-color: var(--color-violet-500);
+    }
+
+    &-xtd-lime {
+      background-color: var(--color-lime-500);
+    }
+
+    &-primary {
+      background-color: var(--color-primary-400);
+    }
+
+    &-primary-light {
+      background-color: var(--color-primary-300);
+    }
+
+    &-xtd-cyan {
+      background-color: var(--color-cyan-500);
+    }
+  }
 }

--- a/tests/dummy/app/templates/visual.hbs
+++ b/tests/dummy/app/templates/visual.hbs
@@ -385,6 +385,15 @@
       <OSS::Avatar @size="sm" />
       <OSS::Avatar @size="md" />
       <OSS::Avatar @size="lg" />
+      <OSS::Avatar @size="lg" @initials="U"/>
+      <OSS::Avatar @size="lg" @skin="danger" @initials="P"/>
+      <OSS::Avatar @size="lg" @skin="xtd-orange" @initials="F"/>
+      <OSS::Avatar @size="lg" @skin="xtd-violet-light" @initials="L"/>
+      <OSS::Avatar @size="lg" @skin="xtd-violet" @initials="U"/>
+      <OSS::Avatar @size="lg" @skin="xtd-lime" @initials="E"/>
+      <OSS::Avatar @size="lg" @skin="primary" @initials="N"/>
+      <OSS::Avatar @size="lg" @skin="primary-light" @initials="C"/>
+      <OSS::Avatar @size="lg" @skin="xtd-cyan" @initials="E"/>
     </div>
   </div>
 

--- a/tests/integration/components/o-s-s/avatar-test.ts
+++ b/tests/integration/components/o-s-s/avatar-test.ts
@@ -3,7 +3,7 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { find, render, setupOnerror, waitFor, waitUntil } from '@ember/test-helpers';
 
-import { SizeDefinition, AvatarSkins,  DEFAULT_IMAGE_URL } from '@upfluence/oss-components/components/o-s-s/avatar';
+import { SizeDefinition, AvatarSkins, DEFAULT_IMAGE_URL } from '@upfluence/oss-components/components/o-s-s/avatar';
 
 module('Integration | Component | o-s-s/avatar', function (hooks) {
   setupRenderingTest(hooks);

--- a/tests/integration/components/o-s-s/avatar-test.ts
+++ b/tests/integration/components/o-s-s/avatar-test.ts
@@ -3,7 +3,7 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { find, render, setupOnerror, waitFor, waitUntil } from '@ember/test-helpers';
 
-import { SizeDefinition, DEFAULT_IMAGE_URL } from '@upfluence/oss-components/components/o-s-s/avatar';
+import { SizeDefinition, AvatarSkins,  DEFAULT_IMAGE_URL } from '@upfluence/oss-components/components/o-s-s/avatar';
 
 module('Integration | Component | o-s-s/avatar', function (hooks) {
   setupRenderingTest(hooks);
@@ -63,6 +63,25 @@ module('Integration | Component | o-s-s/avatar', function (hooks) {
     });
   });
 
+  module('Skins', function () {
+    test('it sets no skin class when skin is not provided', async function (assert) {
+      await render(hbs`<OSS::Avatar />`);
+
+      assert.dom('.upf-avatar').exists();
+      assert.dom('.upf-avatar').hasNoClass(`upf-avatar--skin`);
+    });
+
+    AvatarSkins.forEach((skin) => {
+      test(`it sets the right class when using a supported skin: ${skin}`, async function (assert) {
+        this.skin = skin;
+        await render(hbs`<OSS::Avatar @skin={{this.skin}} />`);
+
+        assert.dom('.upf-avatar').hasClass(`upf-avatar--skin`).hasClass(`upf-avatar--skin-${skin}`);
+      })
+    })
+
+  })
+
   module('Sizes', function () {
     test('it sets the right default class when size is not provided', async function (assert) {
       await render(hbs`<OSS::Avatar />`);
@@ -99,6 +118,17 @@ module('Integration | Component | o-s-s/avatar', function (hooks) {
       });
 
       await render(hbs`<OSS::Avatar @size="test" />`);
+    });
+
+    test('it throws an error if the wrong skin argument is passed', async function (assert: Assert) {
+      setupOnerror((err: Error) => {
+        assert.equal(
+          err.message,
+          `Assertion Failed: [component][OSS::Avatar] Unknown skin. Available skins are: ${AvatarSkins.join(', ')}`
+        );
+      });
+
+      await render(hbs`<OSS::Avatar @skin="test" />`);
     });
 
     test('it displays the initials when both initials and image are provided and the image fails to load', async function (assert) {


### PR DESCRIPTION
### What does this PR do?

<!-- A brief description of the context of this pull request and its purpose. -->

Related to: #[PYX-195](https://linear.app/upfluence/issue/PYX-195/oss-components-update-ossavatar-to-handle-skin)

### What are the observable changes?
Allow passing different skin for `OSS::Avatar`
<img width="895" height="109" alt="Capture d’écran 2026-07-24 à 14 45 43" src="https://github.com/user-attachments/assets/4459e1d6-959a-4c73-8a69-dbcf824817d6" />

<!-- This question could be adequate with multiple use cases, for example: -->

<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [x] Added/updated documentation with Figma design link. Don't forget to replace "design" by "file" in the URL. For example https://www.figma.com/file/example
- [ ] Migrated touched components to Glimmer Components
- [x] Properly labeled
