### PR TITLE
OSS::Stats::Banner

### DIFF
--- a/addon/components/o-s-s/stats/banner.hbs
+++ b/addon/components/o-s-s/stats/banner.hbs
@@ -1,0 +1,63 @@
+<div class="oss-stats-banner fx-col fx-gap-px-12" ...attributes>
+  <div class="oss-stats-banner__header fx-row fx-gap-px-12 fx-malign-space-between">
+    <div class="oss-stats-banner__header_content fx-row fx-gap-px-12 fx-malign-center fx-xalign-center">
+      {{#if (and this.loading this.hasBadgeContent)}}
+        <OSS::Skeleton @height={{36}} @width={{36}} class="oss-stats-banner__skeleton--badge" />
+      {{else if this.hasBadgeContent}}
+        <OSS::Badge
+          @icon={{@badgeIcon}}
+          @image={{@badgeImage}}
+          @text={{@badgeText}}
+          @skin={{@badgeSkin}}
+          @size={{@badgeSize}}
+          @plain={{@badgePlain}}
+        />
+      {{/if}}
+      <div class="oss-stats-banner__content">
+        {{#if (has-block "content")}}
+          {{yield to="content"}}
+        {{else if (and this.loading @title)}}
+          <OSS::Skeleton @height={{18}} @width={{420}} class="oss-stats-banner__skeleton--title" />
+        {{else}}
+          <div class="header-section fx-row fx-gap-px-8 fx-malign-space-between">
+            <span class="font-color-gray-600">{{@title}}</span>
+          </div>
+        {{/if}}
+      </div>
+    </div>
+
+    <div>
+      {{#if (and this.loading (has-block "extra-badges"))}}
+        <div class="fx-row fx-gap-px-6">
+          <OSS::Skeleton @height={{28}} @width={{28}} class="oss-stats-banner__skeleton--extra-badge" />
+          <OSS::Skeleton @height={{28}} @width={{28}} class="oss-stats-banner__skeleton--extra-badge" />
+        </div>
+      {{else if (has-block "extra-badges")}}
+        {{yield to="extra-badges"}}
+      {{/if}}
+    </div>
+  </div>
+  <div class="oss-stats-banner__bottom_content fx-row fx-gap-px-12 fx-malign-space-between">
+    <div class="oss-stats-banner__stat fx-row fx-gap-px-4">
+      {{#if (and this.loading @statValue)}}
+        <OSS::Skeleton @height={{18}} @width={{90}} class="oss-stats-banner__skeleton--stat-value" />
+      {{else}}
+        <span class="font-color-gray-600">{{@statValue}}</span>
+
+      {{/if}}
+
+      {{#if (and this.loading @statExtraInfo)}}
+        <OSS::Skeleton @height={{16}} @width={{120}} class="oss-stats-banner__skeleton--stat-extra" />
+      {{else if @statExtraInfo}}
+        <span class="font-color-gray-400">{{@statExtraInfo}}</span>
+      {{/if}}
+    </div>
+    {{#if (and this.loading (has-block "cta"))}}
+      <OSS::Skeleton @height={{32}} @width={{120}} class="oss-stats-banner__skeleton--cta" />
+    {{else if (has-block "cta")}}
+      <div class="oss-stats-banner__cta">
+        {{yield to="cta"}}
+      </div>
+    {{/if}}
+  </div>
+</div>

--- a/addon/components/o-s-s/stats/banner.hbs
+++ b/addon/components/o-s-s/stats/banner.hbs
@@ -1,10 +1,17 @@
 <div class="oss-stats-banner fx-col fx-gap-px-12" ...attributes>
   <div class="oss-stats-banner__header fx-row fx-gap-px-12 fx-malign-space-between">
-    <div class="oss-stats-banner__header_content fx-row fx-gap-px-12 fx-malign-center fx-xalign-center">
-      {{#if (and this.loading (has-block "badges"))}}
-        <OSS::Skeleton @height={{36}} @width={{36}} class="oss-stats-banner__skeleton--badge" />
-      {{else if (has-block "badges")}}
-        {{yield to="badges"}}
+    <div class="oss-stats-banner__header_content fx-row fx-gap-px-9 fx-malign-center fx-xalign-center">
+      {{#if @badge}}
+        {{#if @extraIcon}}
+          <OSS::Icon @icon={{@extraIcon.icon}} style={{if @extraIcon.color (concat "color:" @extraIcon.color)}} />
+        {{/if}}
+        <OSS::Badge
+          @icon={{@badge.icon}}
+          @image={{@badge.image}}
+          @text={{@badge.text}}
+          @skin={{@badge.skin}}
+          @size="sm"
+        />
       {{/if}}
       <div class="oss-stats-banner__content">
         {{#if (has-block "content")}}
@@ -12,8 +19,16 @@
         {{else if (and this.loading @title)}}
           <OSS::Skeleton @height={{18}} @width={{420}} class="oss-stats-banner__skeleton--title" />
         {{else}}
-          <div class="header-section fx-row fx-gap-px-8 fx-malign-space-between">
-            <span class="font-color-gray-600">{{@title}}</span>
+          <div class="header-section fx-row fx-gap-px-8 fx-malign-space-between fx-xalign-center">
+            <span class="font-color-gray-600 font-weight-semibold">{{@title}}</span>
+            {{#if @titleInfo}}
+              <span {{enable-tooltip title=@titleInfo placement="top"}}>
+                <OSS::Icon @icon="fa-circle-info" />
+              </span>
+            {{/if}}
+            {{#if (has-block "dropdown")}}
+              {{yield to="dropdown"}}
+            {{/if}}
           </div>
         {{/if}}
       </div>
@@ -31,18 +46,25 @@
     </div>
   </div>
   <div class="oss-stats-banner__bottom_content fx-row fx-gap-px-12 fx-malign-space-between">
-    <div class="oss-stats-banner__stat fx-row fx-gap-px-4">
+    <div class="oss-stats-banner__stat fx-row fx-gap-px-6 fx-xalign-center">
       {{#if (and this.loading @statValue)}}
         <OSS::Skeleton @height={{18}} @width={{90}} class="oss-stats-banner__skeleton--stat-value" />
       {{else}}
-        <span class="font-color-gray-600">{{@statValue}}</span>
-
+        <span class="font-color-gray-900 font-weight-semibold font-size-h3">{{@statValue}}</span>
       {{/if}}
-
       {{#if (and this.loading @statExtraInfo)}}
         <OSS::Skeleton @height={{16}} @width={{120}} class="oss-stats-banner__skeleton--stat-extra" />
       {{else if @statExtraInfo}}
-        <span class="font-color-gray-400">{{@statExtraInfo}}</span>
+        <span class="font-color-gray-500">{{@statExtraInfo}}</span>
+      {{/if}}
+
+      {{#if @extraInfoTag}}
+        <OSS::Tag
+          @label={{@extraInfoTag.label}}
+          @skin={{@extraInfoTag.skin}}
+          @icon={{@extraInfoTag.icon}}
+          @plain={{@extraInfoTag.plain}}
+        />
       {{/if}}
     </div>
     {{#if (and this.loading (has-block "cta"))}}

--- a/addon/components/o-s-s/stats/banner.hbs
+++ b/addon/components/o-s-s/stats/banner.hbs
@@ -1,66 +1,74 @@
 <div class="oss-stats-banner fx-gap-px-12" ...attributes>
   <div class="oss-stats-banner__header fx-malign-space-between">
     <div class="oss-stats-banner__header_content fx-row fx-gap-px-9 fx-malign-center fx-xalign-center">
-      {{#if @badge}}
-        {{#if @extraIcon}}
-          <OSS::Icon @icon={{@extraIcon.icon}} style={{if @extraIcon.color (concat "color:" @extraIcon.color)}} />
+      {{#if @badgeConfig}}
+        {{#if @extraIconConfig}}
+          <OSS::Icon
+            @icon={{@extraIconConfig.icon}}
+            style={{if @extraIconConfig.color (concat "color:" @extraIconConfig.color)}}
+          />
         {{/if}}
         <OSS::Badge
-          @icon={{@badge.icon}}
-          @image={{@badge.image}}
-          @text={{@badge.text}}
-          @skin={{@badge.skin}}
+          @icon={{@badgeConfig.icon}}
+          @image={{@badgeConfig.image}}
+          @text={{@badgeConfig.text}}
+          @skin={{@badgeConfig.skin}}
           @size="sm"
         />
       {{/if}}
       <div class="oss-stats-banner__content">
         {{#if (has-block "content")}}
           {{yield to="content"}}
-        {{else if (and this.loading @title)}}
+        {{else if (and @loading @title)}}
           <OSS::Skeleton @height={{18}} @width="100%" class="oss-stats-banner__skeleton--title" />
         {{else}}
-          <div class="header-section fx-row fx-gap-px-8 fx-malign-space-between fx-xalign-center">
-            <span class="font-color-gray-600 font-weight-semibold">{{@title}}</span>
-            {{#if @titleInfo}}
-              <span {{enable-tooltip title=@titleInfo placement="top"}}>
-                <OSS::Icon @icon="fa-circle-info" />
-              </span>
-            {{/if}}
-            {{#if (has-block "dropdown")}}
-              {{yield to="dropdown"}}
-            {{/if}}
+          <div class="oss-stats-banner__title-row fx-row fx-gap-px-8 fx-xalign-center">
+            <span
+              class="oss-stats-banner__title text-ellipsis font-color-gray-600 font-weight-semibold"
+              {{enable-tooltip title=@title placement="top" displayOnlyOnOverflow=true}}
+            >{{@title}}</span>
+            <div class="oss-stats-banner__title-actions fx-row fx-gap-px-8 fx-xalign-center">
+              {{#if @titleInfoCircle}}
+                <span {{enable-tooltip title=@titleInfoCircle placement="top"}}>
+                  <OSS::Icon @icon="fa-info-circle" class="font-color-gray-400" />
+                </span>
+              {{/if}}
+              {{#if (has-block "dropdown")}}
+                {{yield to="dropdown"}}
+              {{/if}}
+            </div>
           </div>
         {{/if}}
       </div>
     </div>
 
-    <div>
-      {{#if (has-block "extra-badges")}}
+    {{#if (and (has-block "extra-badges") (not @loading))}}
+      <div class="oss-stats-banner__extra-badges fx-row fx-gap-px-3 fx-xalign-center">
         {{yield to="extra-badges"}}
-      {{/if}}
-    </div>
+      </div>
+    {{/if}}
   </div>
   <div class="oss-stats-banner__bottom_content fx-row fx-gap-px-12 fx-malign-space-between">
     <div class="oss-stats-banner__stat fx-row fx-gap-px-6 fx-xalign-center">
-      {{#if (and this.loading @statValue)}}
-        <OSS::Skeleton @height={{18}} @width={{90}} class="oss-stats-banner__skeleton--stat-value" />
+      {{#if (and @loading @statValue)}}
+        <OSS::Skeleton @height={{18}} @width={{210}} class="oss-stats-banner__skeleton--stat-value" />
       {{else}}
         <span class="font-color-gray-900 font-weight-semibold font-size-h3">{{@statValue}}</span>
-      {{/if}}
-      {{#if @statExtraInfo}}
-        <span class="font-color-gray-500">{{@statExtraInfo}}</span>
-      {{/if}}
+        {{#if @statExtraInfo}}
+          <span class="font-color-gray-500">{{@statExtraInfo}}</span>
+        {{/if}}
 
-      {{#if @extraInfoTag}}
-        <OSS::Tag
-          @label={{@extraInfoTag.label}}
-          @skin={{@extraInfoTag.skin}}
-          @icon={{@extraInfoTag.icon}}
-          @plain={{@extraInfoTag.plain}}
-        />
+        {{#if @extraInfoTagConfig}}
+          <OSS::Tag
+            @label={{@extraInfoTagConfig.label}}
+            @skin={{@extraInfoTagConfig.skin}}
+            @icon={{@extraInfoTagConfig.icon}}
+            @plain={{@extraInfoTagConfig.plain}}
+          />
+        {{/if}}
       {{/if}}
     </div>
-    {{#if (has-block "cta")}}
+    {{#if (and (has-block "cta") (not @loading))}}
       <div class="oss-stats-banner__cta">
         {{yield to="cta"}}
       </div>

--- a/addon/components/o-s-s/stats/banner.hbs
+++ b/addon/components/o-s-s/stats/banner.hbs
@@ -17,9 +17,7 @@
         />
       {{/if}}
       <div class="oss-stats-banner__content">
-        {{#if (has-block "content")}}
-          {{yield to="content"}}
-        {{else if (and @loading @title)}}
+        {{#if (and @loading @title)}}
           <OSS::Skeleton @height={{18}} @width="100%" class="oss-stats-banner__skeleton--title" />
         {{else}}
           <div class="oss-stats-banner__title-row fx-row fx-gap-px-8 fx-xalign-center">

--- a/addon/components/o-s-s/stats/banner.hbs
+++ b/addon/components/o-s-s/stats/banner.hbs
@@ -2,22 +2,24 @@
   <div class="oss-stats-banner__header" data-control-name="stats-banner-header">
     <div class="oss-stats-banner__header_content" data-control-name="stats-banner-header-content">
       {{#if @badge}}
-        {{#if @badge.extraIcon}}
-          <OSS::Icon
-            @icon={{@badge.extraIcon.icon}}
-            style={{if @badge.extraIcon.color (concat "color:" @badge.extraIcon.color)}}
+        <div class="oss-stats-banner__badge" data-control-name="stats-banner-badge">
+          {{#if @badge.extraIcon}}
+            <OSS::Icon
+              @icon={{@badge.extraIcon.icon}}
+              style={{if @badge.extraIcon.color (concat "color:" @badge.extraIcon.color)}}
+            />
+          {{/if}}
+          <OSS::Badge
+            @icon={{@badge.icon}}
+            @image={{@badge.image}}
+            @text={{@badge.text}}
+            @skin={{@badge.skin}}
+            @size="sm"
           />
-        {{/if}}
-        <OSS::Badge
-          @icon={{@badge.icon}}
-          @image={{@badge.image}}
-          @text={{@badge.text}}
-          @skin={{@badge.skin}}
-          @size="sm"
-        />
+        </div>
       {{/if}}
 
-      <div class="oss-stats-banner__content">
+      <div class="oss-stats-banner__content" data-control-name="stats-banner-content">
         {{#if @loading}}
           <OSS::Skeleton @height={{12}} @width={{150}} class="oss-stats-banner__skeleton--title" />
         {{else}}
@@ -61,20 +63,19 @@
         <OSS::Skeleton @height={{30}} @width={{150}} class="oss-stats-banner__skeleton--stat-value" />
       {{else}}
         <div class="oss-stats-banner__stat-main" data-control-name="stats-banner-stat-main">
-          <div class="oss-stats-banner__stat-main-content">
-            <span class="font-color-gray-900 font-weight-semibold font-size-h3">{{@statValue}}</span>
+          <div class="oss-stats-banner__stat-main-content" data-control-name="stats-banner-stat-main-content">
+            {{#if @statValue}}
+              <span class="font-color-gray-900 font-weight-semibold font-size-h3">{{@statValue.label}}</span>
 
-            {{#if @statExtraInfo}}
-              <span class="oss-stats-banner__stat-extra font-color-gray-500">{{@statExtraInfo}}</span>
-            {{/if}}
+              {{#if @statValue.suffix}}
+                <span class="oss-stats-banner__stat-extra font-color-gray-500">{{@statValue.suffix}}</span>
+              {{/if}}
 
-            {{#if @extraInfoTagConfig}}
-              <OSS::Tag
-                @label={{@extraInfoTagConfig.label}}
-                @skin={{@extraInfoTagConfig.skin}}
-                @icon={{@extraInfoTagConfig.icon}}
-                @plain={{@extraInfoTagConfig.plain}}
-              />
+              {{#if @statValue.tags}}
+                {{#each @statValue.tags as |tag|}}
+                  <OSS::Tag @label={{tag.label}} @skin={{tag.skin}} @icon={{tag.icon}} @plain={{tag.plain}} />
+                {{/each}}
+              {{/if}}
             {{/if}}
           </div>
 
@@ -87,4 +88,5 @@
       {{/if}}
     </div>
   </div>
+
 </div>

--- a/addon/components/o-s-s/stats/banner.hbs
+++ b/addon/components/o-s-s/stats/banner.hbs
@@ -24,7 +24,9 @@
             <span
               class="oss-stats-banner__title text-ellipsis font-color-gray-600 font-weight-semibold"
               {{enable-tooltip title=@title placement="top" displayOnlyOnOverflow=true}}
-            >{{@title}}</span>
+            >
+              {{@title}}
+            </span>
             <div class="oss-stats-banner__title-actions fx-row fx-gap-px-8 fx-xalign-center">
               {{#if @titleInfoCircle}}
                 <span {{enable-tooltip title=@titleInfoCircle placement="top"}}>

--- a/addon/components/o-s-s/stats/banner.hbs
+++ b/addon/components/o-s-s/stats/banner.hbs
@@ -18,7 +18,7 @@
       {{/if}}
       <div class="oss-stats-banner__content">
         {{#if @loading}}
-          <OSS::Skeleton @height={{18}} @width="100%" class="oss-stats-banner__skeleton--title" />
+          <OSS::Skeleton @height={{12}} @width={{150}} class="oss-stats-banner__skeleton--title" />
         {{else}}
           <div class="oss-stats-banner__title-row fx-row fx-gap-px-8 fx-xalign-center">
             <span
@@ -49,7 +49,7 @@
   <div class="oss-stats-banner__bottom_content fx-row fx-gap-px-12 fx-malign-space-between">
     <div class="oss-stats-banner__stat fx-row fx-gap-px-6 fx-xalign-center">
       {{#if @loading}}
-        <OSS::Skeleton @height={{18}} @width={{210}} class="oss-stats-banner__skeleton--stat-value" />
+        <OSS::Skeleton @height={{30}} @width={{150}} class="oss-stats-banner__skeleton--stat-value" />
       {{else}}
         <span class="font-color-gray-900 font-weight-semibold font-size-h3">{{@statValue}}</span>
         {{#if @statExtraInfo}}

--- a/addon/components/o-s-s/stats/banner.hbs
+++ b/addon/components/o-s-s/stats/banner.hbs
@@ -1,5 +1,5 @@
-<div class="oss-stats-banner fx-col fx-gap-px-12" ...attributes>
-  <div class="oss-stats-banner__header fx-row fx-gap-px-12 fx-malign-space-between">
+<div class="oss-stats-banner fx-gap-px-12" ...attributes>
+  <div class="oss-stats-banner__header fx-malign-space-between">
     <div class="oss-stats-banner__header_content fx-row fx-gap-px-9 fx-malign-center fx-xalign-center">
       {{#if @badge}}
         {{#if @extraIcon}}
@@ -17,7 +17,7 @@
         {{#if (has-block "content")}}
           {{yield to="content"}}
         {{else if (and this.loading @title)}}
-          <OSS::Skeleton @height={{18}} @width={{420}} class="oss-stats-banner__skeleton--title" />
+          <OSS::Skeleton @height={{18}} @width="100%" class="oss-stats-banner__skeleton--title" />
         {{else}}
           <div class="header-section fx-row fx-gap-px-8 fx-malign-space-between fx-xalign-center">
             <span class="font-color-gray-600 font-weight-semibold">{{@title}}</span>
@@ -35,12 +35,7 @@
     </div>
 
     <div>
-      {{#if (and this.loading (has-block "extra-badges"))}}
-        <div class="fx-row fx-gap-px-6">
-          <OSS::Skeleton @height={{28}} @width={{28}} class="oss-stats-banner__skeleton--extra-badge" />
-          <OSS::Skeleton @height={{28}} @width={{28}} class="oss-stats-banner__skeleton--extra-badge" />
-        </div>
-      {{else if (has-block "extra-badges")}}
+      {{#if (has-block "extra-badges")}}
         {{yield to="extra-badges"}}
       {{/if}}
     </div>
@@ -52,9 +47,7 @@
       {{else}}
         <span class="font-color-gray-900 font-weight-semibold font-size-h3">{{@statValue}}</span>
       {{/if}}
-      {{#if (and this.loading @statExtraInfo)}}
-        <OSS::Skeleton @height={{16}} @width={{120}} class="oss-stats-banner__skeleton--stat-extra" />
-      {{else if @statExtraInfo}}
+      {{#if @statExtraInfo}}
         <span class="font-color-gray-500">{{@statExtraInfo}}</span>
       {{/if}}
 
@@ -67,9 +60,7 @@
         />
       {{/if}}
     </div>
-    {{#if (and this.loading (has-block "cta"))}}
-      <OSS::Skeleton @height={{32}} @width={{120}} class="oss-stats-banner__skeleton--cta" />
-    {{else if (has-block "cta")}}
+    {{#if (has-block "cta")}}
       <div class="oss-stats-banner__cta">
         {{yield to="cta"}}
       </div>

--- a/addon/components/o-s-s/stats/banner.hbs
+++ b/addon/components/o-s-s/stats/banner.hbs
@@ -17,7 +17,7 @@
         />
       {{/if}}
       <div class="oss-stats-banner__content">
-        {{#if (and @loading @title)}}
+        {{#if @loading}}
           <OSS::Skeleton @height={{18}} @width="100%" class="oss-stats-banner__skeleton--title" />
         {{else}}
           <div class="oss-stats-banner__title-row fx-row fx-gap-px-8 fx-xalign-center">
@@ -48,7 +48,7 @@
   </div>
   <div class="oss-stats-banner__bottom_content fx-row fx-gap-px-12 fx-malign-space-between">
     <div class="oss-stats-banner__stat fx-row fx-gap-px-6 fx-xalign-center">
-      {{#if (and @loading @statValue)}}
+      {{#if @loading}}
         <OSS::Skeleton @height={{18}} @width={{210}} class="oss-stats-banner__skeleton--stat-value" />
       {{else}}
         <span class="font-color-gray-900 font-weight-semibold font-size-h3">{{@statValue}}</span>

--- a/addon/components/o-s-s/stats/banner.hbs
+++ b/addon/components/o-s-s/stats/banner.hbs
@@ -1,40 +1,46 @@
-<div class="oss-stats-banner fx-gap-px-12" ...attributes>
-  <div class="oss-stats-banner__header fx-malign-space-between">
-    <div class="oss-stats-banner__header_content fx-row fx-gap-px-9 fx-malign-center fx-xalign-center">
-      {{#if @badgeConfig}}
-        {{#if @extraIconConfig}}
+<div class="oss-stats-banner" data-control-name="oss-stats-banner" ...attributes>
+  <div class="oss-stats-banner__header" data-control-name="stats-banner-header">
+    <div class="oss-stats-banner__header_content" data-control-name="stats-banner-header-content">
+      {{#if @badge}}
+        {{#if @badge.extraIcon}}
           <OSS::Icon
-            @icon={{@extraIconConfig.icon}}
-            style={{if @extraIconConfig.color (concat "color:" @extraIconConfig.color)}}
+            @icon={{@badge.extraIcon.icon}}
+            style={{if @badge.extraIcon.color (concat "color:" @badge.extraIcon.color)}}
           />
         {{/if}}
         <OSS::Badge
-          @icon={{@badgeConfig.icon}}
-          @image={{@badgeConfig.image}}
-          @text={{@badgeConfig.text}}
-          @skin={{@badgeConfig.skin}}
+          @icon={{@badge.icon}}
+          @image={{@badge.image}}
+          @text={{@badge.text}}
+          @skin={{@badge.skin}}
           @size="sm"
         />
       {{/if}}
+
       <div class="oss-stats-banner__content">
         {{#if @loading}}
           <OSS::Skeleton @height={{12}} @width={{150}} class="oss-stats-banner__skeleton--title" />
         {{else}}
-          <div class="oss-stats-banner__title-row fx-row fx-gap-px-8 fx-xalign-center">
+          <div class="oss-stats-banner__title-row" data-control-name="stats-banner-title-row">
             <span
               class="oss-stats-banner__title text-ellipsis font-color-gray-600 font-weight-semibold"
-              {{enable-tooltip title=@title placement="top" displayOnlyOnOverflow=true}}
+              {{enable-tooltip title=@titleConfig.text placement="top" displayOnlyOnOverflow=true}}
             >
-              {{@title}}
+              {{@titleConfig.text}}
             </span>
-            <div class="oss-stats-banner__title-actions fx-row fx-gap-px-8 fx-xalign-center">
-              {{#if @titleInfoCircle}}
-                <span {{enable-tooltip title=@titleInfoCircle placement="top"}}>
+
+            <div class="oss-stats-banner__title-actions" data-control-name="stats-banner-title-actions">
+              {{#if @titleConfig.infoCircle}}
+                <span
+                  data-control-name="stats-banner-title-info-circle"
+                  {{enable-tooltip title=@titleConfig.infoCircle placement="top"}}
+                >
                   <OSS::Icon @icon="fa-info-circle" class="font-color-gray-400" />
                 </span>
               {{/if}}
-              {{#if (has-block "dropdown")}}
-                {{yield to="dropdown"}}
+
+              {{#if (has-block "title-suffix")}}
+                {{yield to="title-suffix"}}
               {{/if}}
             </div>
           </div>
@@ -43,35 +49,42 @@
     </div>
 
     {{#if (and (has-block "extra-badges") (not @loading))}}
-      <div class="oss-stats-banner__extra-badges fx-row fx-gap-px-3 fx-xalign-center">
+      <div class="oss-stats-banner__extra-badges" data-control-name="stats-banner-extra-badges">
         {{yield to="extra-badges"}}
       </div>
     {{/if}}
   </div>
-  <div class="oss-stats-banner__bottom_content fx-row fx-gap-px-12 fx-malign-space-between">
-    <div class="oss-stats-banner__stat fx-row fx-gap-px-6 fx-xalign-center">
+
+  <div class="oss-stats-banner__bottom_content" data-control-name="stats-banner-bottom-content">
+    <div class="oss-stats-banner__stat" data-control-name="stats-banner-stat">
       {{#if @loading}}
         <OSS::Skeleton @height={{30}} @width={{150}} class="oss-stats-banner__skeleton--stat-value" />
       {{else}}
-        <span class="font-color-gray-900 font-weight-semibold font-size-h3">{{@statValue}}</span>
-        {{#if @statExtraInfo}}
-          <span class="font-color-gray-500">{{@statExtraInfo}}</span>
-        {{/if}}
+        <div class="oss-stats-banner__stat-main" data-control-name="stats-banner-stat-main">
+          <div class="oss-stats-banner__stat-main-content">
+            <span class="font-color-gray-900 font-weight-semibold font-size-h3">{{@statValue}}</span>
 
-        {{#if @extraInfoTagConfig}}
-          <OSS::Tag
-            @label={{@extraInfoTagConfig.label}}
-            @skin={{@extraInfoTagConfig.skin}}
-            @icon={{@extraInfoTagConfig.icon}}
-            @plain={{@extraInfoTagConfig.plain}}
-          />
-        {{/if}}
+            {{#if @statExtraInfo}}
+              <span class="oss-stats-banner__stat-extra font-color-gray-500">{{@statExtraInfo}}</span>
+            {{/if}}
+
+            {{#if @extraInfoTagConfig}}
+              <OSS::Tag
+                @label={{@extraInfoTagConfig.label}}
+                @skin={{@extraInfoTagConfig.skin}}
+                @icon={{@extraInfoTagConfig.icon}}
+                @plain={{@extraInfoTagConfig.plain}}
+              />
+            {{/if}}
+          </div>
+
+          {{#if (has-block "cta")}}
+            <div class="oss-stats-banner__cta" data-control-name="stats-banner-cta">
+              {{yield to="cta"}}
+            </div>
+          {{/if}}
+        </div>
       {{/if}}
     </div>
-    {{#if (and (has-block "cta") (not @loading))}}
-      <div class="oss-stats-banner__cta">
-        {{yield to="cta"}}
-      </div>
-    {{/if}}
   </div>
 </div>

--- a/addon/components/o-s-s/stats/banner.hbs
+++ b/addon/components/o-s-s/stats/banner.hbs
@@ -1,17 +1,10 @@
 <div class="oss-stats-banner fx-col fx-gap-px-12" ...attributes>
   <div class="oss-stats-banner__header fx-row fx-gap-px-12 fx-malign-space-between">
     <div class="oss-stats-banner__header_content fx-row fx-gap-px-12 fx-malign-center fx-xalign-center">
-      {{#if (and this.loading this.hasBadgeContent)}}
+      {{#if (and this.loading (has-block "badges"))}}
         <OSS::Skeleton @height={{36}} @width={{36}} class="oss-stats-banner__skeleton--badge" />
-      {{else if this.hasBadgeContent}}
-        <OSS::Badge
-          @icon={{@badgeIcon}}
-          @image={{@badgeImage}}
-          @text={{@badgeText}}
-          @skin={{@badgeSkin}}
-          @size={{@badgeSize}}
-          @plain={{@badgePlain}}
-        />
+      {{else if (has-block "badges")}}
+        {{yield to="badges"}}
       {{/if}}
       <div class="oss-stats-banner__content">
         {{#if (has-block "content")}}

--- a/addon/components/o-s-s/stats/banner.stories.js
+++ b/addon/components/o-s-s/stats/banner.stories.js
@@ -31,7 +31,7 @@ export default {
     docs: {
       description: {
         component:
-          'A stats banner supporting badge, extra icon, title with tooltip, inline tag, and named blocks for content, extra-badges, dropdown and CTA.'
+          'A stats banner supporting badge, extra icon, title with tooltip, inline tag, and named blocks for extra-badges, dropdown and CTA.'
       },
       iframeHeight: 260
     }
@@ -47,10 +47,6 @@ const Template = (args) => ({
   template: hbs`
     <div style="max-width: 1200px;">
       <OSS::Stats::Banner @title={{this.title}} @badgeConfig={{hash icon="fa-check" skin="success"}}>
-        <:content>
-          <span class="font-color-gray-600">{{this.title}}</span>
-        </:content>
-
         <div class="oss-stats-banner__card">
           <div class="oss-stats-banner__card-label">Total paid amount</div>
           <div class="oss-stats-banner__card-value">$12,493,343.22</div>
@@ -92,10 +88,6 @@ const WithCTA = (args) => ({
   template: hbs`
     <div style="max-width: 1200px;">
       <OSS::Stats::Banner @title={{this.title}} @badgeConfig={{hash icon="fa-check" skin="success"}}>
-        <:content>
-          <span class="font-color-gray-600">{{this.title}}</span>
-        </:content>
-
         <:cta>
           <OSS::Button @label="Export" @icon="fa-download" @size="sm" @skin="secondary" />
         </:cta>

--- a/addon/components/o-s-s/stats/banner.stories.js
+++ b/addon/components/o-s-s/stats/banner.stories.js
@@ -4,34 +4,50 @@ export default {
   title: 'Components/OSS::Stats::Banner',
   component: 'stats-banner',
   argTypes: {
-    title: {
-      description: 'Header text displayed in the banner',
-      table: { type: { summary: 'string' }, defaultValue: { summary: 'undefined' } },
-      control: { type: 'text' }
+    titleConfig: {
+      description: 'Header object: { text, infoCircle }',
+      table: { type: { summary: 'StatsBannerTitle' }, defaultValue: { summary: 'undefined' } }
     },
-    titleInfoCircle: {
-      description: 'When provided, displays an info-circle icon next to the title with this text as tooltip',
-      table: { type: { summary: 'string' }, defaultValue: { summary: 'undefined' } },
-      control: { type: 'text' }
+    badge: {
+      description: 'Badge object passed to OSS::Badge, supports extraIcon: { icon, color }',
+      table: { type: { summary: 'StatsBannerBadge' }, defaultValue: { summary: 'undefined' } }
     },
-    badgeConfig: {
-      description: 'Badge config passed down to OSS::Badge (icon, image, text, skin, plain, size)',
-      table: { type: { summary: 'StatsBannerBadgeConfig' }, defaultValue: { summary: 'undefined' } }
+    statValue: {
+      description: 'Main KPI value displayed in the stat row',
+      control: 'text',
+      table: { type: { summary: 'string | number' }, defaultValue: { summary: 'undefined' } }
     },
-    extraIconConfig: {
-      description: 'Icon displayed to the left of the badge. Accepts { icon, color }',
-      table: { type: { summary: 'StatsBannerExtraIconConfig' }, defaultValue: { summary: 'undefined' } }
+    statExtraInfo: {
+      description: 'Secondary information shown next to the main KPI value',
+      control: 'text',
+      table: { type: { summary: 'string' }, defaultValue: { summary: 'undefined' } }
     },
     extraInfoTagConfig: {
       description: 'Tag displayed next to the stat value. Accepts OSS::Tag config (label, skin, icon, plain)',
       table: { type: { summary: 'StatsBannerExtraInfoTagConfig' }, defaultValue: { summary: 'undefined' } }
+    },
+    loading: {
+      description: 'Displays skeletons in place of title and KPI values',
+      control: 'boolean',
+      table: { type: { summary: 'boolean' }, defaultValue: { summary: 'false' } }
+    },
+    ctaPrimaryLabel: {
+      description: 'Primary CTA label used by stories that render a CTA block',
+      control: 'text',
+      table: { category: 'Story controls' }
+    },
+    ctaSecondaryLabel: {
+      description: 'Secondary CTA label used by stories that render multiple CTA actions',
+      control: 'text',
+      table: { category: 'Story controls' }
     }
   },
   parameters: {
+    layout: 'padded',
     docs: {
       description: {
         component:
-          'A stats banner supporting badge, extra icon, title with tooltip, inline tag, and named blocks for extra-badges, dropdown and CTA.'
+          'A stats banner supporting title and badge objects, inline KPI info, and named blocks for extra-badges, title-suffix, and CTA actions.'
       },
       iframeHeight: 260
     }
@@ -39,113 +55,284 @@ export default {
 };
 
 const defaultArgs = {
-  title:
-    'Use statistics to surface a key KPI or summary at-a-glance. Apply locale-aware number formatting, keep significant digits reasonable, and always show units and currency.'
+  titleConfig: {
+    text: 'Very long stats banner title that should truncate with ellipsis when the available width becomes too small',
+    infoCircle: 'This is a helpful description of the stat'
+  },
+  badge: {
+    icon: 'fa-check',
+    skin: 'success',
+    extraIcon: {
+      icon: 'fa-star',
+      color: '#f59e0b'
+    }
+  },
+  statValue: '123,456',
+  statExtraInfo: 'Extra info',
+  extraInfoTagConfig: {
+    label: 'New',
+    skin: 'success',
+    icon: 'fa-sparkles',
+    plain: false
+  },
+  loading: false,
+  ctaPrimaryLabel: 'CTA',
+  ctaSecondaryLabel: 'Export'
 };
 
-const Template = (args) => ({
+const PlaygroundTemplate = (args) => ({
   template: hbs`
-    <div style="max-width: 1200px;">
-      <OSS::Stats::Banner @title={{this.title}} @badgeConfig={{hash icon="fa-check" skin="success"}}>
-        <div class="oss-stats-banner__card">
-          <div class="oss-stats-banner__card-label">Total paid amount</div>
-          <div class="oss-stats-banner__card-value">$12,493,343.22</div>
-          <div class="oss-stats-banner__card-meta">supplementary info</div>
-        </div>
-
-        <div class="oss-stats-banner__card">
-          <div class="oss-stats-banner__card-label">Commission to authorize</div>
-          <div class="oss-stats-banner__card-value">$5,920</div>
-          <div class="oss-stats-banner__card-meta">supplementary info</div>
-        </div>
-
-        <div class="oss-stats-banner__card">
-          <div class="oss-stats-banner__card-label">Pending amount</div>
-          <div class="oss-stats-banner__card-value">$594,032</div>
-          <div class="oss-stats-banner__card-meta">supplementary info</div>
-        </div>
-
-        <div class="oss-stats-banner__card oss-stats-banner__card--highlighted">
-          <div class="fx-row fx-malign-space-between fx-xalign-center fx-gap-px-6">
-            <OSS::Tag @label="Ready-to-pay commission" @icon="fa-circle-check" @skin="secondary" @size="xs" />
-
-            <OSS::Button @label="Pay" @size="xs" @icon="fa-money-bill" />
-          </div>
-          <div class="oss-stats-banner__card-value">$5,920</div>
-          <div class="oss-stats-banner__card-meta">supplementary info</div>
-
-          <div class="margin-top-px-6">
-            <OSS::Tag @label="5 payments" @skin="secondary" @size="xs" />
-          </div>
-        </div>
-      </OSS::Stats::Banner>
-    </div>
-  `,
-  context: args
-});
-
-const WithCTA = (args) => ({
-  template: hbs`
-    <div style="max-width: 1200px;">
-      <OSS::Stats::Banner @title={{this.title}} @badgeConfig={{hash icon="fa-check" skin="success"}}>
-        <:cta>
-          <OSS::Button @label="Export" @icon="fa-download" @size="sm" @skin="secondary" />
-        </:cta>
-
-        <div class="oss-stats-banner__card">
-          <div class="oss-stats-banner__card-label">Total paid amount</div>
-          <div class="oss-stats-banner__card-value">$12,493,343.22</div>
-          <div class="oss-stats-banner__card-meta">supplementary info</div>
-        </div>
-      </OSS::Stats::Banner>
-    </div>
-  `,
-  context: args
-});
-
-export const Default = Template.bind({});
-Default.args = defaultArgs;
-
-export const UsageWithHeaderCTA = WithCTA.bind({});
-UsageWithHeaderCTA.args = defaultArgs;
-
-const WithExtraIconAndTitleInfoCircle = (args) => ({
-  template: hbs`
-    <div style="max-width: 1200px;">
+    <div style="width: 1200px; max-width: 100%;">
       <OSS::Stats::Banner
-        @title={{this.title}}
-        @titleInfoCircle="This KPI represents total paid amounts across all campaigns"
-        @badgeConfig={{hash icon="fa-check" skin="success"}}
-        @extraIconConfig={{hash icon="fa-star" color="#f59e0b"}}
-        @statValue="$12,493"
-        @statExtraInfo="supplementary info"
-        @extraInfoTagConfig={{hash label="New" skin="success" icon="fa-sparkles"}}
-      />
-    </div>
-  `,
-  context: args
-});
-
-export const WithExtraFeaturesAndTitleInfoCircle = WithExtraIconAndTitleInfoCircle.bind({});
-WithExtraFeaturesAndTitleInfoCircle.args = defaultArgs;
-
-const WithDropdown = (args) => ({
-  template: hbs`
-    <div style="max-width: 1200px;">
-      <OSS::Stats::Banner @title={{this.title}} @badgeConfig={{hash icon="fa-check" skin="success"}} @statValue="$12,493">
-        <:dropdown>
+        @titleConfig={{this.titleConfig}}
+        @badge={{this.badge}}
+        @statValue={{this.statValue}}
+        @statExtraInfo={{this.statExtraInfo}}
+        @extraInfoTagConfig={{this.extraInfoTagConfig}}
+        @loading={{this.loading}}
+      >
+        <:title-suffix>
           <OSS::ButtonDropdown @icon="fa-caret-down" @hideArrow={{true}} @square={{true}} @size="sm">
             <:items>
               <div class="oss-button-dropdown__item">Option A</div>
               <div class="oss-button-dropdown__item">Option B</div>
             </:items>
           </OSS::ButtonDropdown>
-        </:dropdown>
+        </:title-suffix>
+
+        <:extra-badges>
+          <OSS::Badge @text="2x" @size="lg" />
+        </:extra-badges>
+
+        <:cta>
+          <div class="fx-row fx-gap-px-6">
+            <OSS::Button @skin="primary" @label={{this.ctaPrimaryLabel}} @icon="fas fa-box-open" @size="md" />
+            <OSS::Button @skin="secondary" @label={{this.ctaSecondaryLabel}} @icon="fa-download" @size="md" />
+          </div>
+        </:cta>
       </OSS::Stats::Banner>
     </div>
   `,
   context: args
 });
 
-export const UsageWithDropdown = WithDropdown.bind({});
-UsageWithDropdown.args = defaultArgs;
+const ThreeUpTemplate = (args) => ({
+  template: hbs`
+    <div style="width: 1200px; max-width: 100%;">
+      <div class="fx-row fx-gap-px-12" style="flex-wrap: wrap;">
+        <OSS::Stats::Banner
+          class="fx-1"
+          @badge={{this.badge}}
+          @titleConfig={{this.titleConfig}}
+          @statValue={{this.statValue}}
+          @statExtraInfo={{this.statExtraInfo}}
+        >
+          <:cta>
+            <OSS::Button @skin="secondary" @label={{this.ctaSecondaryLabel}} @size="sm" />
+          </:cta>
+        </OSS::Stats::Banner>
+
+        <OSS::Stats::Banner
+          class="fx-1"
+          @badge={{hash icon="fa-star" skin="primary"}}
+          @titleConfig={{hash text="Commissions"}}
+          @statValue="$5,920"
+          @statExtraInfo="to authorize"
+        >
+          <:cta>
+            <OSS::Button @skin="primary" @label="Pay" @size="sm" />
+          </:cta>
+        </OSS::Stats::Banner>
+
+        <OSS::Stats::Banner
+          class="fx-1"
+                @badge={{hash icon="fa-bolt" skin="alert"}}
+          @titleConfig={{hash text="Pending"}}
+          @statValue="$594,032"
+          @statExtraInfo="across campaigns"
+        >
+          <:cta>
+            <OSS::Button @skin="secondary" @label="Open" @size="sm" />
+          </:cta>
+        </OSS::Stats::Banner>
+      </div>
+    </div>
+  `,
+  context: args
+});
+
+const DefaultTemplate = (args) => ({
+  template: hbs`
+    <div style="width: 1200px; max-width: 100%;">
+      <OSS::Stats::Banner
+        @titleConfig={{this.titleConfig}}
+        @badge={{this.badge}}
+        @statValue={{this.statValue}}
+        @statExtraInfo={{this.statExtraInfo}}
+        @extraInfoTagConfig={{this.extraInfoTagConfig}}
+      >
+
+        <:cta>
+          <div class="fx-row fx-gap-px-6">
+            <OSS::Button @label={{this.ctaSecondaryLabel}} @icon="fa-download" @size="sm" @skin="secondary" />
+            <OSS::Button @label={{this.ctaPrimaryLabel}} @icon="fa-money-bill" @size="sm" @skin="primary" />
+          </div>
+        </:cta>
+      </OSS::Stats::Banner>
+    </div>
+  `,
+  context: args
+});
+
+const LoadingTemplate = (args) => ({
+  template: hbs`
+    <div style="width: 1200px; max-width: 100%;">
+      <OSS::Stats::Banner
+        @loading={{true}}
+        @titleConfig={{this.titleConfig}}
+        @badge={{this.badge}}
+        @statValue={{this.statValue}}
+        @statExtraInfo={{this.statExtraInfo}}
+      >
+        <:extra-badges>
+          <OSS::Badge @text="2x" @size="lg" />
+        </:extra-badges>
+      </OSS::Stats::Banner>
+    </div>
+  `,
+  context: args
+});
+
+const MinimalTemplate = (args) => ({
+  template: hbs`
+    <div style="width: 1200px; max-width: 100%;">
+      <OSS::Stats::Banner
+        @titleConfig={{this.titleConfig}}
+        @badge={{this.badge}}
+        @statValue={{this.statValue}}
+        @statExtraInfo={{this.statExtraInfo}}
+      />
+    </div>
+  `,
+  context: args
+});
+
+const TitleSuffixOnlyTemplate = (args) => ({
+  template: hbs`
+    <div style="width: 1200px; max-width: 100%;">
+      <OSS::Stats::Banner
+        @titleConfig={{this.titleConfig}}
+        @badge={{this.badge}}
+        @statValue={{this.statValue}}
+        @statExtraInfo={{this.statExtraInfo}}
+      >
+        <:title-suffix>
+          <OSS::ButtonDropdown @icon="fa-caret-down" @hideArrow={{true}} @square={{true}} @size="sm">
+            <:items>
+              <div class="oss-button-dropdown__item">Last 7 days</div>
+              <div class="oss-button-dropdown__item">Last 30 days</div>
+              <div class="oss-button-dropdown__item">Last quarter</div>
+            </:items>
+          </OSS::ButtonDropdown>
+        </:title-suffix>
+      </OSS::Stats::Banner>
+    </div>
+  `,
+  context: args
+});
+
+export const Default = PlaygroundTemplate.bind({});
+Default.args = defaultArgs;
+
+export const ThreeUpCompact = ThreeUpTemplate.bind({});
+ThreeUpCompact.args = {
+  ...defaultArgs,
+  titleConfig: {
+    text: 'Revenue',
+    infoCircle: 'Revenue generated during the selected period'
+  },
+  badge: {
+    icon: 'fa-check',
+    skin: 'success'
+  },
+  statValue: '$12,493',
+  statExtraInfo: 'vs last month',
+  ctaSecondaryLabel: 'Details'
+};
+
+export const WithDefaultCards = DefaultTemplate.bind({});
+WithDefaultCards.args = {
+  ...defaultArgs,
+  titleConfig: {
+    text: 'Commissions overview',
+    infoCircle: 'Summary of pending and approved commissions'
+  },
+  badge: {
+    icon: 'fa-star',
+    skin: 'primary',
+    extraIcon: {
+      icon: 'fa-bolt',
+      color: '#fb923c'
+    }
+  },
+  statValue: '$5,920',
+  statExtraInfo: 'to authorize',
+  extraInfoTagConfig: {
+    label: 'Urgent',
+    skin: 'warning',
+    icon: 'fa-triangle-exclamation',
+    plain: false
+  },
+  ctaPrimaryLabel: 'Pay',
+  ctaSecondaryLabel: 'Export CSV'
+};
+
+export const Loading = LoadingTemplate.bind({});
+Loading.args = {
+  ...defaultArgs,
+  titleConfig: {
+    text: 'Loading stats banner title',
+    infoCircle: 'Helpful title information'
+  },
+  badge: {
+    icon: 'fa-hourglass-half',
+    skin: 'alert'
+  },
+  statValue: '999,999',
+  statExtraInfo: 'Fetching latest data',
+  loading: true
+};
+
+export const Minimal = MinimalTemplate.bind({});
+Minimal.args = {
+  ...defaultArgs,
+  titleConfig: {
+    text: 'Active campaigns',
+    infoCircle: undefined
+  },
+  badge: undefined,
+  statValue: '42',
+  statExtraInfo: 'currently running',
+  extraInfoTagConfig: undefined
+};
+
+export const WithTitleSuffixOnly = TitleSuffixOnlyTemplate.bind({});
+WithTitleSuffixOnly.args = {
+  ...defaultArgs,
+  titleConfig: {
+    text: 'Paid amount',
+    infoCircle: 'Compare period-over-period in the dropdown'
+  },
+  badge: {
+    icon: 'fa-chart-line',
+    skin: 'primary'
+  },
+  statValue: '$87,240',
+  statExtraInfo: 'last 30 days',
+  extraInfoTagConfig: {
+    label: '+12%',
+    skin: 'success',
+    icon: 'fa-arrow-up',
+    plain: false
+  }
+};

--- a/addon/components/o-s-s/stats/banner.stories.js
+++ b/addon/components/o-s-s/stats/banner.stories.js
@@ -13,33 +13,13 @@ export default {
         defaultValue: { summary: 'undefined' }
       },
       control: { type: 'text' }
-    },
-    badgeIcon: {
-      description: 'Font Awesome icon forwarded to OSS::Badge (@icon)',
-      table: {
-        type: {
-          summary: 'string'
-        },
-        defaultValue: { summary: 'fa-check' }
-      },
-      control: { type: 'text' }
-    },
-    badgeSkin: {
-      description: 'Badge skin forwarded to OSS::Badge (@skin)',
-      table: {
-        type: {
-          summary: 'primary|success|alert|error|xtd-cyan|xtd-orange|xtd-yellow|xtd-lime|xtd-blue|xtd-violet|xtd-smart'
-        },
-        defaultValue: { summary: 'success' }
-      },
-      control: { type: 'text' }
     }
   },
   parameters: {
     docs: {
       description: {
         component:
-          'A block-first stats banner. Badge props are forwarded to OSS::Badge, while content and CTA remain named blocks; provide stat cards in the default block.'
+          'A block-first stats banner. Badges, content and CTA are all provided through named blocks; provide stat cards in the default block.'
       },
       iframeHeight: 260
     }
@@ -48,15 +28,17 @@ export default {
 
 const defaultArgs = {
   title:
-    'Use statistics to surface a key KPI or summary at-a-glance. Apply locale-aware number formatting, keep significant digits reasonable, and always show units and currency.',
-  badgeIcon: 'fa-check',
-  badgeSkin: 'success'
+    'Use statistics to surface a key KPI or summary at-a-glance. Apply locale-aware number formatting, keep significant digits reasonable, and always show units and currency.'
 };
 
 const Template = (args) => ({
   template: hbs`
     <div style="max-width: 1200px;">
-      <OSS::Stats::Banner @title={{this.title}} @badgeIcon={{this.badgeIcon}} @badgeSkin={{this.badgeSkin}}>
+      <OSS::Stats::Banner @title={{this.title}}>
+
+        <:badges>
+          <OSS::Badge @icon="fa-check" @skin="success" />
+        </:badges>
 
         <:content>
           <span class="font-color-gray-600">{{this.title}}</span>
@@ -102,7 +84,11 @@ const Template = (args) => ({
 const WithCTA = (args) => ({
   template: hbs`
     <div style="max-width: 1200px;">
-      <OSS::Stats::Banner @title={{this.title}} @badgeIcon={{this.badgeIcon}} @badgeSkin={{this.badgeSkin}}>
+      <OSS::Stats::Banner @title={{this.title}}>
+        <:badges>
+          <OSS::Badge @icon="fa-check" @skin="success" />
+        </:badges>
+
         <:content>
           <span class="font-color-gray-600">{{this.title}}</span>
         </:content>

--- a/addon/components/o-s-s/stats/banner.stories.js
+++ b/addon/components/o-s-s/stats/banner.stories.js
@@ -6,20 +6,32 @@ export default {
   argTypes: {
     title: {
       description: 'Header text displayed in the banner',
-      table: {
-        type: {
-          summary: 'string'
-        },
-        defaultValue: { summary: 'undefined' }
-      },
+      table: { type: { summary: 'string' }, defaultValue: { summary: 'undefined' } },
       control: { type: 'text' }
+    },
+    titleInfo: {
+      description: 'When provided, displays an info-circle icon next to the title with this text as tooltip',
+      table: { type: { summary: 'string' }, defaultValue: { summary: 'undefined' } },
+      control: { type: 'text' }
+    },
+    badge: {
+      description: 'Badge config passed down to OSS::Badge (icon, image, text, skin, plain, size)',
+      table: { type: { summary: 'StatsBannerBadge' }, defaultValue: { summary: 'undefined' } }
+    },
+    extraIcon: {
+      description: 'Icon displayed to the left of the badge. Accepts { icon, color }',
+      table: { type: { summary: 'StatsBannerExtraIcon' }, defaultValue: { summary: 'undefined' } }
+    },
+    extraInfoTag: {
+      description: 'Tag displayed next to the stat value. Accepts OSS::Tag config (label, skin, icon, plain)',
+      table: { type: { summary: 'StatsBannerExtraInfoTag' }, defaultValue: { summary: 'undefined' } }
     }
   },
   parameters: {
     docs: {
       description: {
         component:
-          'A block-first stats banner. Badges, content and CTA are all provided through named blocks; provide stat cards in the default block.'
+          'A stats banner supporting badge, extra icon, title with tooltip, inline tag, and named blocks for content, extra-badges, dropdown and CTA.'
       },
       iframeHeight: 260
     }
@@ -34,12 +46,7 @@ const defaultArgs = {
 const Template = (args) => ({
   template: hbs`
     <div style="max-width: 1200px;">
-      <OSS::Stats::Banner @title={{this.title}}>
-
-        <:badges>
-          <OSS::Badge @icon="fa-check" @skin="success" />
-        </:badges>
-
+      <OSS::Stats::Banner @title={{this.title}} @badge={{hash icon="fa-check" skin="success"}}>
         <:content>
           <span class="font-color-gray-600">{{this.title}}</span>
         </:content>
@@ -84,11 +91,7 @@ const Template = (args) => ({
 const WithCTA = (args) => ({
   template: hbs`
     <div style="max-width: 1200px;">
-      <OSS::Stats::Banner @title={{this.title}}>
-        <:badges>
-          <OSS::Badge @icon="fa-check" @skin="success" />
-        </:badges>
-
+      <OSS::Stats::Banner @title={{this.title}} @badge={{hash icon="fa-check" skin="success"}}>
         <:content>
           <span class="font-color-gray-600">{{this.title}}</span>
         </:content>
@@ -113,3 +116,44 @@ Default.args = defaultArgs;
 
 export const UsageWithHeaderCTA = WithCTA.bind({});
 UsageWithHeaderCTA.args = defaultArgs;
+
+const WithExtraIconAndTitleInfo = (args) => ({
+  template: hbs`
+    <div style="max-width: 1200px;">
+      <OSS::Stats::Banner
+        @title={{this.title}}
+        @titleInfo="This KPI represents total paid amounts across all campaigns"
+        @badge={{hash icon="fa-check" skin="success"}}
+        @extraIcon={{hash icon="fa-star" color="#f59e0b"}}
+        @statValue="$12,493"
+        @statExtraInfo="supplementary info"
+        @extraInfoTag={{hash label="New" skin="success" icon="fa-sparkles"}}
+      />
+    </div>
+  `,
+  context: args
+});
+
+export const WithExtraFeaturesAndTitleInfo = WithExtraIconAndTitleInfo.bind({});
+WithExtraFeaturesAndTitleInfo.args = defaultArgs;
+
+const WithDropdown = (args) => ({
+  template: hbs`
+    <div style="max-width: 1200px;">
+      <OSS::Stats::Banner @title={{this.title}} @badge={{hash icon="fa-check" skin="success"}} @statValue="$12,493">
+        <:dropdown>
+          <OSS::ButtonDropdown @icon="fa-caret-down" @hideArrow={{true}} @square={{true}} @size="sm">
+            <:items>
+              <div class="oss-button-dropdown__item">Option A</div>
+              <div class="oss-button-dropdown__item">Option B</div>
+            </:items>
+          </OSS::ButtonDropdown>
+        </:dropdown>
+      </OSS::Stats::Banner>
+    </div>
+  `,
+  context: args
+});
+
+export const UsageWithDropdown = WithDropdown.bind({});
+UsageWithDropdown.args = defaultArgs;

--- a/addon/components/o-s-s/stats/banner.stories.js
+++ b/addon/components/o-s-s/stats/banner.stories.js
@@ -9,22 +9,22 @@ export default {
       table: { type: { summary: 'string' }, defaultValue: { summary: 'undefined' } },
       control: { type: 'text' }
     },
-    titleInfo: {
+    titleInfoCircle: {
       description: 'When provided, displays an info-circle icon next to the title with this text as tooltip',
       table: { type: { summary: 'string' }, defaultValue: { summary: 'undefined' } },
       control: { type: 'text' }
     },
-    badge: {
+    badgeConfig: {
       description: 'Badge config passed down to OSS::Badge (icon, image, text, skin, plain, size)',
-      table: { type: { summary: 'StatsBannerBadge' }, defaultValue: { summary: 'undefined' } }
+      table: { type: { summary: 'StatsBannerBadgeConfig' }, defaultValue: { summary: 'undefined' } }
     },
-    extraIcon: {
+    extraIconConfig: {
       description: 'Icon displayed to the left of the badge. Accepts { icon, color }',
-      table: { type: { summary: 'StatsBannerExtraIcon' }, defaultValue: { summary: 'undefined' } }
+      table: { type: { summary: 'StatsBannerExtraIconConfig' }, defaultValue: { summary: 'undefined' } }
     },
-    extraInfoTag: {
+    extraInfoTagConfig: {
       description: 'Tag displayed next to the stat value. Accepts OSS::Tag config (label, skin, icon, plain)',
-      table: { type: { summary: 'StatsBannerExtraInfoTag' }, defaultValue: { summary: 'undefined' } }
+      table: { type: { summary: 'StatsBannerExtraInfoTagConfig' }, defaultValue: { summary: 'undefined' } }
     }
   },
   parameters: {
@@ -46,7 +46,7 @@ const defaultArgs = {
 const Template = (args) => ({
   template: hbs`
     <div style="max-width: 1200px;">
-      <OSS::Stats::Banner @title={{this.title}} @badge={{hash icon="fa-check" skin="success"}}>
+      <OSS::Stats::Banner @title={{this.title}} @badgeConfig={{hash icon="fa-check" skin="success"}}>
         <:content>
           <span class="font-color-gray-600">{{this.title}}</span>
         </:content>
@@ -91,7 +91,7 @@ const Template = (args) => ({
 const WithCTA = (args) => ({
   template: hbs`
     <div style="max-width: 1200px;">
-      <OSS::Stats::Banner @title={{this.title}} @badge={{hash icon="fa-check" skin="success"}}>
+      <OSS::Stats::Banner @title={{this.title}} @badgeConfig={{hash icon="fa-check" skin="success"}}>
         <:content>
           <span class="font-color-gray-600">{{this.title}}</span>
         </:content>
@@ -117,30 +117,30 @@ Default.args = defaultArgs;
 export const UsageWithHeaderCTA = WithCTA.bind({});
 UsageWithHeaderCTA.args = defaultArgs;
 
-const WithExtraIconAndTitleInfo = (args) => ({
+const WithExtraIconAndTitleInfoCircle = (args) => ({
   template: hbs`
     <div style="max-width: 1200px;">
       <OSS::Stats::Banner
         @title={{this.title}}
-        @titleInfo="This KPI represents total paid amounts across all campaigns"
-        @badge={{hash icon="fa-check" skin="success"}}
-        @extraIcon={{hash icon="fa-star" color="#f59e0b"}}
+        @titleInfoCircle="This KPI represents total paid amounts across all campaigns"
+        @badgeConfig={{hash icon="fa-check" skin="success"}}
+        @extraIconConfig={{hash icon="fa-star" color="#f59e0b"}}
         @statValue="$12,493"
         @statExtraInfo="supplementary info"
-        @extraInfoTag={{hash label="New" skin="success" icon="fa-sparkles"}}
+        @extraInfoTagConfig={{hash label="New" skin="success" icon="fa-sparkles"}}
       />
     </div>
   `,
   context: args
 });
 
-export const WithExtraFeaturesAndTitleInfo = WithExtraIconAndTitleInfo.bind({});
-WithExtraFeaturesAndTitleInfo.args = defaultArgs;
+export const WithExtraFeaturesAndTitleInfoCircle = WithExtraIconAndTitleInfoCircle.bind({});
+WithExtraFeaturesAndTitleInfoCircle.args = defaultArgs;
 
 const WithDropdown = (args) => ({
   template: hbs`
     <div style="max-width: 1200px;">
-      <OSS::Stats::Banner @title={{this.title}} @badge={{hash icon="fa-check" skin="success"}} @statValue="$12,493">
+      <OSS::Stats::Banner @title={{this.title}} @badgeConfig={{hash icon="fa-check" skin="success"}} @statValue="$12,493">
         <:dropdown>
           <OSS::ButtonDropdown @icon="fa-caret-down" @hideArrow={{true}} @square={{true}} @size="sm">
             <:items>

--- a/addon/components/o-s-s/stats/banner.stories.js
+++ b/addon/components/o-s-s/stats/banner.stories.js
@@ -1,0 +1,129 @@
+import { hbs } from 'ember-cli-htmlbars';
+
+export default {
+  title: 'Components/OSS::Stats::Banner',
+  component: 'stats-banner',
+  argTypes: {
+    title: {
+      description: 'Header text displayed in the banner',
+      table: {
+        type: {
+          summary: 'string'
+        },
+        defaultValue: { summary: 'undefined' }
+      },
+      control: { type: 'text' }
+    },
+    badgeIcon: {
+      description: 'Font Awesome icon forwarded to OSS::Badge (@icon)',
+      table: {
+        type: {
+          summary: 'string'
+        },
+        defaultValue: { summary: 'fa-check' }
+      },
+      control: { type: 'text' }
+    },
+    badgeSkin: {
+      description: 'Badge skin forwarded to OSS::Badge (@skin)',
+      table: {
+        type: {
+          summary: 'primary|success|alert|error|xtd-cyan|xtd-orange|xtd-yellow|xtd-lime|xtd-blue|xtd-violet|xtd-smart'
+        },
+        defaultValue: { summary: 'success' }
+      },
+      control: { type: 'text' }
+    }
+  },
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'A block-first stats banner. Badge props are forwarded to OSS::Badge, while content and CTA remain named blocks; provide stat cards in the default block.'
+      },
+      iframeHeight: 260
+    }
+  }
+};
+
+const defaultArgs = {
+  title:
+    'Use statistics to surface a key KPI or summary at-a-glance. Apply locale-aware number formatting, keep significant digits reasonable, and always show units and currency.',
+  badgeIcon: 'fa-check',
+  badgeSkin: 'success'
+};
+
+const Template = (args) => ({
+  template: hbs`
+    <div style="max-width: 1200px;">
+      <OSS::Stats::Banner @title={{this.title}} @badgeIcon={{this.badgeIcon}} @badgeSkin={{this.badgeSkin}}>
+
+        <:content>
+          <span class="font-color-gray-600">{{this.title}}</span>
+        </:content>
+
+        <div class="oss-stats-banner__card">
+          <div class="oss-stats-banner__card-label">Total paid amount</div>
+          <div class="oss-stats-banner__card-value">$12,493,343.22</div>
+          <div class="oss-stats-banner__card-meta">supplementary info</div>
+        </div>
+
+        <div class="oss-stats-banner__card">
+          <div class="oss-stats-banner__card-label">Commission to authorize</div>
+          <div class="oss-stats-banner__card-value">$5,920</div>
+          <div class="oss-stats-banner__card-meta">supplementary info</div>
+        </div>
+
+        <div class="oss-stats-banner__card">
+          <div class="oss-stats-banner__card-label">Pending amount</div>
+          <div class="oss-stats-banner__card-value">$594,032</div>
+          <div class="oss-stats-banner__card-meta">supplementary info</div>
+        </div>
+
+        <div class="oss-stats-banner__card oss-stats-banner__card--highlighted">
+          <div class="fx-row fx-malign-space-between fx-xalign-center fx-gap-px-6">
+            <OSS::Tag @label="Ready-to-pay commission" @icon="fa-circle-check" @skin="secondary" @size="xs" />
+
+            <OSS::Button @label="Pay" @size="xs" @icon="fa-money-bill" />
+          </div>
+          <div class="oss-stats-banner__card-value">$5,920</div>
+          <div class="oss-stats-banner__card-meta">supplementary info</div>
+
+          <div class="margin-top-px-6">
+            <OSS::Tag @label="5 payments" @skin="secondary" @size="xs" />
+          </div>
+        </div>
+      </OSS::Stats::Banner>
+    </div>
+  `,
+  context: args
+});
+
+const WithCTA = (args) => ({
+  template: hbs`
+    <div style="max-width: 1200px;">
+      <OSS::Stats::Banner @title={{this.title}} @badgeIcon={{this.badgeIcon}} @badgeSkin={{this.badgeSkin}}>
+        <:content>
+          <span class="font-color-gray-600">{{this.title}}</span>
+        </:content>
+
+        <:cta>
+          <OSS::Button @label="Export" @icon="fa-download" @size="sm" @skin="secondary" />
+        </:cta>
+
+        <div class="oss-stats-banner__card">
+          <div class="oss-stats-banner__card-label">Total paid amount</div>
+          <div class="oss-stats-banner__card-value">$12,493,343.22</div>
+          <div class="oss-stats-banner__card-meta">supplementary info</div>
+        </div>
+      </OSS::Stats::Banner>
+    </div>
+  `,
+  context: args
+});
+
+export const Default = Template.bind({});
+Default.args = defaultArgs;
+
+export const UsageWithHeaderCTA = WithCTA.bind({});
+UsageWithHeaderCTA.args = defaultArgs;

--- a/addon/components/o-s-s/stats/banner.stories.js
+++ b/addon/components/o-s-s/stats/banner.stories.js
@@ -13,18 +13,9 @@ export default {
       table: { type: { summary: 'StatsBannerBadge' }, defaultValue: { summary: 'undefined' } }
     },
     statValue: {
-      description: 'Main KPI value displayed in the stat row',
-      control: 'text',
-      table: { type: { summary: 'string | number' }, defaultValue: { summary: 'undefined' } }
-    },
-    statExtraInfo: {
-      description: 'Secondary information shown next to the main KPI value',
-      control: 'text',
-      table: { type: { summary: 'string' }, defaultValue: { summary: 'undefined' } }
-    },
-    extraInfoTagConfig: {
-      description: 'Tag displayed next to the stat value. Accepts OSS::Tag config (label, skin, icon, plain)',
-      table: { type: { summary: 'StatsBannerExtraInfoTagConfig' }, defaultValue: { summary: 'undefined' } }
+      description: 'Stat object: { label, suffix?, tags? }',
+      control: 'object',
+      table: { type: { summary: 'StatsBannerStatValue' }, defaultValue: { summary: 'undefined' } }
     },
     loading: {
       description: 'Displays skeletons in place of title and KPI values',
@@ -67,13 +58,17 @@ const defaultArgs = {
       color: '#f59e0b'
     }
   },
-  statValue: '123,456',
-  statExtraInfo: 'Extra info',
-  extraInfoTagConfig: {
-    label: 'New',
-    skin: 'success',
-    icon: 'fa-sparkles',
-    plain: false
+  statValue: {
+    label: '123,456',
+    suffix: 'Extra info',
+    tags: [
+      {
+        label: 'New',
+        skin: 'success',
+        icon: 'fa-sparkles',
+        plain: false
+      }
+    ]
   },
   loading: false,
   ctaPrimaryLabel: 'CTA',
@@ -87,8 +82,6 @@ const PlaygroundTemplate = (args) => ({
         @titleConfig={{this.titleConfig}}
         @badge={{this.badge}}
         @statValue={{this.statValue}}
-        @statExtraInfo={{this.statExtraInfo}}
-        @extraInfoTagConfig={{this.extraInfoTagConfig}}
         @loading={{this.loading}}
       >
         <:title-suffix>
@@ -125,7 +118,6 @@ const ThreeUpTemplate = (args) => ({
           @badge={{this.badge}}
           @titleConfig={{this.titleConfig}}
           @statValue={{this.statValue}}
-          @statExtraInfo={{this.statExtraInfo}}
         >
           <:cta>
             <OSS::Button @skin="secondary" @label={{this.ctaSecondaryLabel}} @size="sm" />
@@ -136,8 +128,7 @@ const ThreeUpTemplate = (args) => ({
           class="fx-1"
           @badge={{hash icon="fa-star" skin="primary"}}
           @titleConfig={{hash text="Commissions"}}
-          @statValue="$5,920"
-          @statExtraInfo="to authorize"
+          @statValue={{hash label="$5,920" suffix="to authorize"}}
         >
           <:cta>
             <OSS::Button @skin="primary" @label="Pay" @size="sm" />
@@ -146,10 +137,9 @@ const ThreeUpTemplate = (args) => ({
 
         <OSS::Stats::Banner
           class="fx-1"
-                @badge={{hash icon="fa-bolt" skin="alert"}}
+                  @badge={{hash icon="fa-bolt" skin="alert"}}
           @titleConfig={{hash text="Pending"}}
-          @statValue="$594,032"
-          @statExtraInfo="across campaigns"
+                  @statValue={{hash label="$594,032" suffix="across campaigns"}}
         >
           <:cta>
             <OSS::Button @skin="secondary" @label="Open" @size="sm" />
@@ -168,8 +158,6 @@ const DefaultTemplate = (args) => ({
         @titleConfig={{this.titleConfig}}
         @badge={{this.badge}}
         @statValue={{this.statValue}}
-        @statExtraInfo={{this.statExtraInfo}}
-        @extraInfoTagConfig={{this.extraInfoTagConfig}}
       >
 
         <:cta>
@@ -192,7 +180,6 @@ const LoadingTemplate = (args) => ({
         @titleConfig={{this.titleConfig}}
         @badge={{this.badge}}
         @statValue={{this.statValue}}
-        @statExtraInfo={{this.statExtraInfo}}
       >
         <:extra-badges>
           <OSS::Badge @text="2x" @size="lg" />
@@ -210,7 +197,6 @@ const MinimalTemplate = (args) => ({
         @titleConfig={{this.titleConfig}}
         @badge={{this.badge}}
         @statValue={{this.statValue}}
-        @statExtraInfo={{this.statExtraInfo}}
       />
     </div>
   `,
@@ -224,7 +210,6 @@ const TitleSuffixOnlyTemplate = (args) => ({
         @titleConfig={{this.titleConfig}}
         @badge={{this.badge}}
         @statValue={{this.statValue}}
-        @statExtraInfo={{this.statExtraInfo}}
       >
         <:title-suffix>
           <OSS::ButtonDropdown @icon="fa-caret-down" @hideArrow={{true}} @square={{true}} @size="sm">
@@ -255,8 +240,10 @@ ThreeUpCompact.args = {
     icon: 'fa-check',
     skin: 'success'
   },
-  statValue: '$12,493',
-  statExtraInfo: 'vs last month',
+  statValue: {
+    label: '$12,493',
+    suffix: 'vs last month'
+  },
   ctaSecondaryLabel: 'Details'
 };
 
@@ -275,13 +262,17 @@ WithDefaultCards.args = {
       color: '#fb923c'
     }
   },
-  statValue: '$5,920',
-  statExtraInfo: 'to authorize',
-  extraInfoTagConfig: {
-    label: 'Urgent',
-    skin: 'warning',
-    icon: 'fa-triangle-exclamation',
-    plain: false
+  statValue: {
+    label: '$5,920',
+    suffix: 'to authorize',
+    tags: [
+      {
+        label: 'Urgent',
+        skin: 'warning',
+        icon: 'fa-triangle-exclamation',
+        plain: false
+      }
+    ]
   },
   ctaPrimaryLabel: 'Pay',
   ctaSecondaryLabel: 'Export CSV'
@@ -298,8 +289,10 @@ Loading.args = {
     icon: 'fa-hourglass-half',
     skin: 'alert'
   },
-  statValue: '999,999',
-  statExtraInfo: 'Fetching latest data',
+  statValue: {
+    label: '999,999',
+    suffix: 'Fetching latest data'
+  },
   loading: true
 };
 
@@ -311,9 +304,10 @@ Minimal.args = {
     infoCircle: undefined
   },
   badge: undefined,
-  statValue: '42',
-  statExtraInfo: 'currently running',
-  extraInfoTagConfig: undefined
+  statValue: {
+    label: '42',
+    suffix: 'currently running'
+  }
 };
 
 export const WithTitleSuffixOnly = TitleSuffixOnlyTemplate.bind({});
@@ -327,12 +321,16 @@ WithTitleSuffixOnly.args = {
     icon: 'fa-chart-line',
     skin: 'primary'
   },
-  statValue: '$87,240',
-  statExtraInfo: 'last 30 days',
-  extraInfoTagConfig: {
-    label: '+12%',
-    skin: 'success',
-    icon: 'fa-arrow-up',
-    plain: false
+  statValue: {
+    label: '$87,240',
+    suffix: 'last 30 days',
+    tags: [
+      {
+        label: '+12%',
+        skin: 'success',
+        icon: 'fa-arrow-up',
+        plain: false
+      }
+    ]
   }
 };

--- a/addon/components/o-s-s/stats/banner.stories.js
+++ b/addon/components/o-s-s/stats/banner.stories.js
@@ -9,11 +9,11 @@ export default {
       table: { type: { summary: 'StatsBannerTitle' }, defaultValue: { summary: 'undefined' } }
     },
     badge: {
-      description: 'Badge object passed to OSS::Badge, supports extraIcon: { icon, color }',
-      table: { type: { summary: 'StatsBannerBadge' }, defaultValue: { summary: 'undefined' } }
+      description: 'Badge object passed to OSS::Badge, with optional extraIcon: StatsBannerExtraIconArgs',
+      table: { type: { summary: 'StatsBannerBadge = StatsBannerBadgeArgs & { extraIcon?: StatsBannerExtraIconArgs }' }, defaultValue: { summary: 'undefined' } }
     },
     statValue: {
-      description: 'Stat object: { label, suffix?, tags? }',
+      description: 'Stat object: { label, suffix?, tags?: StatsBannerTag[] }',
       control: 'object',
       table: { type: { summary: 'StatsBannerStatValue' }, defaultValue: { summary: 'undefined' } }
     },

--- a/addon/components/o-s-s/stats/banner.ts
+++ b/addon/components/o-s-s/stats/banner.ts
@@ -5,8 +5,8 @@ import type { OSSTagArgs } from '@upfluence/oss-components/components/o-s-s/tag'
 import type { OSSBadgeArgs } from '@upfluence/oss-components/components/o-s-s/badge';
 import type { OSSIconArgs } from '@upfluence/oss-components/components/o-s-s/icon';
 
-export type StatsBannerBadgeConfig = Pick<OSSBadgeArgs, 'icon' | 'image' | 'text' | 'skin'>;
-export type StatsBannerExtraIconConfig = Pick<OSSIconArgs, 'icon'> & { color?: string };
+export type StatsBannerBadgeArgs = Pick<OSSBadgeArgs, 'icon' | 'image' | 'text' | 'skin'>;
+export type StatsBannerExtraIconArgs = Pick<OSSIconArgs, 'icon'> & { color?: string };
 export type StatsBannerTag = Pick<OSSTagArgs, 'label' | 'skin' | 'icon' | 'plain'>;
 export type StatsBannerTitle = {
   text: string;
@@ -17,8 +17,8 @@ export type StatsBannerStatValue = {
   suffix?: ReturnType<IntlService['t']> | string;
   tags?: StatsBannerTag[];
 };
-export type StatsBannerBadge = StatsBannerBadgeConfig & {
-  extraIcon?: StatsBannerExtraIconConfig;
+export type StatsBannerBadge = StatsBannerBadgeArgs & {
+  extraIcon?: StatsBannerExtraIconArgs;
 };
 
 interface OSSStatsBannerSignature {

--- a/addon/components/o-s-s/stats/banner.ts
+++ b/addon/components/o-s-s/stats/banner.ts
@@ -1,25 +1,14 @@
 import Component from '@glimmer/component';
-import type { SizeType, SkinType } from '@upfluence/oss-components/components/o-s-s/badge';
 
 interface OSSStatsBannerArgs {
   loading?: boolean;
   title?: string;
   statValue?: string;
   statExtraInfo?: string;
-  badgeIcon?: string;
-  badgeImage?: string;
-  badgeText?: string;
-  badgeSkin?: SkinType;
-  badgeSize?: SizeType;
-  badgePlain?: boolean;
 }
 
 export default class OSSStatsBanner extends Component<OSSStatsBannerArgs> {
   get loading(): boolean {
     return this.args.loading ?? false;
-  }
-
-  get hasBadgeContent(): boolean {
-    return Boolean(this.args.badgeIcon || this.args.badgeImage || this.args.badgeText);
   }
 }

--- a/addon/components/o-s-s/stats/banner.ts
+++ b/addon/components/o-s-s/stats/banner.ts
@@ -1,4 +1,5 @@
 import Component from '@glimmer/component';
+import { assert } from '@ember/debug';
 import type { OSSTagArgs } from '@upfluence/oss-components/components/o-s-s/tag';
 import type { OSSBadgeArgs } from '@upfluence/oss-components/components/o-s-s/badge';
 import type { OSSIconArgs } from '@upfluence/oss-components/components/o-s-s/icon';
@@ -6,16 +7,30 @@ import type { OSSIconArgs } from '@upfluence/oss-components/components/o-s-s/ico
 export type StatsBannerExtraInfoTagConfig = Pick<OSSTagArgs, 'label' | 'skin' | 'icon' | 'plain'>;
 export type StatsBannerBadgeConfig = Pick<OSSBadgeArgs, 'icon' | 'image' | 'text' | 'skin'>;
 export type StatsBannerExtraIconConfig = Pick<OSSIconArgs, 'icon'> & { color?: string };
+export type StatsBannerTitle = {
+  text: string;
+  infoCircle?: string;
+};
+export type StatsBannerBadge = StatsBannerBadgeConfig & {
+  extraIcon?: StatsBannerExtraIconConfig;
+};
 
 interface OSSStatsBannerSignature {
+  titleConfig: StatsBannerTitle;
+  badge?: StatsBannerBadge;
   loading?: boolean;
-  title?: string;
-  titleInfoCircle?: string;
-  badgeConfig?: StatsBannerBadgeConfig;
-  extraIconConfig?: StatsBannerExtraIconConfig;
   extraInfoTagConfig?: StatsBannerExtraInfoTagConfig;
   statValue?: string;
   statExtraInfo?: string;
 }
 
-export default class OSSStatsBanner extends Component<OSSStatsBannerSignature> {}
+export default class OSSStatsBanner extends Component<OSSStatsBannerSignature> {
+  constructor(owner: unknown, args: OSSStatsBannerSignature) {
+    super(owner, args);
+
+    assert(
+      '[component][OSS::Stats::Banner] You must pass a title via @titleConfig.text.',
+      Boolean(args.titleConfig?.text)
+    );
+  }
+}

--- a/addon/components/o-s-s/stats/banner.ts
+++ b/addon/components/o-s-s/stats/banner.ts
@@ -3,23 +3,19 @@ import type { OSSTagArgs } from '@upfluence/oss-components/components/o-s-s/tag'
 import type { OSSBadgeArgs } from '@upfluence/oss-components/components/o-s-s/badge';
 import type { OSSIconArgs } from '@upfluence/oss-components/components/o-s-s/icon';
 
-export type StatsBannerExtraInfoTag = Pick<OSSTagArgs, 'label' | 'skin' | 'icon' | 'plain'>;
-export type StatsBannerBadge = Pick<OSSBadgeArgs, 'icon' | 'image' | 'text' | 'skin'>;
-export type StatsBannerExtraIcon = { icon: string; color?: string };
+export type StatsBannerExtraInfoTagConfig = Pick<OSSTagArgs, 'label' | 'skin' | 'icon' | 'plain'>;
+export type StatsBannerBadgeConfig = Pick<OSSBadgeArgs, 'icon' | 'image' | 'text' | 'skin'>;
+export type StatsBannerExtraIconConfig = Pick<OSSIconArgs, 'icon'> & { color?: string };
 
 interface OSSStatsBannerSignature {
   loading?: boolean;
   title?: string;
-  titleInfo?: string;
+  titleInfoCircle?: string;
+  badgeConfig?: StatsBannerBadgeConfig;
+  extraIconConfig?: StatsBannerExtraIconConfig;
+  extraInfoTagConfig?: StatsBannerExtraInfoTagConfig;
   statValue?: string;
   statExtraInfo?: string;
-  extraInfoTag?: StatsBannerExtraInfoTag;
-  badge?: StatsBannerBadge;
-  extraIcon?: StatsBannerExtraIcon;
 }
 
-export default class OSSStatsBanner extends Component<OSSStatsBannerSignature> {
-  get loading(): boolean {
-    return this.args.loading ?? false;
-  }
-}
+export default class OSSStatsBanner extends Component<OSSStatsBannerSignature> {}

--- a/addon/components/o-s-s/stats/banner.ts
+++ b/addon/components/o-s-s/stats/banner.ts
@@ -1,15 +1,21 @@
 import Component from '@glimmer/component';
 import { assert } from '@ember/debug';
+import type IntlService from 'ember-intl/services/intl';
 import type { OSSTagArgs } from '@upfluence/oss-components/components/o-s-s/tag';
 import type { OSSBadgeArgs } from '@upfluence/oss-components/components/o-s-s/badge';
 import type { OSSIconArgs } from '@upfluence/oss-components/components/o-s-s/icon';
 
-export type StatsBannerExtraInfoTagConfig = Pick<OSSTagArgs, 'label' | 'skin' | 'icon' | 'plain'>;
 export type StatsBannerBadgeConfig = Pick<OSSBadgeArgs, 'icon' | 'image' | 'text' | 'skin'>;
 export type StatsBannerExtraIconConfig = Pick<OSSIconArgs, 'icon'> & { color?: string };
+export type StatsBannerTag = Pick<OSSTagArgs, 'label' | 'skin' | 'icon' | 'plain'>;
 export type StatsBannerTitle = {
   text: string;
   infoCircle?: string;
+};
+export type StatsBannerStatValue = {
+  label: ReturnType<IntlService['t']> | string;
+  suffix?: ReturnType<IntlService['t']> | string;
+  tags?: StatsBannerTag[];
 };
 export type StatsBannerBadge = StatsBannerBadgeConfig & {
   extraIcon?: StatsBannerExtraIconConfig;
@@ -19,9 +25,7 @@ interface OSSStatsBannerSignature {
   titleConfig: StatsBannerTitle;
   badge?: StatsBannerBadge;
   loading?: boolean;
-  extraInfoTagConfig?: StatsBannerExtraInfoTagConfig;
-  statValue?: string;
-  statExtraInfo?: string;
+  statValue?: StatsBannerStatValue;
 }
 
 export default class OSSStatsBanner extends Component<OSSStatsBannerSignature> {

--- a/addon/components/o-s-s/stats/banner.ts
+++ b/addon/components/o-s-s/stats/banner.ts
@@ -1,0 +1,25 @@
+import Component from '@glimmer/component';
+import type { SizeType, SkinType } from '@upfluence/oss-components/components/o-s-s/badge';
+
+interface OSSStatsBannerArgs {
+  loading?: boolean;
+  title?: string;
+  statValue?: string;
+  statExtraInfo?: string;
+  badgeIcon?: string;
+  badgeImage?: string;
+  badgeText?: string;
+  badgeSkin?: SkinType;
+  badgeSize?: SizeType;
+  badgePlain?: boolean;
+}
+
+export default class OSSStatsBanner extends Component<OSSStatsBannerArgs> {
+  get loading(): boolean {
+    return this.args.loading ?? false;
+  }
+
+  get hasBadgeContent(): boolean {
+    return Boolean(this.args.badgeIcon || this.args.badgeImage || this.args.badgeText);
+  }
+}

--- a/addon/components/o-s-s/stats/banner.ts
+++ b/addon/components/o-s-s/stats/banner.ts
@@ -1,13 +1,24 @@
 import Component from '@glimmer/component';
+import type { OSSTagArgs } from '@upfluence/oss-components/components/o-s-s/tag';
+import type { OSSBadgeArgs } from '@upfluence/oss-components/components/o-s-s/badge';
+import type { OSSIconArgs } from '@upfluence/oss-components/components/o-s-s/icon';
 
-interface OSSStatsBannerArgs {
+export type StatsBannerExtraInfoTag = Pick<OSSTagArgs, 'label' | 'skin' | 'icon' | 'plain'>;
+export type StatsBannerBadge = Pick<OSSBadgeArgs, 'icon' | 'image' | 'text' | 'skin'>;
+export type StatsBannerExtraIcon = { icon: string; color?: string };
+
+interface OSSStatsBannerSignature {
   loading?: boolean;
   title?: string;
+  titleInfo?: string;
   statValue?: string;
   statExtraInfo?: string;
+  extraInfoTag?: StatsBannerExtraInfoTag;
+  badge?: StatsBannerBadge;
+  extraIcon?: StatsBannerExtraIcon;
 }
 
-export default class OSSStatsBanner extends Component<OSSStatsBannerArgs> {
+export default class OSSStatsBanner extends Component<OSSStatsBannerSignature> {
   get loading(): boolean {
     return this.args.loading ?? false;
   }

--- a/app/components/o-s-s/stats/banner.js
+++ b/app/components/o-s-s/stats/banner.js
@@ -1,0 +1,1 @@
+export { default } from '@upfluence/oss-components/components/o-s-s/stats/banner';

--- a/app/styles/organisms/stats-banner.less
+++ b/app/styles/organisms/stats-banner.less
@@ -104,6 +104,11 @@
     max-width: 100%;
   }
 
+  &__skeleton--stat-value,
+  &__skeleton--stat-extra {
+    max-width: 100%;
+  }
+
   &__skeleton--cta {
     border-radius: var(--border-radius-xl);
   }

--- a/app/styles/organisms/stats-banner.less
+++ b/app/styles/organisms/stats-banner.less
@@ -1,6 +1,4 @@
 .oss-stats-banner {
-  container-type: inline-size;
-
   display: flex;
   flex: 1;
   flex-direction: column;
@@ -92,7 +90,6 @@
   .oss-stats-banner {
     &__header {
       align-items: flex-start;
-      flex-direction: column;
     }
 
     &__stats {

--- a/app/styles/organisms/stats-banner.less
+++ b/app/styles/organisms/stats-banner.less
@@ -190,7 +190,7 @@
   }
 }
 
-@container (width <= 540px) {
+@container (width <= 320px) {
   .oss-stats-banner {
     &__stat-main {
       grid-template-columns: minmax(0, 1fr) auto;

--- a/app/styles/organisms/stats-banner.less
+++ b/app/styles/organisms/stats-banner.less
@@ -27,8 +27,8 @@
 
   &__badge {
     display: flex;
-    align-items: flex-start;
-    padding-top: var(--spacing-px-3);
+    align-items: center;
+    gap: var(--spacing-px-6);
   }
 
   &__content {

--- a/app/styles/organisms/stats-banner.less
+++ b/app/styles/organisms/stats-banner.less
@@ -1,7 +1,9 @@
 .oss-stats-banner {
+  container-type: inline-size;
   display: flex;
   flex: 1;
   flex-direction: column;
+  gap: var(--spacing-px-12);
   padding: var(--spacing-px-12) var(--spacing-px-18);
   border: 1px solid var(--color-border-default);
   border-radius: var(--border-radius-md);
@@ -9,6 +11,7 @@
 
   &__header {
     display: flex;
+    justify-content: space-between;
     align-items: center;
     gap: var(--spacing-px-12);
     min-width: 0;
@@ -16,6 +19,8 @@
 
   &__header_content {
     display: flex;
+    align-items: center;
+    gap: var(--spacing-px-9);
     flex: 1;
     min-width: 0;
   }
@@ -35,6 +40,10 @@
 
   &__title-row {
     display: flex;
+    align-items: center;
+    justify-content: flex-start;
+    flex-wrap: nowrap;
+    gap: var(--spacing-px-6);
     flex: 1;
     min-width: 0;
   }
@@ -49,9 +58,64 @@
     flex-shrink: 0;
   }
 
-  &__cta {
+  &__title-actions {
     display: flex;
     align-items: center;
+    flex-wrap: nowrap;
+    gap: var(--spacing-px-6);
+  }
+
+  &__extra-badges {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-px-3);
+  }
+
+  &__cta {
+    display: flex;
+    align-items: flex-end;
+    align-self: end;
+    justify-self: end;
+  }
+
+  &__bottom_content {
+    display: flex;
+    justify-content: space-between;
+    gap: var(--spacing-px-12);
+    align-items: flex-start;
+    flex: 1;
+    min-height: 0;
+  }
+
+  &__stat {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    min-width: 0;
+    min-height: 0;
+  }
+
+  &__stat-main {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: end;
+    width: 100%;
+    height: 100%;
+    min-width: 0;
+    gap: var(--spacing-px-12);
+  }
+
+  &__stat-main-content {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-px-6);
+    min-width: 0;
+    flex-wrap: wrap;
+  }
+
+  &__stat-extra {
+    line-height: 1.2;
+    white-space: nowrap;
   }
 
   &__stats {
@@ -128,6 +192,25 @@
 
 @container (width <= 540px) {
   .oss-stats-banner {
+    &__stat-main {
+      grid-template-columns: minmax(0, 1fr) auto;
+      align-items: end;
+      height: 100%;
+    }
+
+    &__cta {
+      align-self: end;
+      justify-self: end;
+      margin-left: auto;
+    }
+
+    &__stat-main-content {
+      flex-direction: column;
+      align-items: flex-start;
+      gap: var(--spacing-px-9);
+      flex-wrap: nowrap;
+    }
+
     &__stats {
       grid-template-columns: minmax(0, 1fr);
     }

--- a/app/styles/organisms/stats-banner.less
+++ b/app/styles/organisms/stats-banner.less
@@ -2,7 +2,6 @@
   display: flex;
   flex: 1;
   flex-direction: column;
-  gap: var(--spacing-px-12);
   padding: var(--spacing-px-12) var(--spacing-px-18);
   border: 1px solid var(--color-border-default);
   border-radius: var(--border-radius-md);
@@ -12,6 +11,13 @@
     display: flex;
     align-items: center;
     gap: var(--spacing-px-12);
+    min-width: 0;
+  }
+
+  &__header_content {
+    display: flex;
+    flex: 1;
+    min-width: 0;
   }
 
   &__badge {
@@ -24,6 +30,23 @@
     display: flex;
     flex: 1;
     line-height: 1.4;
+    min-width: 0;
+  }
+
+  &__title-row {
+    display: flex;
+    flex: 1;
+    min-width: 0;
+  }
+
+  &__title {
+    flex: 0 1 auto;
+    min-width: 0;
+  }
+
+  &__title-actions,
+  &__extra-badges {
+    flex-shrink: 0;
   }
 
   &__cta {

--- a/app/styles/organisms/stats-banner.less
+++ b/app/styles/organisms/stats-banner.less
@@ -5,7 +5,7 @@
   flex: 1;
   flex-direction: column;
   gap: var(--spacing-px-12);
-  padding: var(--spacing-px-12);
+  padding: var(--spacing-px-12) var(--spacing-px-18);
   border: 1px solid var(--color-border-default);
   border-radius: var(--border-radius-md);
   background-color: var(--color-white);

--- a/app/styles/organisms/stats-banner.less
+++ b/app/styles/organisms/stats-banner.less
@@ -1,0 +1,110 @@
+.oss-stats-banner {
+  container-type: inline-size;
+
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  gap: var(--spacing-px-12);
+  padding: var(--spacing-px-12);
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--border-radius-md);
+  background-color: var(--color-white);
+
+  &__header {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-px-12);
+  }
+
+  &__badge {
+    display: flex;
+    align-items: flex-start;
+    padding-top: var(--spacing-px-3);
+  }
+
+  &__content {
+    display: flex;
+    flex: 1;
+    line-height: 1.4;
+  }
+
+  &__cta {
+    display: flex;
+    align-items: center;
+  }
+
+  &__stats {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: var(--spacing-px-12);
+  }
+
+  &__card {
+    border: 1px solid var(--color-border-default);
+    border-radius: var(--border-radius-md);
+    background-color: var(--color-gray-50);
+    padding: var(--spacing-px-12);
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-px-3);
+    min-height: 84px;
+  }
+
+  &__card--highlighted {
+    border-color: var(--color-violet-500);
+    background-color: var(--color-violet-50);
+  }
+
+  &__card-label {
+    color: var(--color-gray-500);
+    font-size: var(--font-size-xs);
+    line-height: 1.2;
+  }
+
+  &__card-value {
+    color: var(--color-gray-900);
+    font-size: var(--font-size-lg);
+    font-weight: var(--font-weight-semibold);
+    line-height: 1.2;
+  }
+
+  &__card-meta {
+    color: var(--color-gray-400);
+    font-size: var(--font-size-xs);
+    line-height: 1.2;
+  }
+
+  &__skeleton--badge,
+  &__skeleton--extra-badge {
+    border-radius: 9999px;
+  }
+
+  &__skeleton--title {
+    max-width: 100%;
+  }
+
+  &__skeleton--cta {
+    border-radius: var(--border-radius-xl);
+  }
+}
+
+@container (width <= 900px) {
+  .oss-stats-banner {
+    &__header {
+      align-items: flex-start;
+      flex-direction: column;
+    }
+
+    &__stats {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+  }
+}
+
+@container (width <= 540px) {
+  .oss-stats-banner {
+    &__stats {
+      grid-template-columns: minmax(0, 1fr);
+    }
+  }
+}

--- a/app/styles/oss-components.less
+++ b/app/styles/oss-components.less
@@ -92,5 +92,6 @@
 @import 'organisms/carousel';
 @import 'organisms/wizard-container';
 @import 'organisms/marketing-banner';
+@import 'organisms/stats-banner';
 @import 'organisms/context-menu';
 @import 'animations/smart-rotating-gradient';

--- a/tests/dummy/app/controllers/index.js
+++ b/tests/dummy/app/controllers/index.js
@@ -20,6 +20,9 @@ export default class ApplicationController extends Controller {
   }
 
   @action
+  noop() {}
+
+  @action
   triggerToast(type) {
     this.toast[type](`I am the ${type} subtitle`, 'Title');
   }

--- a/tests/dummy/app/styles/app.less
+++ b/tests/dummy/app/styles/app.less
@@ -125,6 +125,10 @@
   max-width: 335px;
 }
 
+.demo-stats-banner {
+  max-width: 1200px;
+}
+
 .demo-modal-content {
   height: 200px;
   background-color: var(--color-white);

--- a/tests/dummy/app/templates/data.hbs
+++ b/tests/dummy/app/templates/data.hbs
@@ -263,4 +263,105 @@
     </div>
   </div>
 
+  <div
+    class="fx-col fx-1 background-color-white border border-color-default border-radius-md padding-px-12 fx-gap-px-12"
+  >
+    <div class="font-size-md font-weight-semibold">
+      Stats banner
+    </div>
+    <div class="fx-col fx-gap-px-24">
+      <OSS::Stats::Banner
+        class="demo-stats-banner"
+        @badge={{hash icon="fa-check" skin="success" extraIcon=(hash icon="fa-star")}}
+        @titleConfig={{hash
+          text="Very long stats banner title that should truncate with ellipsis when the available width becomes too small"
+          infoCircle="This is a helpful description of the stat"
+        }}
+        @statValue="123,456"
+        @statExtraInfo="Extra info"
+        @extraInfoTagConfig={{hash label="New" skin="success" icon="fa-sparkles"}}
+      >
+        <:title-suffix>
+          <OSS::ButtonDropdown @icon="fa-caret-down" @hideArrow={{true}} @square={{true}} @size="sm">
+            <:items>
+              <div class="oss-button-dropdown__item">Option A</div>
+              <div class="oss-button-dropdown__item">Option B</div>
+            </:items>
+          </OSS::ButtonDropdown>
+        </:title-suffix>
+        <:extra-badges>
+          <OSS::Badge @text="2x" @size="lg" />
+        </:extra-badges>
+        <:cta>
+          <div class="fx-row fx-gap-px-6">
+            <OSS::Button @skin="primary" @label="CTA" @icon="fas fa-box-open" @size="md" />
+            <OSS::Button @skin="secondary" @label="Export" @icon="fa-download" @size="md" />
+          </div>
+        </:cta>
+      </OSS::Stats::Banner>
+
+      <OSS::Stats::Banner
+        class="demo-stats-banner"
+        @badge={{hash icon="fa-check" skin="success"}}
+        @titleConfig={{hash
+          text="Another intentionally long stats banner title to validate truncation next to the info-circle icon"
+          infoCircle="This stat title also has helpful context"
+        }}
+        @statValue="123,456"
+        @statExtraInfo="Potatoes"
+      />
+
+      <div class="demo-stats-banner-row fx-row fx-gap-px-12">
+        <OSS::Stats::Banner
+          class="demo-stats-banner demo-stats-banner--sm"
+          @badge={{hash icon="fa-check" skin="success"}}
+          @titleConfig={{hash text="Revenue"}}
+          @statValue="$12,493"
+          @statExtraInfo="vs last month"
+        >
+          <:cta>
+            <OSS::Button @skin="secondary" @label="Details" @size="sm" />
+          </:cta>
+        </OSS::Stats::Banner>
+
+        <OSS::Stats::Banner
+          class="demo-stats-banner demo-stats-banner--sm"
+          @badge={{hash icon="fa-star" skin="primary"}}
+          @titleConfig={{hash text="Commissions"}}
+          @statValue="$5,920"
+          @statExtraInfo="to authorize"
+        >
+          <:cta>
+            <OSS::Button @skin="primary" @label="Pay" @size="sm" />
+          </:cta>
+        </OSS::Stats::Banner>
+
+        <OSS::Stats::Banner
+          class="demo-stats-banner demo-stats-banner--sm"
+          @badge={{hash icon="fa-star" skin="primary"}}
+          @titleConfig={{hash text="Commissions"}}
+          @statValue="$5,920"
+          @statExtraInfo="to authorize"
+        >
+          <:cta>
+            <OSS::Button @skin="primary" @label="Pay" @size="sm" />
+          </:cta>
+        </OSS::Stats::Banner>
+      </div>
+
+      <OSS::Stats::Banner
+        class="demo-stats-banner"
+        @loading={{true}}
+        @badge={{hash icon="fa-check" skin="success"}}
+        @titleConfig={{hash text="Loading stats banner title" infoCircle="Helpful title information"}}
+        @statValue="123,456"
+        @statExtraInfo="Potatoes"
+      >
+        <:extra-badges>
+          <OSS::Badge @text="2x" @size="lg" />
+        </:extra-badges>
+      </OSS::Stats::Banner>
+    </div>
+  </div>
+
 </div>

--- a/tests/dummy/app/templates/data.hbs
+++ b/tests/dummy/app/templates/data.hbs
@@ -277,9 +277,11 @@
           text="Very long stats banner title that should truncate with ellipsis when the available width becomes too small"
           infoCircle="This is a helpful description of the stat"
         }}
-        @statValue="123,456"
-        @statExtraInfo="Extra info"
-        @extraInfoTagConfig={{hash label="New" skin="success" icon="fa-sparkles"}}
+        @statValue={{hash
+          label="123,456"
+          suffix="Extra info"
+          tags=(array (hash label="New" skin="success" icon="fa-sparkles"))
+        }}
       >
         <:title-suffix>
           <OSS::ButtonDropdown @icon="fa-caret-down" @hideArrow={{true}} @square={{true}} @size="sm">
@@ -307,8 +309,7 @@
           text="Another intentionally long stats banner title to validate truncation next to the info-circle icon"
           infoCircle="This stat title also has helpful context"
         }}
-        @statValue="123,456"
-        @statExtraInfo="Potatoes"
+        @statValue={{hash label="123,456" suffix="Potatoes"}}
       />
 
       <div class="demo-stats-banner-row fx-row fx-gap-px-12">
@@ -316,8 +317,7 @@
           class="demo-stats-banner demo-stats-banner--sm"
           @badge={{hash icon="fa-check" skin="success"}}
           @titleConfig={{hash text="Revenue"}}
-          @statValue="$12,493"
-          @statExtraInfo="vs last month"
+          @statValue={{hash label="$12,493" suffix="vs last month"}}
         >
           <:cta>
             <OSS::Button @skin="secondary" @label="Details" @size="sm" />
@@ -328,8 +328,7 @@
           class="demo-stats-banner demo-stats-banner--sm"
           @badge={{hash icon="fa-star" skin="primary"}}
           @titleConfig={{hash text="Commissions"}}
-          @statValue="$5,920"
-          @statExtraInfo="to authorize"
+          @statValue={{hash label="$5,920" suffix="to authorize"}}
         >
           <:cta>
             <OSS::Button @skin="primary" @label="Pay" @size="sm" />
@@ -340,8 +339,7 @@
           class="demo-stats-banner demo-stats-banner--sm"
           @badge={{hash icon="fa-star" skin="primary"}}
           @titleConfig={{hash text="Commissions"}}
-          @statValue="$5,920"
-          @statExtraInfo="to authorize"
+          @statValue={{hash label="$5,920" suffix="to authorize"}}
         >
           <:cta>
             <OSS::Button @skin="primary" @label="Pay" @size="sm" />
@@ -354,8 +352,7 @@
         @loading={{true}}
         @badge={{hash icon="fa-check" skin="success"}}
         @titleConfig={{hash text="Loading stats banner title" infoCircle="Helpful title information"}}
-        @statValue="123,456"
-        @statExtraInfo="Potatoes"
+        @statValue={{hash label="123,456" suffix="Potatoes"}}
       >
         <:extra-badges>
           <OSS::Badge @text="2x" @size="lg" />

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -230,6 +230,33 @@
     class="fx-col fx-1 background-color-white border border-color-default border-radius-md padding-px-12 fx-gap-px-12"
   >
     <div class="font-size-md font-weight-semibold">
+      Stats banner
+    </div>
+    <div class="fx-col fx-gap-px-24">
+      <OSS::Stats::Banner
+        class="demo-stats-banner"
+        @badgeIcon="fa-check"
+        @badgeSkin="success"
+        @title="Title"
+        @statValue="123,456"
+        @statExtraInfo="Extra info"
+      >
+        <:extra-badges>
+          <OSS::Badge @text="2x" @size="lg" />
+        </:extra-badges>
+        <:cta>
+          <OSS::Button @skin="primary" @label="CTA" @icon="fas fa-box-open" @size="md" />
+        </:cta>
+      </OSS::Stats::Banner>
+
+      <OSS::Stats::Banner class="demo-stats-banner" @loading={{true}} />
+    </div>
+  </div>
+
+  <div
+    class="fx-col fx-1 background-color-white border border-color-default border-radius-md padding-px-12 fx-gap-px-12"
+  >
+    <div class="font-size-md font-weight-semibold">
       Banner
     </div>
     <div class="fx-col fx-gap-px-24">

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -235,13 +235,13 @@
     <div class="fx-col fx-gap-px-24">
       <OSS::Stats::Banner
         class="demo-stats-banner"
-        @badge={{hash icon="fa-check" skin="success"}}
-        @extraIcon={{hash icon="fa-star"}}
-        @title="Title"
-        @titleInfo="This is a helpful description of the stat"
+        @badgeConfig={{hash icon="fa-check" skin="success"}}
+        @extraIconConfig={{hash icon="fa-star"}}
+        @title="Very long stats banner title that should truncate with ellipsis when the available width becomes too small"
+        @titleInfoCircle="This is a helpful description of the stat"
         @statValue="123,456"
         @statExtraInfo="Extra info"
-        @extraInfoTag={{hash label="New" skin="success" icon="fa-sparkles"}}
+        @extraInfoTagConfig={{hash label="New" skin="success" icon="fa-sparkles"}}
       >
         <:dropdown>
           <OSS::ButtonDropdown @icon="fa-caret-down" @hideArrow={{true}} @square={{true}} @size="sm">
@@ -261,12 +261,29 @@
 
       <OSS::Stats::Banner
         class="demo-stats-banner"
-        @badge={{hash icon="fa-check" skin="success"}}
-        @loading={{true}}
-        @title="Title"
+        @badgeConfig={{hash icon="fa-check" skin="success"}}
+        @title="Another intentionally long stats banner title to validate truncation next to the info-circle icon"
+        @titleInfoCircle="This stat title also has helpful context"
         @statValue="123,456"
-        @statInfo="Potatoes"
+        @statExtraInfo="Potatoes"
       />
+
+      <OSS::Stats::Banner
+        class="demo-stats-banner"
+        @loading={{true}}
+        @badgeConfig={{hash icon="fa-check" skin="success"}}
+        @title="Loading stats banner title"
+        @titleInfoCircle="Helpful title information"
+        @statValue="123,456"
+        @statExtraInfo="Potatoes"
+      >
+        <:extra-badges>
+          <OSS::Badge @text="2x" @size="lg" />
+        </:extra-badges>
+        <:cta>
+          <OSS::Button @skin="primary" @label="CTA" @icon="fas fa-box-open" @size="md" />
+        </:cta>
+      </OSS::Stats::Banner>
     </div>
   </div>
 

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -235,12 +235,22 @@
     <div class="fx-col fx-gap-px-24">
       <OSS::Stats::Banner
         class="demo-stats-banner"
-        @badgeIcon="fa-check"
-        @badgeSkin="success"
+        @badge={{hash icon="fa-check" skin="success"}}
+        @extraIcon={{hash icon="fa-star"}}
         @title="Title"
+        @titleInfo="This is a helpful description of the stat"
         @statValue="123,456"
         @statExtraInfo="Extra info"
+        @extraInfoTag={{hash label="New" skin="success" icon="fa-sparkles"}}
       >
+        <:dropdown>
+          <OSS::ButtonDropdown @icon="fa-caret-down" @hideArrow={{true}} @square={{true}} @size="sm">
+            <:items>
+              <div class="oss-button-dropdown__item" role="button" {{on "click" this.noop}}>Option A</div>
+              <div class="oss-button-dropdown__item" role="button" {{on "click" this.noop}}>Option B</div>
+            </:items>
+          </OSS::ButtonDropdown>
+        </:dropdown>
         <:extra-badges>
           <OSS::Badge @text="2x" @size="lg" />
         </:extra-badges>
@@ -249,7 +259,14 @@
         </:cta>
       </OSS::Stats::Banner>
 
-      <OSS::Stats::Banner class="demo-stats-banner" @loading={{true}} />
+      <OSS::Stats::Banner
+        class="demo-stats-banner"
+        @badge={{hash icon="fa-check" skin="success"}}
+        @loading={{true}}
+        @title="Title"
+        @statValue="123,456"
+        @statInfo="Potatoes"
+      />
     </div>
   </div>
 

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -230,67 +230,6 @@
     class="fx-col fx-1 background-color-white border border-color-default border-radius-md padding-px-12 fx-gap-px-12"
   >
     <div class="font-size-md font-weight-semibold">
-      Stats banner
-    </div>
-    <div class="fx-col fx-gap-px-24">
-      <OSS::Stats::Banner
-        class="demo-stats-banner"
-        @badgeConfig={{hash icon="fa-check" skin="success"}}
-        @extraIconConfig={{hash icon="fa-star"}}
-        @title="Very long stats banner title that should truncate with ellipsis when the available width becomes too small"
-        @titleInfoCircle="This is a helpful description of the stat"
-        @statValue="123,456"
-        @statExtraInfo="Extra info"
-        @extraInfoTagConfig={{hash label="New" skin="success" icon="fa-sparkles"}}
-      >
-        <:dropdown>
-          <OSS::ButtonDropdown @icon="fa-caret-down" @hideArrow={{true}} @square={{true}} @size="sm">
-            <:items>
-              <div class="oss-button-dropdown__item" role="button" {{on "click" this.noop}}>Option A</div>
-              <div class="oss-button-dropdown__item" role="button" {{on "click" this.noop}}>Option B</div>
-            </:items>
-          </OSS::ButtonDropdown>
-        </:dropdown>
-        <:extra-badges>
-          <OSS::Badge @text="2x" @size="lg" />
-        </:extra-badges>
-        <:cta>
-          <OSS::Button @skin="primary" @label="CTA" @icon="fas fa-box-open" @size="md" />
-        </:cta>
-      </OSS::Stats::Banner>
-
-      <OSS::Stats::Banner
-        class="demo-stats-banner"
-        @badgeConfig={{hash icon="fa-check" skin="success"}}
-        @title="Another intentionally long stats banner title to validate truncation next to the info-circle icon"
-        @titleInfoCircle="This stat title also has helpful context"
-        @statValue="123,456"
-        @statExtraInfo="Potatoes"
-      />
-
-      <OSS::Stats::Banner
-        class="demo-stats-banner"
-        @loading={{true}}
-        @badgeConfig={{hash icon="fa-check" skin="success"}}
-        @title="Loading stats banner title"
-        @titleInfoCircle="Helpful title information"
-        @statValue="123,456"
-        @statExtraInfo="Potatoes"
-      >
-        <:extra-badges>
-          <OSS::Badge @text="2x" @size="lg" />
-        </:extra-badges>
-        <:cta>
-          <OSS::Button @skin="primary" @label="CTA" @icon="fas fa-box-open" @size="md" />
-        </:cta>
-      </OSS::Stats::Banner>
-    </div>
-  </div>
-
-  <div
-    class="fx-col fx-1 background-color-white border border-color-default border-radius-md padding-px-12 fx-gap-px-12"
-  >
-    <div class="font-size-md font-weight-semibold">
       Banner
     </div>
     <div class="fx-col fx-gap-px-24">

--- a/tests/integration/components/o-s-s/stats/banner-test.ts
+++ b/tests/integration/components/o-s-s/stats/banner-test.ts
@@ -37,10 +37,6 @@ module('Integration | Component | o-s-s/stats/banner', function (hooks) {
         @statValue={{this.statValue}}
         @statExtraInfo={{this.statExtraInfo}}
       >
-        <:badges>
-          <OSS::Badge @text="TXT" @skin="primary" @size="sm" />
-        </:badges>
-
         <:extra-badges>
           <div class="test-extra-badges">Extra badges</div>
         </:extra-badges>
@@ -51,31 +47,68 @@ module('Integration | Component | o-s-s/stats/banner', function (hooks) {
       </OSS::Stats::Banner>
     `);
 
-    assert.dom('.oss-stats-banner__skeleton--badge').exists();
     assert.dom('.oss-stats-banner__skeleton--title').exists();
     assert.dom('.oss-stats-banner__skeleton--extra-badge').exists({ count: 2 });
     assert.dom('.oss-stats-banner__skeleton--stat-value').exists();
     assert.dom('.oss-stats-banner__skeleton--stat-extra').exists();
     assert.dom('.oss-stats-banner__skeleton--cta').exists();
-    assert.dom('.oss-stats-banner .upf-badge').doesNotExist();
     assert.dom('.test-extra-badges').doesNotExist();
     assert.dom('.test-cta').doesNotExist();
   });
 
-  test('when @loading is false and badges block is defined, it renders block content instead of badge skeleton', async function (assert) {
+  test('when @badge is defined and @loading is false, it renders the badge and no skeleton', async function (assert) {
     await render(hbs`
-      <OSS::Stats::Banner @loading={{false}}>
-        <:badges>
-          <OSS::Badge @text="TXT" @skin="primary" @size="sm" />
-        </:badges>
-      </OSS::Stats::Banner>
+      <OSS::Stats::Banner @loading={{false}} @badge={{hash text="TXT" skin="primary" size="sm"}} />
     `);
 
     assert.dom('.oss-stats-banner .upf-badge').exists();
     assert.dom('.oss-stats-banner .upf-badge .upf-badge__text').hasText('TXT');
     assert.dom('.oss-stats-banner .upf-badge').hasClass('upf-badge--primary');
-    assert.dom('.oss-stats-banner .upf-badge').hasClass('upf-badge--size-sm');
     assert.dom('.oss-stats-banner__skeleton--badge').doesNotExist();
+  });
+
+  test('when @badge is defined and @loading is true, it still renders the badge', async function (assert) {
+    await render(hbs`
+      <OSS::Stats::Banner @loading={{true}} @badge={{hash text="TXT" skin="primary" size="sm"}} />
+    `);
+
+    assert.dom('.oss-stats-banner .upf-badge').exists();
+  });
+
+  test('when @extraIcon is defined, it renders the icon next to the badge', async function (assert) {
+    await render(hbs`
+      <OSS::Stats::Banner @badge={{hash icon="fa-check" skin="success"}} @extraIcon={{hash icon="fa-star"}} />
+    `);
+
+    assert.dom('.oss-stats-banner .fa-star').exists();
+  });
+
+  test('when @extraIcon has a color, it applies the color as inline style', async function (assert) {
+    await render(hbs`
+      <OSS::Stats::Banner @badge={{hash icon="fa-check" skin="success"}} @extraIcon={{hash icon="fa-star" color="red"}} />
+    `);
+
+    assert.dom('.oss-stats-banner .fa-star').hasAttribute('style', 'color:red');
+  });
+
+  test('when @titleInfo is defined, it renders an info-circle icon next to the title', async function (assert) {
+    await render(hbs`
+      <OSS::Stats::Banner @title="My stat" @titleInfo="Helpful description" />
+    `);
+
+    assert.dom('.oss-stats-banner .fa-circle-info').exists();
+  });
+
+  test('when the dropdown block is defined, it renders its content in the title row', async function (assert) {
+    await render(hbs`
+      <OSS::Stats::Banner @title="My stat">
+        <:dropdown>
+          <div class="test-dropdown">Dropdown</div>
+        </:dropdown>
+      </OSS::Stats::Banner>
+    `);
+
+    assert.dom('.oss-stats-banner .test-dropdown').exists();
   });
 
   test('when @loading is false and title/stat values are defined, it renders text instead of skeletons', async function (assert) {
@@ -121,11 +154,7 @@ module('Integration | Component | o-s-s/stats/banner', function (hooks) {
 
   test('it renders content, cta and extra-badges named blocks and hides related skeletons when @loading is false', async function (assert) {
     await render(hbs`
-      <OSS::Stats::Banner @loading={{false}}>
-        <:badges>
-          <OSS::Badge @text="TXT" @skin="primary" @size="sm" />
-        </:badges>
-
+      <OSS::Stats::Banner @loading={{false}} @badge={{hash text="TXT" skin="primary" size="sm"}}>
         <:content>
           <div class="test-content">Content</div>
         </:content>
@@ -144,8 +173,8 @@ module('Integration | Component | o-s-s/stats/banner', function (hooks) {
     assert.dom('.test-extra-badges').exists();
     assert.dom('.test-cta').exists();
     assert.dom('.oss-stats-banner .upf-badge').exists();
-    assert.dom('.oss-stats-banner__skeleton--title').doesNotExist();
     assert.dom('.oss-stats-banner__skeleton--badge').doesNotExist();
+    assert.dom('.oss-stats-banner__skeleton--title').doesNotExist();
     assert.dom('.oss-stats-banner__skeleton--extra-badge').doesNotExist();
     assert.dom('.oss-stats-banner__skeleton--cta').doesNotExist();
   });

--- a/tests/integration/components/o-s-s/stats/banner-test.ts
+++ b/tests/integration/components/o-s-s/stats/banner-test.ts
@@ -139,26 +139,9 @@ module('Integration | Component | o-s-s/stats/banner', function (hooks) {
     assert.dom('.oss-stats-banner__skeleton--cta').doesNotExist();
   });
 
-  test('when @loading is true and only a content block is defined, it does not render a title skeleton', async function (assert) {
-    await render(hbs`
-      <OSS::Stats::Banner @loading={{true}}>
-        <:content>
-          <div class="test-content">Content</div>
-        </:content>
-      </OSS::Stats::Banner>
-    `);
-
-    assert.dom('.test-content').exists();
-    assert.dom('.oss-stats-banner__skeleton--title').doesNotExist();
-  });
-
-  test('it renders content, cta and extra-badges named blocks and hides related skeletons when @loading is false', async function (assert) {
+  test('it renders cta and extra-badges named blocks and hides related skeletons when @loading is false', async function (assert) {
     await render(hbs`
       <OSS::Stats::Banner @loading={{false}} @badgeConfig={{hash text="TXT" skin="primary" size="sm"}}>
-        <:content>
-          <div class="test-content">Content</div>
-        </:content>
-
         <:extra-badges>
           <div class="test-extra-badges">Extra badges</div>
         </:extra-badges>
@@ -169,7 +152,6 @@ module('Integration | Component | o-s-s/stats/banner', function (hooks) {
       </OSS::Stats::Banner>
     `);
 
-    assert.dom('.test-content').exists();
     assert.dom('.test-extra-badges').exists();
     assert.dom('.test-cta').exists();
     assert.dom('.oss-stats-banner .upf-badge').exists();

--- a/tests/integration/components/o-s-s/stats/banner-test.ts
+++ b/tests/integration/components/o-s-s/stats/banner-test.ts
@@ -14,150 +14,170 @@ module('Integration | Component | o-s-s/stats/banner', function (hooks) {
     assert.dom('.oss-stats-banner__bottom_content').exists();
   });
 
-  test('when @loading is true and no related args or blocks are defined, it renders title/stat skeletons', async function (assert) {
-    await render(hbs`<OSS::Stats::Banner @loading={{true}} />`);
+  module('Loading state handling', function () {
+    test('when @loading is true and no related args or blocks are defined, it renders title/stat skeletons', async function (assert) {
+      await render(hbs`<OSS::Stats::Banner @loading={{true}} />`);
 
-    assert.dom('.oss-stats-banner__skeleton--badge').doesNotExist();
-    assert.dom('.oss-stats-banner__skeleton--title').exists();
-    assert.dom('.oss-stats-banner__skeleton--extra-badge').doesNotExist();
-    assert.dom('.oss-stats-banner__skeleton--stat-value').exists();
-    assert.dom('.oss-stats-banner__skeleton--stat-extra').doesNotExist();
-    assert.dom('.oss-stats-banner__skeleton--cta').doesNotExist();
+      assert.dom('.oss-stats-banner__skeleton--badge').doesNotExist();
+      assert.dom('.oss-stats-banner__skeleton--title').exists();
+      assert.dom('.oss-stats-banner__skeleton--extra-badge').doesNotExist();
+      assert.dom('.oss-stats-banner__skeleton--stat-value').exists();
+      assert.dom('.oss-stats-banner__skeleton--stat-extra').exists();
+      assert.dom('.oss-stats-banner__skeleton--cta').doesNotExist();
+    });
+
+    test('when @loading is true, it renders title/stat skeletons and hides named block content', async function (assert) {
+      this.title = 'Stats title';
+      this.statValue = '$5,920';
+      this.statExtraInfo = 'supplementary info';
+
+      await render(hbs`
+        <OSS::Stats::Banner
+          @loading={{true}}
+          @title={{this.title}}
+          @statValue={{this.statValue}}
+          @statExtraInfo={{this.statExtraInfo}}
+        >
+          <:extra-badges>
+            <div class="test-extra-badges">Extra badges</div>
+          </:extra-badges>
+
+          <:cta>
+            <button type="button" class="test-cta">CTA</button>
+          </:cta>
+        </OSS::Stats::Banner>
+      `);
+
+      assert.dom('.oss-stats-banner__skeleton--title').exists();
+      assert.dom('.oss-stats-banner__skeleton--stat-value').exists();
+      assert.dom('.oss-stats-banner__skeleton--extra-badge').doesNotExist();
+      assert.dom('.oss-stats-banner__skeleton--stat-extra').exists();
+      assert.dom('.oss-stats-banner__skeleton--cta').doesNotExist();
+      assert.dom('.test-extra-badges').doesNotExist();
+      assert.dom('.test-cta').doesNotExist();
+    });
+
+    test('when @loading is false and title/stat values are defined, it renders text instead of skeletons', async function (assert) {
+      this.title = 'Stats title';
+      this.statValue = '$5,920';
+      this.statExtraInfo = 'supplementary info';
+
+      await render(
+        hbs`<OSS::Stats::Banner @loading={{false}} @title={{this.title}} @statValue={{this.statValue}} @statExtraInfo={{this.statExtraInfo}} />`
+      );
+
+      assert.dom('.oss-stats-banner__content').hasText('Stats title');
+      assert.dom('.oss-stats-banner__stat').includesText('$5,920');
+      assert.dom('.oss-stats-banner__stat').includesText('supplementary info');
+      assert.dom('.oss-stats-banner__skeleton--title').doesNotExist();
+      assert.dom('.oss-stats-banner__skeleton--stat-value').doesNotExist();
+      assert.dom('.oss-stats-banner__skeleton--stat-extra').doesNotExist();
+    });
+
+    test('when @loading is false and no field is defined, it does not render skeletons', async function (assert) {
+      await render(hbs`<OSS::Stats::Banner @loading={{false}} />`);
+
+      assert.dom('.oss-stats-banner__skeleton--badge').doesNotExist();
+      assert.dom('.oss-stats-banner__skeleton--title').doesNotExist();
+      assert.dom('.oss-stats-banner__skeleton--extra-badge').doesNotExist();
+      assert.dom('.oss-stats-banner__skeleton--stat-value').doesNotExist();
+      assert.dom('.oss-stats-banner__skeleton--stat-extra').doesNotExist();
+      assert.dom('.oss-stats-banner__skeleton--cta').doesNotExist();
+    });
   });
 
-  test('when @loading is true, it renders title/stat skeletons and hides named block content', async function (assert) {
-    this.title = 'Stats title';
-    this.statValue = '$5,920';
-    this.statExtraInfo = 'supplementary info';
+  module('Badge and icon handling', function () {
+    test('when @badgeConfig is defined and @loading is false, it renders the badge and no skeleton', async function (assert) {
+      await render(hbs`
+        <OSS::Stats::Banner @loading={{false}} @badgeConfig={{hash text="TXT" skin="primary" size="sm"}} />
+      `);
 
-    await render(hbs`
-      <OSS::Stats::Banner
-        @loading={{true}}
-        @title={{this.title}}
-        @statValue={{this.statValue}}
-        @statExtraInfo={{this.statExtraInfo}}
-      >
-        <:extra-badges>
-          <div class="test-extra-badges">Extra badges</div>
-        </:extra-badges>
+      assert.dom('.oss-stats-banner .upf-badge').exists();
+      assert.dom('.oss-stats-banner .upf-badge .upf-badge__text').hasText('TXT');
+      assert.dom('.oss-stats-banner .upf-badge').hasClass('upf-badge--primary');
+      assert.dom('.oss-stats-banner__skeleton--badge').doesNotExist();
+    });
 
-        <:cta>
-          <button type="button" class="test-cta">CTA</button>
-        </:cta>
-      </OSS::Stats::Banner>
-    `);
+    test('when @badgeConfig is defined and @loading is true, it still renders the badge', async function (assert) {
+      await render(hbs`
+        <OSS::Stats::Banner @loading={{true}} @badgeConfig={{hash text="TXT" skin="primary" size="sm"}} />
+      `);
 
-    assert.dom('.oss-stats-banner__skeleton--title').exists();
-    assert.dom('.oss-stats-banner__skeleton--stat-value').exists();
-    assert.dom('.oss-stats-banner__skeleton--extra-badge').doesNotExist();
-    assert.dom('.oss-stats-banner__skeleton--stat-extra').doesNotExist();
-    assert.dom('.oss-stats-banner__skeleton--cta').doesNotExist();
-    assert.dom('.test-extra-badges').doesNotExist();
-    assert.dom('.test-cta').doesNotExist();
+      assert.dom('.oss-stats-banner .upf-badge').exists();
+    });
+
+    test('when @extraIconConfig is defined, it renders the icon next to the badge', async function (assert) {
+      await render(hbs`
+        <OSS::Stats::Banner @badgeConfig={{hash icon="fa-check" skin="success"}} @extraIconConfig={{hash icon="fa-star"}} />
+      `);
+
+      assert.dom('.oss-stats-banner .fa-star').exists();
+    });
+
+    test('when @extraIconConfig has a color, it applies the color as inline style', async function (assert) {
+      await render(hbs`
+        <OSS::Stats::Banner @badgeConfig={{hash icon="fa-check" skin="success"}} @extraIconConfig={{hash icon="fa-star" color="red"}} />
+      `);
+
+      assert.dom('.oss-stats-banner .fa-star').hasAttribute('style', 'color:red');
+    });
   });
 
-  test('when @badgeConfig is defined and @loading is false, it renders the badge and no skeleton', async function (assert) {
-    await render(hbs`
-      <OSS::Stats::Banner @loading={{false}} @badgeConfig={{hash text="TXT" skin="primary" size="sm"}} />
-    `);
+  module('Title actions handling', function () {
+    test('when @titleInfoCircle is defined, it renders an info-circle icon next to the title', async function (assert) {
+      await render(hbs`
+        <OSS::Stats::Banner @title="My stat" @titleInfoCircle="Helpful description" />
+      `);
 
-    assert.dom('.oss-stats-banner .upf-badge').exists();
-    assert.dom('.oss-stats-banner .upf-badge .upf-badge__text').hasText('TXT');
-    assert.dom('.oss-stats-banner .upf-badge').hasClass('upf-badge--primary');
-    assert.dom('.oss-stats-banner__skeleton--badge').doesNotExist();
+      assert.dom('.oss-stats-banner .fa-info-circle').exists();
+    });
+
+    test('when @titleInfoCircle is not defined, it does not render an info-circle icon', async function (assert) {
+      await render(hbs`<OSS::Stats::Banner @title="My stat" />`);
+
+      assert.dom('.oss-stats-banner .fa-info-circle').doesNotExist();
+    });
+
+    test('when the dropdown block is defined, it renders its content in the title row', async function (assert) {
+      await render(hbs`
+        <OSS::Stats::Banner @title="My stat">
+          <:dropdown>
+            <div class="test-dropdown">Dropdown</div>
+          </:dropdown>
+        </OSS::Stats::Banner>
+      `);
+
+      assert.dom('.oss-stats-banner .test-dropdown').exists();
+    });
+
+    test('when the dropdown block is not defined, it does not render dropdown content', async function (assert) {
+      await render(hbs`<OSS::Stats::Banner @title="My stat" />`);
+
+      assert.dom('.oss-stats-banner .test-dropdown').doesNotExist();
+    });
   });
 
-  test('when @badgeConfig is defined and @loading is true, it still renders the badge', async function (assert) {
-    await render(hbs`
-      <OSS::Stats::Banner @loading={{true}} @badgeConfig={{hash text="TXT" skin="primary" size="sm"}} />
-    `);
+  module('Named blocks handling', function () {
+    test('when @loading is false, it renders cta and extra-badges named blocks', async function (assert) {
+      await render(hbs`
+        <OSS::Stats::Banner @loading={{false}} @badgeConfig={{hash text="TXT" skin="primary" size="sm"}}>
+          <:extra-badges>
+            <div class="test-extra-badges">Extra badges</div>
+          </:extra-badges>
 
-    assert.dom('.oss-stats-banner .upf-badge').exists();
-  });
+          <:cta>
+            <button type="button" class="test-cta">CTA</button>
+          </:cta>
+        </OSS::Stats::Banner>
+      `);
 
-  test('when @extraIconConfig is defined, it renders the icon next to the badge', async function (assert) {
-    await render(hbs`
-      <OSS::Stats::Banner @badgeConfig={{hash icon="fa-check" skin="success"}} @extraIconConfig={{hash icon="fa-star"}} />
-    `);
-
-    assert.dom('.oss-stats-banner .fa-star').exists();
-  });
-
-  test('when @extraIconConfig has a color, it applies the color as inline style', async function (assert) {
-    await render(hbs`
-      <OSS::Stats::Banner @badgeConfig={{hash icon="fa-check" skin="success"}} @extraIconConfig={{hash icon="fa-star" color="red"}} />
-    `);
-
-    assert.dom('.oss-stats-banner .fa-star').hasAttribute('style', 'color:red');
-  });
-
-  test('when @titleInfoCircle is defined, it renders an info-circle icon next to the title', async function (assert) {
-    await render(hbs`
-      <OSS::Stats::Banner @title="My stat" @titleInfoCircle="Helpful description" />
-    `);
-
-    assert.dom('.oss-stats-banner .fa-info-circle').exists();
-  });
-
-  test('when the dropdown block is defined, it renders its content in the title row', async function (assert) {
-    await render(hbs`
-      <OSS::Stats::Banner @title="My stat">
-        <:dropdown>
-          <div class="test-dropdown">Dropdown</div>
-        </:dropdown>
-      </OSS::Stats::Banner>
-    `);
-
-    assert.dom('.oss-stats-banner .test-dropdown').exists();
-  });
-
-  test('when @loading is false and title/stat values are defined, it renders text instead of skeletons', async function (assert) {
-    this.title = 'Stats title';
-    this.statValue = '$5,920';
-    this.statExtraInfo = 'supplementary info';
-
-    await render(
-      hbs`<OSS::Stats::Banner @loading={{false}} @title={{this.title}} @statValue={{this.statValue}} @statExtraInfo={{this.statExtraInfo}} />`
-    );
-
-    assert.dom('.oss-stats-banner__content').hasText('Stats title');
-    assert.dom('.oss-stats-banner__stat').includesText('$5,920');
-    assert.dom('.oss-stats-banner__stat').includesText('supplementary info');
-    assert.dom('.oss-stats-banner__skeleton--title').doesNotExist();
-    assert.dom('.oss-stats-banner__skeleton--stat-value').doesNotExist();
-    assert.dom('.oss-stats-banner__skeleton--stat-extra').doesNotExist();
-  });
-
-  test('when @loading is false and no field is defined, it does not render skeletons', async function (assert) {
-    await render(hbs`<OSS::Stats::Banner @loading={{false}} />`);
-
-    assert.dom('.oss-stats-banner__skeleton--badge').doesNotExist();
-    assert.dom('.oss-stats-banner__skeleton--title').doesNotExist();
-    assert.dom('.oss-stats-banner__skeleton--extra-badge').doesNotExist();
-    assert.dom('.oss-stats-banner__skeleton--stat-value').doesNotExist();
-    assert.dom('.oss-stats-banner__skeleton--stat-extra').doesNotExist();
-    assert.dom('.oss-stats-banner__skeleton--cta').doesNotExist();
-  });
-
-  test('it renders cta and extra-badges named blocks and hides related skeletons when @loading is false', async function (assert) {
-    await render(hbs`
-      <OSS::Stats::Banner @loading={{false}} @badgeConfig={{hash text="TXT" skin="primary" size="sm"}}>
-        <:extra-badges>
-          <div class="test-extra-badges">Extra badges</div>
-        </:extra-badges>
-
-        <:cta>
-          <button type="button" class="test-cta">CTA</button>
-        </:cta>
-      </OSS::Stats::Banner>
-    `);
-
-    assert.dom('.test-extra-badges').exists();
-    assert.dom('.test-cta').exists();
-    assert.dom('.oss-stats-banner .upf-badge').exists();
-    assert.dom('.oss-stats-banner__skeleton--badge').doesNotExist();
-    assert.dom('.oss-stats-banner__skeleton--title').doesNotExist();
-    assert.dom('.oss-stats-banner__skeleton--extra-badge').doesNotExist();
-    assert.dom('.oss-stats-banner__skeleton--cta').doesNotExist();
+      assert.dom('.test-extra-badges').exists();
+      assert.dom('.test-cta').exists();
+      assert.dom('.oss-stats-banner .upf-badge').exists();
+      assert.dom('.oss-stats-banner__skeleton--badge').doesNotExist();
+      assert.dom('.oss-stats-banner__skeleton--title').doesNotExist();
+      assert.dom('.oss-stats-banner__skeleton--extra-badge').doesNotExist();
+      assert.dom('.oss-stats-banner__skeleton--cta').doesNotExist();
+    });
   });
 });

--- a/tests/integration/components/o-s-s/stats/banner-test.ts
+++ b/tests/integration/components/o-s-s/stats/banner-test.ts
@@ -56,9 +56,9 @@ module('Integration | Component | o-s-s/stats/banner', function (hooks) {
     assert.dom('.test-cta').doesNotExist();
   });
 
-  test('when @badge is defined and @loading is false, it renders the badge and no skeleton', async function (assert) {
+  test('when @badgeConfig is defined and @loading is false, it renders the badge and no skeleton', async function (assert) {
     await render(hbs`
-      <OSS::Stats::Banner @loading={{false}} @badge={{hash text="TXT" skin="primary" size="sm"}} />
+      <OSS::Stats::Banner @loading={{false}} @badgeConfig={{hash text="TXT" skin="primary" size="sm"}} />
     `);
 
     assert.dom('.oss-stats-banner .upf-badge').exists();
@@ -67,36 +67,36 @@ module('Integration | Component | o-s-s/stats/banner', function (hooks) {
     assert.dom('.oss-stats-banner__skeleton--badge').doesNotExist();
   });
 
-  test('when @badge is defined and @loading is true, it still renders the badge', async function (assert) {
+  test('when @badgeConfig is defined and @loading is true, it still renders the badge', async function (assert) {
     await render(hbs`
-      <OSS::Stats::Banner @loading={{true}} @badge={{hash text="TXT" skin="primary" size="sm"}} />
+      <OSS::Stats::Banner @loading={{true}} @badgeConfig={{hash text="TXT" skin="primary" size="sm"}} />
     `);
 
     assert.dom('.oss-stats-banner .upf-badge').exists();
   });
 
-  test('when @extraIcon is defined, it renders the icon next to the badge', async function (assert) {
+  test('when @extraIconConfig is defined, it renders the icon next to the badge', async function (assert) {
     await render(hbs`
-      <OSS::Stats::Banner @badge={{hash icon="fa-check" skin="success"}} @extraIcon={{hash icon="fa-star"}} />
+      <OSS::Stats::Banner @badgeConfig={{hash icon="fa-check" skin="success"}} @extraIconConfig={{hash icon="fa-star"}} />
     `);
 
     assert.dom('.oss-stats-banner .fa-star').exists();
   });
 
-  test('when @extraIcon has a color, it applies the color as inline style', async function (assert) {
+  test('when @extraIconConfig has a color, it applies the color as inline style', async function (assert) {
     await render(hbs`
-      <OSS::Stats::Banner @badge={{hash icon="fa-check" skin="success"}} @extraIcon={{hash icon="fa-star" color="red"}} />
+      <OSS::Stats::Banner @badgeConfig={{hash icon="fa-check" skin="success"}} @extraIconConfig={{hash icon="fa-star" color="red"}} />
     `);
 
     assert.dom('.oss-stats-banner .fa-star').hasAttribute('style', 'color:red');
   });
 
-  test('when @titleInfo is defined, it renders an info-circle icon next to the title', async function (assert) {
+  test('when @titleInfoCircle is defined, it renders an info-circle icon next to the title', async function (assert) {
     await render(hbs`
-      <OSS::Stats::Banner @title="My stat" @titleInfo="Helpful description" />
+      <OSS::Stats::Banner @title="My stat" @titleInfoCircle="Helpful description" />
     `);
 
-    assert.dom('.oss-stats-banner .fa-circle-info').exists();
+    assert.dom('.oss-stats-banner .fa-info-circle').exists();
   });
 
   test('when the dropdown block is defined, it renders its content in the title row', async function (assert) {
@@ -154,7 +154,7 @@ module('Integration | Component | o-s-s/stats/banner', function (hooks) {
 
   test('it renders content, cta and extra-badges named blocks and hides related skeletons when @loading is false', async function (assert) {
     await render(hbs`
-      <OSS::Stats::Banner @loading={{false}} @badge={{hash text="TXT" skin="primary" size="sm"}}>
+      <OSS::Stats::Banner @loading={{false}} @badgeConfig={{hash text="TXT" skin="primary" size="sm"}}>
         <:content>
           <div class="test-content">Content</div>
         </:content>

--- a/tests/integration/components/o-s-s/stats/banner-test.ts
+++ b/tests/integration/components/o-s-s/stats/banner-test.ts
@@ -7,7 +7,7 @@ module('Integration | Component | o-s-s/stats/banner', function (hooks) {
   setupRenderingTest(hooks);
 
   test('it renders', async function (assert) {
-    await render(hbs`<OSS::Stats::Banner />`);
+    await render(hbs`<OSS::Stats::Banner @titleConfig={{hash text="My stat"}} />`);
 
     assert.dom('.oss-stats-banner').exists();
     assert.dom('.oss-stats-banner__header').exists();
@@ -16,7 +16,7 @@ module('Integration | Component | o-s-s/stats/banner', function (hooks) {
 
   module('Loading state handling', function () {
     test('when @loading is true and no related args or blocks are defined, it renders title/stat skeletons', async function (assert) {
-      await render(hbs`<OSS::Stats::Banner @loading={{true}} />`);
+      await render(hbs`<OSS::Stats::Banner @loading={{true}} @titleConfig={{hash text="My stat"}} />`);
 
       assert.dom('.oss-stats-banner__skeleton--badge').doesNotExist();
       assert.dom('.oss-stats-banner__skeleton--title').exists();
@@ -33,17 +33,13 @@ module('Integration | Component | o-s-s/stats/banner', function (hooks) {
       await render(hbs`
         <OSS::Stats::Banner
           @loading={{true}}
-          @title={{this.title}}
+          @titleConfig={{hash text=this.title}}
           @statValue={{this.statValue}}
           @statExtraInfo={{this.statExtraInfo}}
         >
           <:extra-badges>
             <div class="test-extra-badges">Extra badges</div>
           </:extra-badges>
-
-          <:cta>
-            <button type="button" class="test-cta">CTA</button>
-          </:cta>
         </OSS::Stats::Banner>
       `);
 
@@ -61,7 +57,7 @@ module('Integration | Component | o-s-s/stats/banner', function (hooks) {
       this.statExtraInfo = 'supplementary info';
 
       await render(
-        hbs`<OSS::Stats::Banner @loading={{false}} @title={{this.title}} @statValue={{this.statValue}} @statExtraInfo={{this.statExtraInfo}} />`
+        hbs`<OSS::Stats::Banner @loading={{false}} @titleConfig={{hash text=this.title}} @statValue={{this.statValue}} @statExtraInfo={{this.statExtraInfo}} />`
       );
 
       assert.dom('.oss-stats-banner__content').hasText('Stats title');
@@ -72,7 +68,7 @@ module('Integration | Component | o-s-s/stats/banner', function (hooks) {
     });
 
     test('when @loading is false and no field is defined, it does not render skeletons', async function (assert) {
-      await render(hbs`<OSS::Stats::Banner @loading={{false}} />`);
+      await render(hbs`<OSS::Stats::Banner @loading={{false}} @titleConfig={{hash text="My stat"}} />`);
 
       assert.dom('.oss-stats-banner__skeleton--badge').doesNotExist();
       assert.dom('.oss-stats-banner__skeleton--title').doesNotExist();
@@ -83,9 +79,9 @@ module('Integration | Component | o-s-s/stats/banner', function (hooks) {
   });
 
   module('Badge and icon handling', function () {
-    test('when @badgeConfig is defined and @loading is false, it renders the badge and no skeleton', async function (assert) {
+    test('when @badge is defined and @loading is false, it renders the badge and no skeleton', async function (assert) {
       await render(hbs`
-        <OSS::Stats::Banner @loading={{false}} @badgeConfig={{hash text="TXT" skin="primary" size="sm"}} />
+        <OSS::Stats::Banner @loading={{false}} @titleConfig={{hash text="My stat"}} @badge={{hash text="TXT" skin="primary" size="sm"}} />
       `);
 
       assert.dom('.oss-stats-banner .upf-badge').exists();
@@ -94,25 +90,25 @@ module('Integration | Component | o-s-s/stats/banner', function (hooks) {
       assert.dom('.oss-stats-banner__skeleton--badge').doesNotExist();
     });
 
-    test('when @badgeConfig is defined and @loading is true, it still renders the badge', async function (assert) {
+    test('when @badge is defined and @loading is true, it still renders the badge', async function (assert) {
       await render(hbs`
-        <OSS::Stats::Banner @loading={{true}} @badgeConfig={{hash text="TXT" skin="primary" size="sm"}} />
+        <OSS::Stats::Banner @loading={{true}} @titleConfig={{hash text="My stat"}} @badge={{hash text="TXT" skin="primary" size="sm"}} />
       `);
 
       assert.dom('.oss-stats-banner .upf-badge').exists();
     });
 
-    test('when @extraIconConfig is defined, it renders the icon next to the badge', async function (assert) {
+    test('when @badge.extraIcon is defined, it renders the icon next to the badge', async function (assert) {
       await render(hbs`
-        <OSS::Stats::Banner @badgeConfig={{hash icon="fa-check" skin="success"}} @extraIconConfig={{hash icon="fa-star"}} />
+        <OSS::Stats::Banner @titleConfig={{hash text="My stat"}} @badge={{hash icon="fa-check" skin="success" extraIcon=(hash icon="fa-star")}} />
       `);
 
       assert.dom('.oss-stats-banner .fa-star').exists();
     });
 
-    test('when @extraIconConfig has a color, it applies the color as inline style', async function (assert) {
+    test('when @badge.extraIcon has a color, it applies the color as inline style', async function (assert) {
       await render(hbs`
-        <OSS::Stats::Banner @badgeConfig={{hash icon="fa-check" skin="success"}} @extraIconConfig={{hash icon="fa-star" color="red"}} />
+        <OSS::Stats::Banner @titleConfig={{hash text="My stat"}} @badge={{hash icon="fa-check" skin="success" extraIcon=(hash icon="fa-star" color="red")}} />
       `);
 
       assert.dom('.oss-stats-banner .fa-star').hasAttribute('style', 'color:red');
@@ -120,60 +116,93 @@ module('Integration | Component | o-s-s/stats/banner', function (hooks) {
   });
 
   module('Title actions handling', function () {
-    test('when @titleInfoCircle is defined, it renders an info-circle icon next to the title', async function (assert) {
+    test('when @titleConfig.infoCircle is defined, it renders an info-circle icon next to the title', async function (assert) {
       await render(hbs`
-        <OSS::Stats::Banner @title="My stat" @titleInfoCircle="Helpful description" />
+        <OSS::Stats::Banner @titleConfig={{hash text="My stat" infoCircle="Helpful description"}} />
       `);
 
       assert.dom('.oss-stats-banner .fa-info-circle').exists();
     });
 
-    test('when @titleInfoCircle is not defined, it does not render an info-circle icon', async function (assert) {
-      await render(hbs`<OSS::Stats::Banner @title="My stat" />`);
+    test('when @titleConfig.infoCircle is not defined, it does not render an info-circle icon', async function (assert) {
+      await render(hbs`<OSS::Stats::Banner @titleConfig={{hash text="My stat"}} />`);
 
       assert.dom('.oss-stats-banner .fa-info-circle').doesNotExist();
     });
 
-    test('when the dropdown block is defined, it renders its content in the title row', async function (assert) {
+    test('when the title-suffix block is defined, it renders its content in the title row', async function (assert) {
       await render(hbs`
-        <OSS::Stats::Banner @title="My stat">
-          <:dropdown>
+        <OSS::Stats::Banner @titleConfig={{hash text="My stat"}}>
+          <:title-suffix>
             <div class="test-dropdown">Dropdown</div>
-          </:dropdown>
+          </:title-suffix>
         </OSS::Stats::Banner>
       `);
 
       assert.dom('.oss-stats-banner .test-dropdown').exists();
     });
 
-    test('when the dropdown block is not defined, it does not render dropdown content', async function (assert) {
-      await render(hbs`<OSS::Stats::Banner @title="My stat" />`);
+    test('when no title suffix block is defined, it does not render dropdown content', async function (assert) {
+      await render(hbs`<OSS::Stats::Banner @titleConfig={{hash text="My stat"}} />`);
 
       assert.dom('.oss-stats-banner .test-dropdown').doesNotExist();
     });
   });
 
   module('Named blocks handling', function () {
-    test('when @loading is false, it renders cta and extra-badges named blocks', async function (assert) {
+    test('when @loading is false, it renders extra-badges named block', async function (assert) {
       await render(hbs`
-        <OSS::Stats::Banner @loading={{false}} @badgeConfig={{hash text="TXT" skin="primary" size="sm"}}>
+        <OSS::Stats::Banner
+          @loading={{false}}
+          @titleConfig={{hash text="My stat"}}
+          @badge={{hash text="TXT" skin="primary" size="sm"}}
+        >
           <:extra-badges>
             <div class="test-extra-badges">Extra badges</div>
           </:extra-badges>
-
-          <:cta>
-            <button type="button" class="test-cta">CTA</button>
-          </:cta>
         </OSS::Stats::Banner>
       `);
 
       assert.dom('.test-extra-badges').exists();
-      assert.dom('.test-cta').exists();
       assert.dom('.oss-stats-banner .upf-badge').exists();
       assert.dom('.oss-stats-banner__skeleton--badge').doesNotExist();
       assert.dom('.oss-stats-banner__skeleton--title').doesNotExist();
       assert.dom('.oss-stats-banner__skeleton--extra-badge').doesNotExist();
       assert.dom('.oss-stats-banner__skeleton--cta').doesNotExist();
+    });
+
+    test('when cta named block is defined, it renders multiple actions', async function (assert) {
+      await render(hbs`
+        <OSS::Stats::Banner @titleConfig={{hash text="My stat"}} @statValue="$12,493">
+          <:cta>
+            <button type="button" class="test-cta-primary">Primary</button>
+            <button type="button" class="test-cta-secondary">Secondary</button>
+          </:cta>
+        </OSS::Stats::Banner>
+      `);
+
+      assert.dom('[data-control-name="stats-banner-cta"] .test-cta-primary').exists();
+      assert.dom('[data-control-name="stats-banner-cta"] .test-cta-secondary').exists();
+    });
+
+    test('when default block content is defined and @loading is false, it renders default content in stats area', async function (assert) {
+      await render(hbs`
+        <OSS::Stats::Banner @loading={{false}} @titleConfig={{hash text="My stat"}} @statValue="$12,493">
+          <div class="test-default-content">Default content</div>
+        </OSS::Stats::Banner>
+      `);
+
+      assert.dom('.oss-stats-banner__stats .test-default-content').exists();
+    });
+
+    test('when default block content is defined and @loading is true, it hides default content', async function (assert) {
+      await render(hbs`
+        <OSS::Stats::Banner @loading={{true}} @titleConfig={{hash text="My stat"}} @statValue="$12,493">
+          <div class="test-default-content">Default content</div>
+        </OSS::Stats::Banner>
+      `);
+
+      assert.dom('.oss-stats-banner__stats .test-default-content').doesNotExist();
     });
   });
 });

--- a/tests/integration/components/o-s-s/stats/banner-test.ts
+++ b/tests/integration/components/o-s-s/stats/banner-test.ts
@@ -27,15 +27,13 @@ module('Integration | Component | o-s-s/stats/banner', function (hooks) {
 
     test('when @loading is true, it renders title/stat skeletons and hides named block content', async function (assert) {
       this.title = 'Stats title';
-      this.statValue = '$5,920';
-      this.statExtraInfo = 'supplementary info';
+      this.statValue = { label: '$5,920', suffix: 'supplementary info' };
 
       await render(hbs`
         <OSS::Stats::Banner
           @loading={{true}}
           @titleConfig={{hash text=this.title}}
           @statValue={{this.statValue}}
-          @statExtraInfo={{this.statExtraInfo}}
         >
           <:extra-badges>
             <div class="test-extra-badges">Extra badges</div>
@@ -53,11 +51,10 @@ module('Integration | Component | o-s-s/stats/banner', function (hooks) {
 
     test('when @loading is false and title/stat values are defined, it renders text instead of skeletons', async function (assert) {
       this.title = 'Stats title';
-      this.statValue = '$5,920';
-      this.statExtraInfo = 'supplementary info';
+      this.statValue = { label: '$5,920', suffix: 'supplementary info' };
 
       await render(
-        hbs`<OSS::Stats::Banner @loading={{false}} @titleConfig={{hash text=this.title}} @statValue={{this.statValue}} @statExtraInfo={{this.statExtraInfo}} />`
+        hbs`<OSS::Stats::Banner @loading={{false}} @titleConfig={{hash text=this.title}} @statValue={{this.statValue}} />`
       );
 
       assert.dom('.oss-stats-banner__content').hasText('Stats title');
@@ -173,7 +170,7 @@ module('Integration | Component | o-s-s/stats/banner', function (hooks) {
 
     test('when cta named block is defined, it renders multiple actions', async function (assert) {
       await render(hbs`
-        <OSS::Stats::Banner @titleConfig={{hash text="My stat"}} @statValue="$12,493">
+        <OSS::Stats::Banner @titleConfig={{hash text="My stat"}} @statValue={{hash label="$12,493"}}>
           <:cta>
             <button type="button" class="test-cta-primary">Primary</button>
             <button type="button" class="test-cta-secondary">Secondary</button>
@@ -185,24 +182,41 @@ module('Integration | Component | o-s-s/stats/banner', function (hooks) {
       assert.dom('[data-control-name="stats-banner-cta"] .test-cta-secondary').exists();
     });
 
-    test('when default block content is defined and @loading is false, it renders default content in stats area', async function (assert) {
+    test('when default block content is defined and @loading is false, it does not render default content', async function (assert) {
       await render(hbs`
-        <OSS::Stats::Banner @loading={{false}} @titleConfig={{hash text="My stat"}} @statValue="$12,493">
+        <OSS::Stats::Banner @loading={{false}} @titleConfig={{hash text="My stat"}} @statValue={{hash label="$12,493"}}>
           <div class="test-default-content">Default content</div>
         </OSS::Stats::Banner>
       `);
 
-      assert.dom('.oss-stats-banner__stats .test-default-content').exists();
+      assert.dom('.test-default-content').doesNotExist();
     });
 
-    test('when default block content is defined and @loading is true, it hides default content', async function (assert) {
+    test('when default block content is defined and @loading is true, it does not render default content', async function (assert) {
       await render(hbs`
-        <OSS::Stats::Banner @loading={{true}} @titleConfig={{hash text="My stat"}} @statValue="$12,493">
+        <OSS::Stats::Banner @loading={{true}} @titleConfig={{hash text="My stat"}} @statValue={{hash label="$12,493"}}>
           <div class="test-default-content">Default content</div>
         </OSS::Stats::Banner>
       `);
 
-      assert.dom('.oss-stats-banner__stats .test-default-content').doesNotExist();
+      assert.dom('.test-default-content').doesNotExist();
+    });
+
+    test('when @statValue.tags contains multiple tags, it renders all tags', async function (assert) {
+      await render(hbs`
+        <OSS::Stats::Banner
+          @titleConfig={{hash text="My stat"}}
+          @statValue={{hash
+            label="$12,493"
+            suffix="supplementary info"
+            tags=(array (hash label="Hot" skin="warning") (hash label="New" skin="success" icon="fa-sparkles"))
+          }}
+        />
+      `);
+
+      assert.dom('.oss-stats-banner .upf-tag').exists({ count: 2 });
+      assert.dom('.oss-stats-banner__stat-main-content').includesText('Hot');
+      assert.dom('.oss-stats-banner__stat-main-content').includesText('New');
     });
   });
 });

--- a/tests/integration/components/o-s-s/stats/banner-test.ts
+++ b/tests/integration/components/o-s-s/stats/banner-test.ts
@@ -1,0 +1,142 @@
+import { hbs } from 'ember-cli-htmlbars';
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+
+module('Integration | Component | o-s-s/stats/banner', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function (assert) {
+    await render(hbs`<OSS::Stats::Banner />`);
+
+    assert.dom('.oss-stats-banner').exists();
+    assert.dom('.oss-stats-banner__header').exists();
+    assert.dom('.oss-stats-banner__bottom_content').exists();
+  });
+
+  test('when @loading is true and no related args or blocks are defined, it does not render skeletons', async function (assert) {
+    await render(hbs`<OSS::Stats::Banner @loading={{true}} />`);
+
+    assert.dom('.oss-stats-banner__skeleton--badge').doesNotExist();
+    assert.dom('.oss-stats-banner__skeleton--title').doesNotExist();
+    assert.dom('.oss-stats-banner__skeleton--extra-badge').doesNotExist();
+    assert.dom('.oss-stats-banner__skeleton--stat-value').doesNotExist();
+    assert.dom('.oss-stats-banner__skeleton--stat-extra').doesNotExist();
+    assert.dom('.oss-stats-banner__skeleton--cta').doesNotExist();
+  });
+
+  test('when @loading is true, it renders skeletons only for defined args and named blocks', async function (assert) {
+    this.title = 'Stats title';
+    this.statValue = '$5,920';
+    this.statExtraInfo = 'supplementary info';
+    this.badgeText = 'TXT';
+
+    await render(hbs`
+      <OSS::Stats::Banner
+        @loading={{true}}
+        @title={{this.title}}
+        @statValue={{this.statValue}}
+        @statExtraInfo={{this.statExtraInfo}}
+        @badgeText={{this.badgeText}}
+      >
+        <:extra-badges>
+          <div class="test-extra-badges">Extra badges</div>
+        </:extra-badges>
+
+        <:cta>
+          <button type="button" class="test-cta">CTA</button>
+        </:cta>
+      </OSS::Stats::Banner>
+    `);
+
+    assert.dom('.oss-stats-banner__skeleton--badge').exists();
+    assert.dom('.oss-stats-banner__skeleton--title').exists();
+    assert.dom('.oss-stats-banner__skeleton--extra-badge').exists({ count: 2 });
+    assert.dom('.oss-stats-banner__skeleton--stat-value').exists();
+    assert.dom('.oss-stats-banner__skeleton--stat-extra').exists();
+    assert.dom('.oss-stats-banner__skeleton--cta').exists();
+    assert.dom('.oss-stats-banner .upf-badge').doesNotExist();
+    assert.dom('.test-extra-badges').doesNotExist();
+    assert.dom('.test-cta').doesNotExist();
+  });
+
+  test('when @loading is false and badge args are defined, it renders OSS::Badge instead of badge skeleton', async function (assert) {
+    this.badgeText = 'TXT';
+
+    await render(
+      hbs`<OSS::Stats::Banner @loading={{false}} @badgeText={{this.badgeText}} @badgeSkin="primary" @badgeSize="sm" />`
+    );
+
+    assert.dom('.oss-stats-banner .upf-badge').exists();
+    assert.dom('.oss-stats-banner .upf-badge .upf-badge__text').hasText('TXT');
+    assert.dom('.oss-stats-banner .upf-badge').hasClass('upf-badge--primary');
+    assert.dom('.oss-stats-banner .upf-badge').hasClass('upf-badge--size-sm');
+    assert.dom('.oss-stats-banner__skeleton--badge').doesNotExist();
+  });
+
+  test('when @loading is false and title/stat values are defined, it renders text instead of skeletons', async function (assert) {
+    this.title = 'Stats title';
+    this.statValue = '$5,920';
+    this.statExtraInfo = 'supplementary info';
+
+    await render(
+      hbs`<OSS::Stats::Banner @loading={{false}} @title={{this.title}} @statValue={{this.statValue}} @statExtraInfo={{this.statExtraInfo}} />`
+    );
+
+    assert.dom('.oss-stats-banner__content').hasText('Stats title');
+    assert.dom('.oss-stats-banner__stat').includesText('$5,920');
+    assert.dom('.oss-stats-banner__stat').includesText('supplementary info');
+    assert.dom('.oss-stats-banner__skeleton--title').doesNotExist();
+    assert.dom('.oss-stats-banner__skeleton--stat-value').doesNotExist();
+    assert.dom('.oss-stats-banner__skeleton--stat-extra').doesNotExist();
+  });
+
+  test('when @loading is false and no field is defined, it does not render skeletons', async function (assert) {
+    await render(hbs`<OSS::Stats::Banner @loading={{false}} />`);
+
+    assert.dom('.oss-stats-banner__skeleton--badge').doesNotExist();
+    assert.dom('.oss-stats-banner__skeleton--title').doesNotExist();
+    assert.dom('.oss-stats-banner__skeleton--extra-badge').doesNotExist();
+    assert.dom('.oss-stats-banner__skeleton--stat-value').doesNotExist();
+    assert.dom('.oss-stats-banner__skeleton--stat-extra').doesNotExist();
+    assert.dom('.oss-stats-banner__skeleton--cta').doesNotExist();
+  });
+
+  test('when @loading is true and only a content block is defined, it does not render a title skeleton', async function (assert) {
+    await render(hbs`
+      <OSS::Stats::Banner @loading={{true}}>
+        <:content>
+          <div class="test-content">Content</div>
+        </:content>
+      </OSS::Stats::Banner>
+    `);
+
+    assert.dom('.test-content').exists();
+    assert.dom('.oss-stats-banner__skeleton--title').doesNotExist();
+  });
+
+  test('it renders content, cta and extra-badges named blocks and hides related skeletons when @loading is false', async function (assert) {
+    await render(hbs`
+      <OSS::Stats::Banner @loading={{false}}>
+        <:content>
+          <div class="test-content">Content</div>
+        </:content>
+
+        <:extra-badges>
+          <div class="test-extra-badges">Extra badges</div>
+        </:extra-badges>
+
+        <:cta>
+          <button type="button" class="test-cta">CTA</button>
+        </:cta>
+      </OSS::Stats::Banner>
+    `);
+
+    assert.dom('.test-content').exists();
+    assert.dom('.test-extra-badges').exists();
+    assert.dom('.test-cta').exists();
+    assert.dom('.oss-stats-banner__skeleton--title').doesNotExist();
+    assert.dom('.oss-stats-banner__skeleton--extra-badge').doesNotExist();
+    assert.dom('.oss-stats-banner__skeleton--cta').doesNotExist();
+  });
+});

--- a/tests/integration/components/o-s-s/stats/banner-test.ts
+++ b/tests/integration/components/o-s-s/stats/banner-test.ts
@@ -29,7 +29,6 @@ module('Integration | Component | o-s-s/stats/banner', function (hooks) {
     this.title = 'Stats title';
     this.statValue = '$5,920';
     this.statExtraInfo = 'supplementary info';
-    this.badgeText = 'TXT';
 
     await render(hbs`
       <OSS::Stats::Banner
@@ -37,8 +36,11 @@ module('Integration | Component | o-s-s/stats/banner', function (hooks) {
         @title={{this.title}}
         @statValue={{this.statValue}}
         @statExtraInfo={{this.statExtraInfo}}
-        @badgeText={{this.badgeText}}
       >
+        <:badges>
+          <OSS::Badge @text="TXT" @skin="primary" @size="sm" />
+        </:badges>
+
         <:extra-badges>
           <div class="test-extra-badges">Extra badges</div>
         </:extra-badges>
@@ -60,12 +62,14 @@ module('Integration | Component | o-s-s/stats/banner', function (hooks) {
     assert.dom('.test-cta').doesNotExist();
   });
 
-  test('when @loading is false and badge args are defined, it renders OSS::Badge instead of badge skeleton', async function (assert) {
-    this.badgeText = 'TXT';
-
-    await render(
-      hbs`<OSS::Stats::Banner @loading={{false}} @badgeText={{this.badgeText}} @badgeSkin="primary" @badgeSize="sm" />`
-    );
+  test('when @loading is false and badges block is defined, it renders block content instead of badge skeleton', async function (assert) {
+    await render(hbs`
+      <OSS::Stats::Banner @loading={{false}}>
+        <:badges>
+          <OSS::Badge @text="TXT" @skin="primary" @size="sm" />
+        </:badges>
+      </OSS::Stats::Banner>
+    `);
 
     assert.dom('.oss-stats-banner .upf-badge').exists();
     assert.dom('.oss-stats-banner .upf-badge .upf-badge__text').hasText('TXT');
@@ -118,6 +122,10 @@ module('Integration | Component | o-s-s/stats/banner', function (hooks) {
   test('it renders content, cta and extra-badges named blocks and hides related skeletons when @loading is false', async function (assert) {
     await render(hbs`
       <OSS::Stats::Banner @loading={{false}}>
+        <:badges>
+          <OSS::Badge @text="TXT" @skin="primary" @size="sm" />
+        </:badges>
+
         <:content>
           <div class="test-content">Content</div>
         </:content>
@@ -135,7 +143,9 @@ module('Integration | Component | o-s-s/stats/banner', function (hooks) {
     assert.dom('.test-content').exists();
     assert.dom('.test-extra-badges').exists();
     assert.dom('.test-cta').exists();
+    assert.dom('.oss-stats-banner .upf-badge').exists();
     assert.dom('.oss-stats-banner__skeleton--title').doesNotExist();
+    assert.dom('.oss-stats-banner__skeleton--badge').doesNotExist();
     assert.dom('.oss-stats-banner__skeleton--extra-badge').doesNotExist();
     assert.dom('.oss-stats-banner__skeleton--cta').doesNotExist();
   });

--- a/tests/integration/components/o-s-s/stats/banner-test.ts
+++ b/tests/integration/components/o-s-s/stats/banner-test.ts
@@ -14,13 +14,13 @@ module('Integration | Component | o-s-s/stats/banner', function (hooks) {
     assert.dom('.oss-stats-banner__bottom_content').exists();
   });
 
-  test('when @loading is true and no related args or blocks are defined, it does not render skeletons', async function (assert) {
+  test('when @loading is true and no related args or blocks are defined, it renders title/stat skeletons', async function (assert) {
     await render(hbs`<OSS::Stats::Banner @loading={{true}} />`);
 
     assert.dom('.oss-stats-banner__skeleton--badge').doesNotExist();
-    assert.dom('.oss-stats-banner__skeleton--title').doesNotExist();
+    assert.dom('.oss-stats-banner__skeleton--title').exists();
     assert.dom('.oss-stats-banner__skeleton--extra-badge').doesNotExist();
-    assert.dom('.oss-stats-banner__skeleton--stat-value').doesNotExist();
+    assert.dom('.oss-stats-banner__skeleton--stat-value').exists();
     assert.dom('.oss-stats-banner__skeleton--stat-extra').doesNotExist();
     assert.dom('.oss-stats-banner__skeleton--cta').doesNotExist();
   });

--- a/tests/integration/components/o-s-s/stats/banner-test.ts
+++ b/tests/integration/components/o-s-s/stats/banner-test.ts
@@ -25,7 +25,7 @@ module('Integration | Component | o-s-s/stats/banner', function (hooks) {
     assert.dom('.oss-stats-banner__skeleton--cta').doesNotExist();
   });
 
-  test('when @loading is true, it renders skeletons only for defined args and named blocks', async function (assert) {
+  test('when @loading is true, it renders title/stat skeletons and hides named block content', async function (assert) {
     this.title = 'Stats title';
     this.statValue = '$5,920';
     this.statExtraInfo = 'supplementary info';
@@ -48,10 +48,10 @@ module('Integration | Component | o-s-s/stats/banner', function (hooks) {
     `);
 
     assert.dom('.oss-stats-banner__skeleton--title').exists();
-    assert.dom('.oss-stats-banner__skeleton--extra-badge').exists({ count: 2 });
     assert.dom('.oss-stats-banner__skeleton--stat-value').exists();
-    assert.dom('.oss-stats-banner__skeleton--stat-extra').exists();
-    assert.dom('.oss-stats-banner__skeleton--cta').exists();
+    assert.dom('.oss-stats-banner__skeleton--extra-badge').doesNotExist();
+    assert.dom('.oss-stats-banner__skeleton--stat-extra').doesNotExist();
+    assert.dom('.oss-stats-banner__skeleton--cta').doesNotExist();
     assert.dom('.test-extra-badges').doesNotExist();
     assert.dom('.test-cta').doesNotExist();
   });

--- a/tests/integration/components/o-s-s/stats/banner-test.ts
+++ b/tests/integration/components/o-s-s/stats/banner-test.ts
@@ -22,7 +22,6 @@ module('Integration | Component | o-s-s/stats/banner', function (hooks) {
       assert.dom('.oss-stats-banner__skeleton--title').exists();
       assert.dom('.oss-stats-banner__skeleton--extra-badge').doesNotExist();
       assert.dom('.oss-stats-banner__skeleton--stat-value').exists();
-      assert.dom('.oss-stats-banner__skeleton--stat-extra').exists();
       assert.dom('.oss-stats-banner__skeleton--cta').doesNotExist();
     });
 
@@ -51,7 +50,6 @@ module('Integration | Component | o-s-s/stats/banner', function (hooks) {
       assert.dom('.oss-stats-banner__skeleton--title').exists();
       assert.dom('.oss-stats-banner__skeleton--stat-value').exists();
       assert.dom('.oss-stats-banner__skeleton--extra-badge').doesNotExist();
-      assert.dom('.oss-stats-banner__skeleton--stat-extra').exists();
       assert.dom('.oss-stats-banner__skeleton--cta').doesNotExist();
       assert.dom('.test-extra-badges').doesNotExist();
       assert.dom('.test-cta').doesNotExist();
@@ -71,7 +69,6 @@ module('Integration | Component | o-s-s/stats/banner', function (hooks) {
       assert.dom('.oss-stats-banner__stat').includesText('supplementary info');
       assert.dom('.oss-stats-banner__skeleton--title').doesNotExist();
       assert.dom('.oss-stats-banner__skeleton--stat-value').doesNotExist();
-      assert.dom('.oss-stats-banner__skeleton--stat-extra').doesNotExist();
     });
 
     test('when @loading is false and no field is defined, it does not render skeletons', async function (assert) {
@@ -81,7 +78,6 @@ module('Integration | Component | o-s-s/stats/banner', function (hooks) {
       assert.dom('.oss-stats-banner__skeleton--title').doesNotExist();
       assert.dom('.oss-stats-banner__skeleton--extra-badge').doesNotExist();
       assert.dom('.oss-stats-banner__skeleton--stat-value').doesNotExist();
-      assert.dom('.oss-stats-banner__skeleton--stat-extra').doesNotExist();
       assert.dom('.oss-stats-banner__skeleton--cta').doesNotExist();
     });
   });


### PR DESCRIPTION
### What does this PR do?

<img src="https://github.com/user-attachments/assets/890581ab-6d0c-40ec-b8b4-63b9f6342b11 " alt="Screenshot 2026-08-19 at 17 17 31" width="594" data-linear-height="404" />

Introduces a new OSS::Stats::Banner component for flexible KPI/header composition.

* Adds structured config args for a few elements ( badge & icon )
* Uses dropdown, extra-badges, and cta as named blocks to preserve flexibility in those sections.
* Implements title ellipsis with a top-position tooltip shown only on overflow.
* Renders the info icon when titleInfoCircle is provided.
* Hides extra-badges and cta block content in loading mode for consistent loading UI.
* Updates to Storybook and tests

Related to: #

### What are the observable changes?

### Good PR checklist

- [X] Title makes sense
- [X] Is against the correct branch
- [X] Only addresses one issue
- [X] Properly assigned
- [X] Added/updated tests
- [X] Added/updated documentation with Figma design link. Don't forget to replace "design" by "file" in the URL. For example [https://www.figma.com/file/example](<https://www.figma.com/file/example>)
- [X] Properly labeled